### PR TITLE
add FO paper to web page

### DIFF
--- a/www/genometools.org/htdocs/index.html
+++ b/www/genometools.org/htdocs/index.html
@@ -146,6 +146,16 @@ annotation drawing, AnnotationSketch, LTR prediction, bioinformatics, computatio
     The following software tools are based on the <em>GenomeTools</em> library:
     </p>
     <ul class="pubs">
+      <li><tt><a href="http://www.zbh.uni-hamburg.de/fishoracle">FISH Oracle</a></tt>,
+        a web server for visualizing cancer genomics data.
+      <div class="ref">
+       M. Mader, R. Simon, S. Steinbiss and S. Kurtz.<br>
+       FISH Oracle: a web server for flexible visualization of DNA copy number data in a genomic context. <br>
+       <a href="http://www.jclinbioinformatics.com/content/1/1/20">
+         Journal of Clinical Bioinformatics 2011, 1:20
+       </a>
+      </div>
+      </li>
       <li><tt><a href="http://parseval.sourceforge.net">ParsEval</a></tt>, a
       tool for comparing genome annotations.
       <div class="ref">
@@ -164,16 +174,6 @@ annotation drawing, AnnotationSketch, LTR prediction, bioinformatics, computatio
        and postprocessing of de novo detected LTR retrotransposons. <br>
        <a href="http://www.mobilednajournal.com/content/3/1/18">
          Mobile DNA 2012, 3:18
-       </a>
-      </div>
-      </li>
-      <li><tt><a href="http://www.zbh.uni-hamburg.de/fishoracle">FISH Oracle</a></tt>,
-        a web server for visualizing cancer genomics data.
-      <div class="ref">
-       M. Mader, R. Simon, S. Steinbiss and S. Kurtz.<br>
-       FISH Oracle: a web server for flexible visualization of DNA copy number data in a genomic context. <br>
-       <a href="http://www.jclinbioinformatics.com/content/1/1/20">
-         Journal of Clinical Bioinformatics 2011, 1:20
        </a>
       </div>
       </li>


### PR DESCRIPTION
Adds a link to the published FISH Oracle paper to the GenomeTools web site. This was missing up to now.
