### PR TITLE
use gt_malloc() where possible

### DIFF
--- a/src/core/grep.c
+++ b/src/core/grep.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include "core/ensure.h"
 #include "core/grep_api.h"
+#include "core/ma.h"
 #include "core/unused_api.h"
 
 #ifndef _WIN32
@@ -33,10 +34,10 @@ static void grep_error(int errcode, regex_t *matcher, GtError *err)
   size_t bufsize;
   gt_error_check(err);
   bufsize = regerror(errcode, matcher, NULL, 0);
-  buf = malloc(bufsize);
+  buf = gt_malloc(bufsize);
   (void) regerror(errcode, matcher, buf ? buf : sbuf, buf ? bufsize : BUFSIZ);
   gt_error_set(err, "grep(): %s", buf ? buf : sbuf);
-  free(buf);
+  gt_free(buf);
 }
 #endif
 

--- a/src/core/md5_encoder.c
+++ b/src/core/md5_encoder.c
@@ -26,8 +26,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include "core/md5_encoder_api.h"
 #include "core/assert_api.h"
+#include "core/ma.h"
+#include "core/md5_encoder_api.h"
 
 #define GT_MD5_WORD 32
 #define GT_MD5_MASK 0xFFFFFFFF
@@ -192,7 +193,7 @@ struct GtMD5Encoder {
 
 GtMD5Encoder* gt_md5_encoder_new()
 {
-  GtMD5Encoder *enc = malloc(sizeof (GtMD5Encoder));
+  GtMD5Encoder *enc = gt_malloc(sizeof (GtMD5Encoder));
   enc->len = 0;
   enc->status = 0;
   memset(enc->d_old, 0, sizeof (WORD32)*4);
@@ -258,5 +259,5 @@ void gt_md5_encoder_finish(GtMD5Encoder *enc, unsigned char *output,
 void gt_md5_encoder_delete(GtMD5Encoder *enc)
 {
   if (!enc) return;
-  free(enc);
+  gt_free(enc);
 }

--- a/src/core/msort.c
+++ b/src/core/msort.c
@@ -53,6 +53,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include "core/ma.h"
 #include "core/msort.h"
 
 #define ISIZE sizeof (int)
@@ -218,7 +219,7 @@ msort_r(void *base, size_t nmemb, size_t size, void *cmpinfo,
   if (!(size % ISIZE) && !(((char *)base - (char *)0) % ISIZE))
     iflag = 1;
 
-  if ((list2 = malloc(nmemb * size + PSIZE)) == NULL)
+  if ((list2 = gt_malloc(nmemb * size + PSIZE)) == NULL)
     return (-1);
 
   list1 = base;
@@ -325,7 +326,7 @@ COPY:           b = t;
     memmove(list2, list1, nmemb*size);
     list2 = list1;
   }
-  free(list2);
+  gt_free(list2);
   return (0);
 }
 


### PR DESCRIPTION
In some places, `malloc()` was used where `gt_malloc()` could have been used. To ensure correct space calculation, these calls were replaced by `gt_malloc()` calls.
