### PR TITLE
rename development process related stuff

### DIFF
--- a/gtdata/modules/gtdoclib/gtscript_header.lp
+++ b/gtdata/modules/gtdoclib/gtscript_header.lp
@@ -19,7 +19,7 @@
     <li><a href="manuals.html">Manuals</a></li>
     <li><a href="libgenometools.html">C API</a></li>
     <li><a id="current" href="docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="contract.html">Development Process</a></li>
+    <li><a href="contract.html">Development Contract</a></li>
     <li><a href="contribute.html">Contribute</a></li>
   </ul>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/gtdata/modules/gtdoclib/libgenometools_header.lp
+++ b/gtdata/modules/gtdoclib/libgenometools_header.lp
@@ -19,7 +19,7 @@
     <li><a href="manuals.html">Manuals</a></li>
     <li><a id="current" href="libgenometools.html">C API</a></li>
     <li><a href="docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="contract.html">Development Process</a></li>
+    <li><a href="contract.html">Development Contract</a></li>
     <li><a href="contribute.html">Contribute</a></li>
   </ul>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/contract.html
+++ b/www/genometools.org/htdocs/contract.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<title>The GenomeTools Development Process</title>
+<title>The GenomeTools Development Contract</title>
 <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
@@ -19,7 +19,7 @@
     <li><a href="manuals.html">Manuals</a></li>
     <li><a href="libgenometools.html">C API</a></li>
     <li><a href="docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a id="current" href="contract.html">Development Process</a></li>
+    <li><a id="current" href="contract.html">Development Contract</a></li>
     <li><a href="contribute.html">Contribute</a></li>
   </ul>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>
@@ -28,16 +28,16 @@
 </ul>
 </div>
 <div id="main">
-<h1>The <i>GenomeTools</i> Development Process</h1>
+<h1>The <i>GenomeTools</i> Development Contract</h1>
 
-<p>The <i>GenomeTools</i> Development Process (GtDP) is a fork of the <a href="http://rfc.zeromq.org/spec:22">C4</a> of the <a href="http://www.zeromq.org">ZeroMQ</a> project, with
+<p>The <i>GenomeTools</i> Development Contract (GtDC) is a fork of the <a href="http://rfc.zeromq.org/spec:22">C4</a> of the <a href="http://www.zeromq.org">ZeroMQ</a> project, with
 some sections removed and adjusted licensing terms.<br />
-This is revision <b>0</b> of the GtDP (2013-07-04).</p>
+This is revision <b>0</b> of the GtDC (2013-07-04).</p>
 
 <h2 id="toc0"><span>Language</span></h2>
 <p>The key words &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in <a href="http://tools.ietf.org/html/rfc2119">RFC 2119</a>.</p>
 <h2 id="toc2"><span>Goals</span></h2>
-<p>GtDP is meant to provide a reusable optimal collaboration model for open source software projects. It has these specific goals:</p>
+<p>GtDC is meant to provide a reusable optimal collaboration model for open source software projects. It has these specific goals:</p>
 <ul>
 <li>To maximize the scale of the community around a project, by reducing the friction for new Contributors and creating a scaled participation model with strong positive feedbacks;</li>
 </ul>
@@ -126,7 +126,7 @@ This is revision <b>0</b> of the GtDP (2013-07-04).</p>
 <ul>
 <li>A &quot;Correct Patch&quot; is one that satisfies the above requirements.</li>
 </ul>
-<h3 id="toc7"><span>Development Process</span></h3>
+<h3 id="toc7"><span>Development Contract</span></h3>
 <ul>
 <li>Change on the project SHALL be governed by the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.</li>
 </ul>

--- a/www/genometools.org/htdocs/contribute.html
+++ b/www/genometools.org/htdocs/contribute.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<title>The GenomeTools Contribution Policy</title>
+<title>The GenomeTools Contribution Process</title>
 <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
@@ -19,7 +19,7 @@
     <li><a href="manuals.html">Manuals</a></li>
     <li><a href="libgenometools.html">C API</a></li>
     <li><a href="docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="contract.html">Development Process</a></li>
+    <li><a href="contract.html">Development Contract</a></li>
     <li><a id="current" href="contribute.html">Contribute</a></li>
   </ul>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>
@@ -28,8 +28,9 @@
 </ul>
 </div>
 <div id="main">
-<h1>The <i>GenomeTools</i> Contribution Policy</h1>
-<p><em>GenomeTools</em> development is centered around the <a href="contract.html"><em>GenomeTools</em> development process</a>. If you contribute a nice patch which will be integrated into the master, we'll invite you to join the Maintainer's team and you can add &quot;<em>GenomeTools</em> maintainer&quot; to your resume or C.V.</p>
+<h1>The <i>GenomeTools</i> Contribution Process</h1>
+<p><em>GenomeTools</em> development is centered around the <a
+href="contract.html"><em>GenomeTools</em> development contract</a>. If you contribute a nice patch which will be integrated into the master, we'll invite you to join the Maintainer's team and you can add &quot;<em>GenomeTools</em> maintainer&quot; to your resume or C.V.</p>
 <p>This introductory text has been <a href="http://www.zeromq.org/docs:contributing">borrowed</a> (with adjustments) from the <a href="http://www.zeromq.org">ZeroMQ project</a>.</p>
 <p>Our process is this:</p>
 <ol>

--- a/www/genometools.org/htdocs/docs.html
+++ b/www/genometools.org/htdocs/docs.html
@@ -19,7 +19,7 @@
     <li><a href="manuals.html">Manuals</a></li>
     <li><a href="libgenometools.html">C API</a></li>
     <li><a id="current" href="docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="contract.html">Development Process</a></li>
+    <li><a href="contract.html">Development Contract</a></li>
     <li><a href="contribute.html">Contribute</a></li>
   </ul>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>
@@ -1091,7 +1091,7 @@ Returns translated <code>dna</code>.
 <div id="footer">
 Copyright &copy; 2008-2013
 The <i>GenomeTools</i> authors.
-Last update: 2013-07-05
+Last update: 2013-07-08
 </div>
 </div>
 <!-- Piwik -->

--- a/www/genometools.org/htdocs/documentation.html
+++ b/www/genometools.org/htdocs/documentation.html
@@ -19,7 +19,7 @@
     <li><a href="manuals.html">Manuals</a></li>
     <li><a href="libgenometools.html">C API</a></li>
     <li><a href="docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="contract.html">Development Process</a></li>
+    <li><a href="contract.html">Development Contract</a></li>
     <li><a href="contribute.html">Contribute</a></li>
   </ul>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/libgenometools.html
+++ b/www/genometools.org/htdocs/libgenometools.html
@@ -19,7 +19,7 @@
     <li><a href="manuals.html">Manuals</a></li>
     <li><a id="current" href="libgenometools.html">C API</a></li>
     <li><a href="docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="contract.html">Development Process</a></li>
+    <li><a href="contract.html">Development Contract</a></li>
     <li><a href="contribute.html">Contribute</a></li>
   </ul>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>
@@ -325,16 +325,6 @@ interfaces.
 
 </ul>
 <h2>Sole functions</h2>
-<a name="gt_fasta_show_entry"></a>
-
-<code>void  gt_fasta_show_entry(const char *description, const char *sequence,
-                         unsigned long sequence_length, unsigned long width,
-                         GtFile *outfp)</code>
-<p>
-Print a fasta entry with optional <code>description</code> and mandatory <code>sequence</code> to
-   <code>outfp</code>. If <code>width</code> is != 0 the sequence is formatted accordingly.
-</p>
-<hr>
 <a name="gt_feature_index_gfflike_get_all_features"></a>
 
 <code>int              gt_feature_index_gfflike_get_all_features(GtFeatureIndex *gfi,
@@ -346,6 +336,15 @@ Retrieves all features contained in <code>gfi</code> into <code>results</code>. 
    accordingly.
 </p>
 <hr>
+<a name="GtTrackSelectorFunc"></a>
+
+<code>void  GtTrackSelectorFunc(GtBlock*, GtStr*, void*)</code>
+<p>
+A <code>GtTrackSelectorFunc</code> is a callback function which sets a <code>GtStr</code> to a
+   string to be used as a track identifier for assignment of a <code>GtBlock</code>
+   to a given track.
+</p>
+<hr>
 <a name="GtTrackOrderingFunc"></a>
 
 <code>int  GtTrackOrderingFunc(const char *s1, const char *s2, void *data)</code>
@@ -355,15 +354,6 @@ A function describing the order of tracks based on their track identifier
    should appear before the track with ID <code>s2</code> and a positive value if <code>s1</code>
    should appear after <code>s2</code>. Returning a value of 0 will result in an undefined
    ordering of <code>s1</code> and <code>s2</code>.
-</p>
-<hr>
-<a name="GtTrackSelectorFunc"></a>
-
-<code>void  GtTrackSelectorFunc(GtBlock*, GtStr*, void*)</code>
-<p>
-A <code>GtTrackSelectorFunc</code> is a callback function which sets a <code>GtStr</code> to a
-   string to be used as a track identifier for assignment of a <code>GtBlock</code>
-   to a given track.
 </p>
 <hr>
 <a name="GtAddIntronsStream"></a>
@@ -8423,6 +8413,16 @@ Frees the space allocated for the 2-dimensional array pointed to by
    <code>ARRAY2DIM</code>.
 </p>
 <hr>
+<a name="gt_fasta_show_entry"></a>
+
+<code>void  gt_fasta_show_entry(const char *description, const char *sequence,
+                         unsigned long sequence_length, unsigned long width,
+                         GtFile *outfp)</code>
+<p>
+Print a fasta entry with optional <code>description</code> and mandatory <code>sequence</code> to
+   <code>outfp</code>. If <code>width</code> is != 0 the sequence is formatted accordingly.
+</p>
+<hr>
 <a name="Assert"></a>
 <h2>Module Assert</h2>
 <a name="gt_assert"></a>
@@ -11158,7 +11158,7 @@ Similar to <code>vsnprintf(3)</code>, terminates on error.
 <div id="footer">
 Copyright &copy; 2008-2013
 The <i>GenomeTools</i> authors.
-Last update: 2013-07-05
+Last update: 2013-07-08
 </div>
 </div>
 <!-- Piwik -->

--- a/www/genometools.org/htdocs/manuals.html
+++ b/www/genometools.org/htdocs/manuals.html
@@ -19,7 +19,7 @@
     <li><a id="current" href="manuals.html">Manuals</a></li>
     <li><a href="libgenometools.html">C API</a></li>
     <li><a href="docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="contract.html">Development Process</a></li>
+    <li><a href="contract.html">Development Contract</a></li>
     <li><a href="contribute.html">Contribute</a></li>
   </ul>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tool.conf
+++ b/www/genometools.org/htdocs/tool.conf
@@ -547,7 +547,7 @@ cellspacing="0" cellpadding="4">
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tool_list.conf
+++ b/www/genometools.org/htdocs/tool_list.conf
@@ -547,7 +547,7 @@ cellspacing="0" cellpadding="4">
     <li><a href="manuals.html">Manuals</a></li>
     <li><a href="libgenometools.html">C API</a></li>
     <li><a href="docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="contract.html">Development Process</a></li>
+    <li><a href="contract.html">Development Contract</a></li>
     <li><a href="contribute.html">Contribute</a></li>
   </ul>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools.html
+++ b/www/genometools.org/htdocs/tools.html
@@ -21,7 +21,7 @@
     <li><a href="manuals.html">Manuals</a></li>
     <li><a href="libgenometools.html">C API</a></li>
     <li><a href="docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="contract.html">Development Process</a></li>
+    <li><a href="contract.html">Development Contract</a></li>
     <li><a href="contribute.html">Contribute</a></li>
   </ul>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt.html
+++ b/www/genometools.org/htdocs/tools/gt.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_bed_to_gff3.html
+++ b/www/genometools.org/htdocs/tools/gt_bed_to_gff3.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_cds.html
+++ b/www/genometools.org/htdocs/tools/gt_cds.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_chain2dim.html
+++ b/www/genometools.org/htdocs/tools/gt_chain2dim.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_chseqids.html
+++ b/www/genometools.org/htdocs/tools/gt_chseqids.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_clean.html
+++ b/www/genometools.org/htdocs/tools/gt_clean.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_compreads.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_compreads_compress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_compress.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_compreads_decompress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_decompress.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_compreads_refcompress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_refcompress.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_compreads_refdecompress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_refdecompress.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_congruence.html
+++ b/www/genometools.org/htdocs/tools/gt_congruence.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_congruence_spacedseed.html
+++ b/www/genometools.org/htdocs/tools/gt_congruence_spacedseed.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_convertseq.html
+++ b/www/genometools.org/htdocs/tools/gt_convertseq.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_csa.html
+++ b/www/genometools.org/htdocs/tools/gt_csa.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_dot.html
+++ b/www/genometools.org/htdocs/tools/gt_dot.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_dupfeat.html
+++ b/www/genometools.org/htdocs/tools/gt_dupfeat.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_encseq.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_encseq2spm.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq2spm.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_encseq_bench.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_bench.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_encseq_bitextract.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_bitextract.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_encseq_check.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_check.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_encseq_decode.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_decode.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_encseq_encode.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_encode.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_encseq_info.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_info.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_encseq_md5.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_md5.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_eval.html
+++ b/www/genometools.org/htdocs/tools/gt_eval.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_extractfeat.html
+++ b/www/genometools.org/htdocs/tools/gt_extractfeat.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_extractseq.html
+++ b/www/genometools.org/htdocs/tools/gt_extractseq.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_featureindex.html
+++ b/www/genometools.org/htdocs/tools/gt_featureindex.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_fingerprint.html
+++ b/www/genometools.org/htdocs/tools/gt_fingerprint.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_genomediff.html
+++ b/www/genometools.org/htdocs/tools/gt_genomediff.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_gff3.html
+++ b/www/genometools.org/htdocs/tools/gt_gff3.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_gff3_to_gtf.html
+++ b/www/genometools.org/htdocs/tools/gt_gff3_to_gtf.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_gff3validator.html
+++ b/www/genometools.org/htdocs/tools/gt_gff3validator.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_gtf_to_gff3.html
+++ b/www/genometools.org/htdocs/tools/gt_gtf_to_gff3.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_hop.html
+++ b/www/genometools.org/htdocs/tools/gt_hop.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_id_to_md5.html
+++ b/www/genometools.org/htdocs/tools/gt_id_to_md5.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_interfeat.html
+++ b/www/genometools.org/htdocs/tools/gt_interfeat.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_ltrclustering.html
+++ b/www/genometools.org/htdocs/tools/gt_ltrclustering.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_ltrdigest.html
+++ b/www/genometools.org/htdocs/tools/gt_ltrdigest.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_ltrharvest.html
+++ b/www/genometools.org/htdocs/tools/gt_ltrharvest.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_matchtool.html
+++ b/www/genometools.org/htdocs/tools/gt_matchtool.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_matstat.html
+++ b/www/genometools.org/htdocs/tools/gt_matstat.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_md5_to_id.html
+++ b/www/genometools.org/htdocs/tools/gt_md5_to_id.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_merge.html
+++ b/www/genometools.org/htdocs/tools/gt_merge.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_mergefeat.html
+++ b/www/genometools.org/htdocs/tools/gt_mergefeat.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_mkfeatureindex.html
+++ b/www/genometools.org/htdocs/tools/gt_mkfeatureindex.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_mmapandread.html
+++ b/www/genometools.org/htdocs/tools/gt_mmapandread.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_orffinder.html
+++ b/www/genometools.org/htdocs/tools/gt_orffinder.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_packedindex.html
+++ b/www/genometools.org/htdocs/tools/gt_packedindex.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_prebwt.html
+++ b/www/genometools.org/htdocs/tools/gt_prebwt.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_readjoiner.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_readjoiner_assembly.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner_assembly.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_readjoiner_overlap.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner_overlap.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_readjoiner_prefilter.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner_prefilter.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_repfind.html
+++ b/www/genometools.org/htdocs/tools/gt_repfind.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_scriptfilter.html
+++ b/www/genometools.org/htdocs/tools/gt_scriptfilter.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_select.html
+++ b/www/genometools.org/htdocs/tools/gt_select.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_seq.html
+++ b/www/genometools.org/htdocs/tools/gt_seq.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_seqfilter.html
+++ b/www/genometools.org/htdocs/tools/gt_seqfilter.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_seqids.html
+++ b/www/genometools.org/htdocs/tools/gt_seqids.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_seqmutate.html
+++ b/www/genometools.org/htdocs/tools/gt_seqmutate.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_seqorder.html
+++ b/www/genometools.org/htdocs/tools/gt_seqorder.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_seqstat.html
+++ b/www/genometools.org/htdocs/tools/gt_seqstat.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_seqtransform.html
+++ b/www/genometools.org/htdocs/tools/gt_seqtransform.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_seqtranslate.html
+++ b/www/genometools.org/htdocs/tools/gt_seqtranslate.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_sequniq.html
+++ b/www/genometools.org/htdocs/tools/gt_sequniq.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_shredder.html
+++ b/www/genometools.org/htdocs/tools/gt_shredder.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_shulengthdist.html
+++ b/www/genometools.org/htdocs/tools/gt_shulengthdist.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_simreads.html
+++ b/www/genometools.org/htdocs/tools/gt_simreads.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_sketch.html
+++ b/www/genometools.org/htdocs/tools/gt_sketch.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_sketch_page.html
+++ b/www/genometools.org/htdocs/tools/gt_sketch_page.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_snpper.html
+++ b/www/genometools.org/htdocs/tools/gt_snpper.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_splicesiteinfo.html
+++ b/www/genometools.org/htdocs/tools/gt_splicesiteinfo.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_splitfasta.html
+++ b/www/genometools.org/htdocs/tools/gt_splitfasta.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_stat.html
+++ b/www/genometools.org/htdocs/tools/gt_stat.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_tagerator.html
+++ b/www/genometools.org/htdocs/tools/gt_tagerator.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_tallymer.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_tallymer_mkindex.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer_mkindex.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_tallymer_occratio.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer_occratio.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_tallymer_search.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer_search.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_tirvish.html
+++ b/www/genometools.org/htdocs/tools/gt_tirvish.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_uniq.html
+++ b/www/genometools.org/htdocs/tools/gt_uniq.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_uniquesub.html
+++ b/www/genometools.org/htdocs/tools/gt_uniquesub.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tools/gt_wtree.html
+++ b/www/genometools.org/htdocs/tools/gt_wtree.html
@@ -20,7 +20,7 @@
     <li><a href="../manuals.html">Manuals</a></li>
     <li><a href="../libgenometools.html">C API</a></li>
     <li><a href="../docs.html"><tt>gtscript</tt> docs</a></li>
-    <li><a href="../contract.html">Development Process</a></li>
+    <li><a href="../contract.html">Development Contract</a></li>
     <li><a href="../contribute.html">Contribute</a></li>
   </ul>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>


### PR DESCRIPTION
Rename GenomeTools Development Process (GtDP) to GenomeTools Development
Contract (GtDC) to reflect the contractual nature better.

Rename the GenomeTools Contribution Policy to GenomeTools Contribution Process,
because it describes the actual process. The policy is given in the GtDC.
