### PR TITLE
address cairo/glib `leaks'

### DIFF
--- a/testdata/gt.supp
+++ b/testdata/gt.supp
@@ -161,10 +161,49 @@
    ...
 }
 {
+   cairo_surface_error
+   Memcheck:Addr8
+   ...
+   fun:cairo_surface_finish
+   fun:gt_graphics_cairo_save_to_file
+   ...
+}
+{
+   cairo_surface_error
+   Memcheck:Addr4
+   ...
+   fun:cairo_surface_finish
+   fun:gt_graphics_cairo_save_to_file
+   ...
+}
+{
+   cairo_surface_error
+   Memcheck:Addr8
+   ...
+   fun:cairo_surface_finish
+   fun:gt_graphics_cairo_save_to_stream
+   ...
+}
+{
+   cairo_surface_error
+   Memcheck:Addr4
+   ...
+   fun:cairo_surface_finish
+   fun:gt_graphics_cairo_save_to_stream
+   ...
+}
+{
    fontconfig_leak
    Memcheck:Leak
    fun:*alloc
    ...
    obj:*lib/libfontconfig*
+   ...
+}
+{
+   glib_leak
+   Memcheck:Leak
+   ...
+   fun:gobject_init_ctor
    ...
 }

--- a/testsuite/testsuite.rb
+++ b/testsuite/testsuite.rb
@@ -90,15 +90,18 @@ def run_test(str, opts = {})
   else
     $memcheck = ""
   end
-  run("env GT_SEED=#{$SEED} #{$memcheck} #{$path}#{str}", opts)
+  run("env G_DEBUG=gc-friendly G_SLICE=always-malloc GT_SEED=#{$SEED} " + \
+      "#{$memcheck} #{$path}#{str}", opts)
 end
 
 def run_ruby(str, opts = {})
-  run("env LD_LIBRARY_PATH=#{$cur}/lib ruby -I #{$gtruby} #{$path}#{str}", opts)
+  run("env G_DEBUG=gc-friendly G_SLICE=always-malloc " + \
+      "LD_LIBRARY_PATH=#{$cur}/lib ruby -I #{$gtruby} #{$path}#{str}", opts)
 end
 
 def run_python(str, opts = {})
-  run("env PYTHONPATH=#{$gtpython} LD_LIBRARY_PATH=#{$cur}/lib python " + \
+  run("env G_DEBUG=gc-friendly G_SLICE=always-malloc " + \
+      "PYTHONPATH=#{$gtpython} LD_LIBRARY_PATH=#{$cur}/lib python " + \
       "#{$path}#{str}", opts)
 end
 


### PR DESCRIPTION
This commit addresses several new valgrind issues occurring within cairo and glib which seemingly cannot be influenced from within GenomeTools.
