### PR TITLE
splint fix for GT_LU and GT_LD formatcodes

### DIFF
--- a/src/core/types_api.h
+++ b/src/core/types_api.h
@@ -41,7 +41,11 @@
 #endif
 
 /* Define the conversion string for 'ld' in platform independent fashion. */
+#ifndef S_SPLINT_S
 #define GT_LD "%"GT_LDS
+#else
+#define GT_LD "%ld"
+#endif
 
 /* Define the conversion string for 'lu' in platform independent fashion. */
 #ifndef _WIN64
@@ -51,7 +55,11 @@
 #endif
 
 /* Define the conversion string for '%lu' in platform independent fashion. */
+#ifndef S_SPLINT_S
 #define GT_LU "%"GT_LUS
+#else
+#define GT_LU "%lu"
+#endif
 
 /* Define the conversion string for '%zu' in platform independent fashion. */
 #if !defined(_WIN32)


### PR DESCRIPTION
This fixes most of the splint formatcode problems (other kind of problems remain).

make -k spgt only outputs 1 formatcode error after this fix.
