### PR TITLE
add `gt_feature_index_get_orig_range_for_seqid()`

### DIFF
--- a/src/annotationsketch/gt_sketch.c
+++ b/src/annotationsketch/gt_sketch.c
@@ -370,7 +370,6 @@ static int gt_sketch_runner(int argc, const char **argv, int parsed_args,
     had_err = gt_feature_index_get_range_for_seqid(features,
                                                    &sequence_region_range,
                                                    seqid,
-                                                   true,
                                                    err);
   }
   if (!had_err) {

--- a/src/annotationsketch/gt_sketch_page.c
+++ b/src/annotationsketch/gt_sketch_page.c
@@ -307,7 +307,7 @@ static int gt_sketch_page_runner(GT_UNUSED int argc,
     /* set display range */
     had_err = gt_feature_index_get_range_for_seqid(features,
                                                    &sequence_region_range,
-                                                   seqid, true, err);
+                                                   seqid, err);
   }
   if (!had_err)
   {

--- a/src/examples/sketch_parsed.c
+++ b/src/examples/sketch_parsed.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     if (gt_error_is_set(err))
       handle_error(err);
   }
-  if (gt_feature_index_get_range_for_seqid(feature_index, &range, seqid, true, err))
+  if (gt_feature_index_get_range_for_seqid(feature_index, &range, seqid, err))
     handle_error(err);
   diagram = gt_diagram_new(feature_index, seqid, &range, style, err);
   gt_free(seqid);

--- a/src/extended/anno_db_gfflike.c
+++ b/src/extended/anno_db_gfflike.c
@@ -1565,7 +1565,6 @@ GtStrArray* gt_feature_index_gfflike_get_seqids(const GtFeatureIndex *gfi,
 int gt_feature_index_gfflike_get_range_for_seqid(GtFeatureIndex *gfi,
                                                  GtRange *range,
                                                  const char *seqid,
-                                                 bool dynamic,
                                                  GtError *err)
 {
   GtFeatureIndexGFFlike *fi;
@@ -1573,7 +1572,6 @@ int gt_feature_index_gfflike_get_range_for_seqid(GtFeatureIndex *gfi,
   GtRDBStmt *stmt;
   gt_assert(gfi && range && seqid);
   gt_error_check(err);
-  if(dynamic){} // Not sure how to handle this
   fi = feature_index_gfflike_cast(gfi);
   gt_mutex_lock(fi->dblock);
   stmt = fi->stmts[GT_PSTMT_GET_SEQREG_RANGE_SELECT];
@@ -1685,6 +1683,7 @@ const GtFeatureIndexClass* feature_index_gfflike_class(void)
                                 gt_feature_index_gfflike_get_first_seqid,
                                 gt_feature_index_gfflike_save,
                                 gt_feature_index_gfflike_get_seqids,
+                                gt_feature_index_gfflike_get_range_for_seqid,
                                 gt_feature_index_gfflike_get_range_for_seqid,
                                 gt_feature_index_gfflike_has_seqid,
                                 gt_feature_index_gfflike_delete);

--- a/src/extended/feature_index_api.h
+++ b/src/extended/feature_index_api.h
@@ -77,8 +77,15 @@ GtStrArray* gt_feature_index_get_seqids(const GtFeatureIndex *feature_index,
 int         gt_feature_index_get_range_for_seqid(GtFeatureIndex *feature_index,
                                                  GtRange *range,
                                                  const char *seqid,
-                                                 bool dynamic,
                                                  GtError *err);
+/* Writes the range of the whole sequence region contained in the
+   <feature_index> for region identifier <seqid> to the <GtRange>
+   pointer <range>. */
+int         gt_feature_index_get_orig_range_for_seqid(GtFeatureIndex
+                                                                *feature_index,
+                                                      GtRange *range,
+                                                      const char *seqid,
+                                                      GtError *err);
 /* Returns <has_seqid>  to true if the sequence region identified by <seqid>
    has been registered in the <feature_index>. */
 int         gt_feature_index_has_seqid(const GtFeatureIndex *feature_index,

--- a/src/extended/feature_index_memory.c
+++ b/src/extended/feature_index_memory.c
@@ -302,7 +302,6 @@ GtStrArray* gt_feature_index_memory_get_seqids(const GtFeatureIndex *gfi,
 int gt_feature_index_memory_get_range_for_seqid(GtFeatureIndex *gfi,
                                                 GtRange *range,
                                                 const char *seqid,
-                                                bool dynamic,
                                                 GT_UNUSED GtError *err)
 {
   RegionInfo *info;
@@ -312,12 +311,30 @@ int gt_feature_index_memory_get_range_for_seqid(GtFeatureIndex *gfi,
   info = (RegionInfo*) gt_hashmap_get(fi->regions, seqid);
   gt_assert(info);
 
-  if (dynamic && info->dyn_range.start != ~0UL && info->dyn_range.end != 0) {
+  if (info->dyn_range.start != ~0UL && info->dyn_range.end != 0) {
     range->start = info->dyn_range.start;
     range->end = info->dyn_range.end;
   }
   else if (info->region)
     *range = gt_genome_node_get_range((GtGenomeNode*) info->region);
+  return 0;
+}
+
+int gt_feature_index_memory_get_orig_range_for_seqid(GtFeatureIndex *gfi,
+                                                     GtRange *range,
+                                                     const char *seqid,
+                                                     GT_UNUSED GtError *err)
+{
+  RegionInfo *info;
+  GtFeatureIndexMemory *fi;
+  gt_assert(gfi && range && seqid);
+  fi = gt_feature_index_memory_cast(gfi);
+  info = (RegionInfo*) gt_hashmap_get(fi->regions, seqid);
+  gt_assert(info);
+
+  if (info->region)
+    *range = gt_genome_node_get_range((GtGenomeNode*) info->region);
+
   return 0;
 }
 
@@ -358,6 +375,7 @@ const GtFeatureIndexClass* gt_feature_index_memory_class(void)
                      NULL,
                      gt_feature_index_memory_get_seqids,
                      gt_feature_index_memory_get_range_for_seqid,
+                     gt_feature_index_memory_get_orig_range_for_seqid,
                      gt_feature_index_memory_has_seqid,
                      gt_feature_index_memory_delete);
   }

--- a/src/extended/feature_index_rep.h
+++ b/src/extended/feature_index_rep.h
@@ -46,8 +46,11 @@ typedef GtStrArray* (*GtFeatureIndexGetSeqidsFunc)(const GtFeatureIndex*,
 typedef int         (*GtFeatureIndexGetRangeForSeqidFunc)(GtFeatureIndex*,
                                                           GtRange*,
                                                           const char*,
-                                                          bool dynamic,
                                                           GtError*);
+typedef int         (*GtFeatureIndexGetOrigRangeForSeqidFunc)(GtFeatureIndex*,
+                                                              GtRange*,
+                                                              const char*,
+                                                              GtError*);
 typedef int         (*GtFeatureIndexHasSeqidFunc)(const GtFeatureIndex*,
                                                   bool*,
                                                   const char*,
@@ -80,6 +83,8 @@ const GtFeatureIndexClass* gt_feature_index_class_new(size_t size,
                                                  get_seqids,
                                          GtFeatureIndexGetRangeForSeqidFunc
                                                  get_range_for_seqid,
+                                         GtFeatureIndexGetOrigRangeForSeqidFunc
+                                                 get_orig_range_for_seqid,
                                          GtFeatureIndexHasSeqidFunc
                                                  has_seqid,
                                          GtFeatureIndexFreeFunc

--- a/src/gtlua/feature_index_lua.c
+++ b/src/gtlua/feature_index_lua.c
@@ -216,7 +216,7 @@ static int feature_index_lua_get_range_for_seqid(lua_State *L)
   luaL_argcheck(L, has_seqid, 2,
                 "feature_index does not contain seqid");
   err = gt_error_new();
-  if (gt_feature_index_get_range_for_seqid(*feature_index, &range, seqid, true, err))
+  if (gt_feature_index_get_range_for_seqid(*feature_index, &range, seqid, err))
     return gt_lua_error(L, err);
   gt_error_delete(err);
   return gt_lua_range_push(L, range);

--- a/src/tools/gt_featureindex.c
+++ b/src/tools/gt_featureindex.c
@@ -271,7 +271,6 @@ static int gt_featureindex_runner(GT_UNUSED int argc,
   if (!had_err && !gt_option_is_set(arguments->rngopt)) {
     had_err = gt_feature_index_get_range_for_seqid(fi, &arguments->qry_rng,
                                                    gt_str_get(arguments->seqid),
-                                                   true,
                                                    err);
   }
 
@@ -288,7 +287,6 @@ static int gt_featureindex_runner(GT_UNUSED int argc,
 
     had_err = gt_feature_index_get_range_for_seqid(fi, &rng,
                                                    gt_str_get(arguments->seqid),
-                                                   true,
                                                    err);
   }
   if (!had_err) {


### PR DESCRIPTION
This adds `gt_feature_index_get_orig_range_for_seqid()` as a new `GtFeatureIndex` function, delivering the range of the original sequence region node inserted into the index, instead of the region populated by features (cf. `gt_feature_index_get_range_for_seqid()`). This addresses issue #13.
