### PR TITLE
fix scan-build complaint

### DIFF
--- a/src/ltr/ltrdigest_pdom_visitor.c
+++ b/src/ltr/ltrdigest_pdom_visitor.c
@@ -256,6 +256,7 @@ static int gt_ltrdigest_pdom_visitor_parse_scores(GT_UNUSED
   gt_assert(lv && instream);
   gt_error_check(err);
   had_err = pdom_parser_get_next_line(buf, instream, err);
+  gt_assert(had_err || buf != NULL);
   if (!had_err && strncmp("Scores", buf, (size_t) 6) != 0) {
     gt_error_set(err, "expected 'Scores:' at beginning of new scores "
                       "section, '%s' read instead", buf);


### PR DESCRIPTION
Some versions of scan-build complain about a possible NULL pointer passed to `strncmp`:

```
src/ltr/ltrdigest_pdom_visitor.c:259:19: warning: Null pointer passed as 
an argument to a 'nonnull' parameter
   if (!had_err && strncmp("Scores", buf, (size_t) 6) != 0) {
                   ^                 ~~~ 
1 warning generated.
make: *** [obj/ltrdigest_pdom_visitor.sb] Error 1
```

This commit adds an assertion to fix this.
