### PR TITLE
refactor of GtSeqabstract

### DIFF
--- a/src/match/greedyedist.c
+++ b/src/match/greedyedist.c
@@ -293,10 +293,10 @@ unsigned long greedyunitedist(GtFrontResource *ftres,
 #ifdef SKDEBUG
   printf("unitedistcheckSEPgeneric(ulen=%lu,vlen=%lu)\n",ulenvalue,vlenvalue);
 #endif
-  gt_assert(gt_seqabstract_length_get(useq) < (unsigned long) LONG_MAX);
-  gt_assert(gt_seqabstract_length_get(vseq) < (unsigned long) LONG_MAX);
-  ftres->ulen = (long) gt_seqabstract_length_get(useq);
-  ftres->vlen = (long) gt_seqabstract_length_get(vseq);
+  gt_assert(gt_seqabstract_length(useq) < (unsigned long) LONG_MAX);
+  gt_assert(gt_seqabstract_length(vseq) < (unsigned long) LONG_MAX);
+  ftres->ulen = (long) gt_seqabstract_length(useq);
+  ftres->vlen = (long) gt_seqabstract_length(vseq);
   ftres->integermin = -MAX(ftres->ulen,ftres->vlen);
   prevfspec = &frontspecspace[0];
   firstfrontforward(useq,vseq,ftres,prevfspec);

--- a/src/match/seqabstract.h
+++ b/src/match/seqabstract.h
@@ -25,25 +25,33 @@ typedef struct GtSeqabstract GtSeqabstract;
 
 GtSeqabstract* gt_seqabstract_new_empty(void);
 
-GtSeqabstract* gt_seqabstract_new_ptr(const GtUchar *ptr,
-                                      unsigned long len,
-                                      unsigned long offset);
+/* Creates new <GtSeqabstract> object from <string> of length <len> starting at
+   <offset>. That is the abstract sequence will be of length <len> - <offset>!
+ */
+GtSeqabstract* gt_seqabstract_new_gtuchar(const GtUchar *string,
+                                          unsigned long len,
+                                          unsigned long offset);
 
+/* Creates new <GtSeqabstract> object from <encseq> of length <len> starting at
+   <offset>. That is the abstract sequence will be of length <len> - <offset>!
+ */
 GtSeqabstract* gt_seqabstract_new_encseq(const GtEncseq *encseq,
                                          unsigned long len,
                                          unsigned long offset);
 
-void           gt_seqabstract_reinit_ptr(GtSeqabstract *sa,
-                                         const GtUchar *ptr,
-                                         unsigned long len,
-                                         unsigned long offset);
+/* reinitialize <sa> with <string> of length <len> starting at <offset> */
+void           gt_seqabstract_reinit_gtuchar(GtSeqabstract *sa,
+                                             const GtUchar *string,
+                                             unsigned long len,
+                                             unsigned long offset);
 
+/* reinitialize <sa> with <encseq> of length <len> starting at <offset> */
 void           gt_seqabstract_reinit_encseq(GtSeqabstract *sa,
                                             const GtEncseq *encseq,
                                             unsigned long len,
                                             unsigned long offset);
 
-unsigned long  gt_seqabstract_length_get(const GtSeqabstract *sa);
+unsigned long  gt_seqabstract_length(const GtSeqabstract *sa);
 
 GtUchar        gt_seqabstract_encoded_char(const GtSeqabstract *sa,
                                           unsigned long idx);

--- a/src/match/test-pairwise.c
+++ b/src/match/test-pairwise.c
@@ -165,8 +165,8 @@ void gt_checkgreedyunitedist(GT_UNUSED bool forward,
 {
   unsigned long edist1, edist2;
   GtFrontResource *frontresource = gt_frontresource_new(10UL);
-  GtSeqabstract *greedyedistuseq = gt_seqabstract_new_ptr(useq,ulen,0),
-                *greedyedistvseq = gt_seqabstract_new_ptr(vseq,vlen,0);
+  GtSeqabstract *greedyedistuseq = gt_seqabstract_new_gtuchar(useq,ulen,0),
+                *greedyedistvseq = gt_seqabstract_new_gtuchar(vseq,vlen,0);
 
   edist1 = greedyunitedist(frontresource,greedyedistuseq,greedyedistvseq);
   edist2 = gt_squarededistunit (useq,ulen,vseq,vlen);

--- a/src/match/xdrop.c
+++ b/src/match/xdrop.c
@@ -17,10 +17,12 @@
 */
 
 #include <string.h>
+
 #include "core/chardef.h"
 #include "core/divmodmul.h"
-#include "core/minmax.h"
 #include "core/mathsupport.h"
+#include "core/minmax.h"
+
 #include "xdrop.h"
 
 typedef struct
@@ -225,8 +227,8 @@ void gt_evalxdroparbitscoresextend(bool forward,
                                    unsigned long voffset,
                                    GtXdropscore xdropbelowscore)
 {
-  const long ulen = (long) gt_seqabstract_length_get(useq),
-             vlen = (long) gt_seqabstract_length_get(vseq),
+  const long ulen = (long) gt_seqabstract_length(useq),
+             vlen = (long) gt_seqabstract_length(vseq),
              end_k = ulen - vlen, /* diagonal of endpoint (ulen, vlen) */
              integermax = MAX(ulen, vlen),
              integermin = -integermax,

--- a/src/tools/gt_maxpairs.c
+++ b/src/tools/gt_maxpairs.c
@@ -235,7 +235,7 @@ static int gt_processxdropquerymatches(void *info,
     gt_assert(dbseqstartpos < pos1);
     gt_seqabstract_reinit_encseq(xdropmatchinfo->useq,encseq,
                                  pos1 - dbseqstartpos,0);
-    gt_seqabstract_reinit_ptr(xdropmatchinfo->vseq,query,pos2,0);
+    gt_seqabstract_reinit_gtuchar(xdropmatchinfo->vseq, query, pos2, 0);
     gt_evalxdroparbitscoresextend(false,
                                   &xdropmatchinfo->best_left,
                                   xdropmatchinfo->res,
@@ -255,8 +255,8 @@ static int gt_processxdropquerymatches(void *info,
     gt_seqabstract_reinit_encseq(xdropmatchinfo->useq,
                                  encseq,dbseqstartpos + dbseqlength -
                                         (pos1 + len),0);
-    gt_seqabstract_reinit_ptr(xdropmatchinfo->vseq,
-                              query,query_totallength - (pos2 + len),0);
+    gt_seqabstract_reinit_gtuchar(xdropmatchinfo->vseq,
+                                  query,query_totallength - (pos2 + len), 0);
     gt_evalxdroparbitscoresextend(true,
                                   &xdropmatchinfo->best_right,
                                   xdropmatchinfo->res,
@@ -287,10 +287,8 @@ static int gt_processxdropquerymatches(void *info,
                                encseq,
                                dblen,
                                dbstart);
-  gt_seqabstract_reinit_ptr(xdropmatchinfo->vseq,
-                            query,
-                            querylen,
-                            querystart);
+  gt_seqabstract_reinit_gtuchar(xdropmatchinfo->vseq, query, querylen,
+                                querystart);
   gt_querymatch_fill(xdropmatchinfo->querymatchspaceptr,
                      dblen,
                      dbstart,


### PR DESCRIPTION
renamed some functions
split up lcp function and removed code duplication were possible without endangering performance (hopefully)
