### PR TITLE
use a shared copy of the D.mel genome in LTRd tests

### DIFF
--- a/testsuite/gt_ltrdigest_include.rb
+++ b/testsuite/gt_ltrdigest_include.rb
@@ -53,7 +53,7 @@ def get_protdom_dna_seqs(gff3filename, chr)
         run_test "#{$bin}gt extractseq -frompos " + \
                  "#{start} -topos " + \
                  "#{stop} " + \
-                 "#{$gttestdata}ltrdigest/#{chr}_genomic_dmel_" + \
+                 "#{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_" + \
                  "RELEASE3-1.FASTA.gz > tmp.fas"
         outa = File.open("tmp.fas").read.split("\n")
         outa.shift
@@ -103,7 +103,7 @@ def check_ppt_pbs(gff3filename, chr)
           run_test "#{$bin}gt extractseq -frompos " + \
                    "#{coords[feat][[start,stop]][0]} -topos " + \
                    "#{coords[feat][[start,stop]][1]} " + \
-                   "#{$gttestdata}ltrdigest/#{chr}_genomic_dmel_" + \
+                   "#{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_" + \
                    "RELEASE3-1.FASTA.gz > tmp.fas"
           outa = File.open("tmp.fas").read.split("\n")
           outa.shift
@@ -195,7 +195,7 @@ if $gttestdata then
   Name "gt ltrdigest unsorted input GFF"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3", :retval => 1
     grep(last_stderr, /is not sorted/)
   end
@@ -205,7 +205,7 @@ if $gttestdata then
 
 #  Keywords "gt_ltrdigest"
 #  Test do
-#    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+#    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
 #    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz #{$gttestdata}ltrdigest/dmel_test_Run9_4_wrong_seqid.gff3", :retval => 1
 #    grep(last_stderr, "Feature 'LTR_retrotransposon1' on line 6 has invalid region identifier,must be 'seqX' with X being a sequence number, but was 'chr4'")
 #  end
@@ -213,7 +213,7 @@ if $gttestdata then
   Name "gt ltrdigest missing input sequence"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
     grep(last_stderr, /mandatory/)
   end
@@ -221,7 +221,7 @@ if $gttestdata then
   Name "gt ltrdigest missing tRNA library but -trna given"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -trnas -outfileprefix foo #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
     grep(last_stderr, /missing argument to option/)
   end
@@ -229,7 +229,7 @@ if $gttestdata then
   Name "gt ltrdigest corrupt tRNA library"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -trnas #{$gttestdata}ltrdigest/corrupt_trna.fas #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
     grep(last_stderr, /cannot guess file type of file/)
   end
@@ -237,7 +237,7 @@ if $gttestdata then
   Name "gt ltrdigest tRNA implied options"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -lossless  -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -lossless  -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pbsalilen 10 20 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
     grep(last_stderr, /option "-pbsalilen" requires option "-trnas"/)
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pbsoffset 10 20 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
@@ -252,7 +252,7 @@ if $gttestdata then
     Name "gt ltrdigest corrupt pHMM"
     Keywords "gt_ltrdigest"
     Test do
-      run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+      run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
       run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -hmms #{$gttestdata}ltrdigest/corrupt.hmm -- #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
       grep(last_stderr, /error occurred during HMM preprocessing/)
     end
@@ -260,7 +260,7 @@ if $gttestdata then
     Name "gt ltrdigest pHMM implied options"
     Keywords "gt_ltrdigest"
     Test do
-      run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+      run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
       run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pdomevalcutoff 0.2 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
       grep(last_stderr, /option "-pdomevalcutoff" requires option "-hmms"/)
       run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pdomevalcutoff 2.2 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
@@ -270,7 +270,7 @@ if $gttestdata then
     Name "gt ltrdigest use of deprecated '-threads' switch"
     Keywords "gt_ltrdigest"
     Test do
-      run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+      run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
       run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -threads 2 -outfileprefix result4 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 0, :maxtime => 12000
       grep(last_stderr, /option is deprecated. Please use/)
     end
@@ -279,7 +279,7 @@ if $gttestdata then
   Name "gt ltrdigest PPT HMM parameters (background distribution)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     # probabilities do not add up to 1, sum > 0
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -ppttprob 0.3 -pptaprob 0.3 -pptgprob 0.9 -pptcprob 0.2 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
     # probability > 1
@@ -296,7 +296,7 @@ if $gttestdata then
   Name "gt ltrdigest PPT HMM parameters (U-box U frequency)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptuprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptuprob 0.0 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 0
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptuprob 0.91 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 0
@@ -306,7 +306,7 @@ if $gttestdata then
   Name "gt ltrdigest PPT HMM parameters (PPT R/Y frequencies)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptrprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptyprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptrprob 0.97 -pptyprob 0.03 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 0
@@ -318,7 +318,7 @@ if $gttestdata then
   Name "gt ltrdigest GFF and sequence do not match"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz #{$gttestdata}ltrdigest/dmel_test_Run9_2L.gff3.sorted", :retval => 1
     grep(last_stderr, "which is not covered by that sequence")
   end
@@ -330,7 +330,7 @@ if $gttestdata then
       Name "gt ltrdigest D. mel. #{chr} basic test w/ RT"
       Keywords "gt_ltrdigest"
       Test do
-        run_test "#{$bin}gt suffixerator -lossless  -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
+        run_test "#{$bin}gt suffixerator -lossless  -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
         run_test "#{$bin}gt ltrdigest -encseq #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz -outfileprefix result#{chr} -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_test_Run9_#{chr}.gff3.sorted", :retval => 0, :maxtime => 12000
         check_ppt_pbs(last_stdout, chr)
         #run "diff #{last_stdout} #{$gttestdata}ltrdigest/#{chr}_ref.gff3"
@@ -339,7 +339,7 @@ if $gttestdata then
       Name "gt ltrdigest D. mel. chromosome #{chr} basic test, no HMM"
       Keywords "gt_ltrdigest"
       Test do
-        run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
+        run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
         run_test "#{$bin}gt -j 2 ltrdigest -encseq #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz -outfileprefix result#{chr} -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_#{chr}.gff3.sorted",\
        :retval => 0, :maxtime => 700
         check_ppt_pbs(last_stdout, chr)
@@ -354,7 +354,7 @@ if $gttestdata then
       Keywords "gt_ltrdigest aminoacidout"
       Test do
         run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v " + \
-                 "-db #{$gttestdata}ltrdigest/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", \
+                 "-db #{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", \
                  :maxtime => 600
         run_test "#{$bin}gt -j 2 ltrdigest -outfileprefix result#{chr} " + \
                  "-encseq #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz " + \
@@ -372,7 +372,7 @@ if $gttestdata then
     Keywords "gt_ltrdigest aminoacidout aliout"
     Test do
       run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v " + \
-               "-db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz", \
+               "-db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz", \
                :maxtime => 600
       run_test "#{$bin}gt -j 2 ltrdigest -outfileprefix result4 " + \
                "-encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz " + \
@@ -397,7 +397,7 @@ if $gttestdata then
     Keywords "gt_ltrdigest aminoacidout aaout"
     Test do
       run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v " + \
-               "-db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz", \
+               "-db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz", \
                :maxtime => 600
       run_test "#{$bin}gt -j 2 ltrdigest -outfileprefix result4 " + \
                "-encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz " + \
@@ -430,7 +430,7 @@ if $gttestdata then
   Name "gt ltrdigest unsorted input GFF (legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     grep(last_stderr, /is not sorted/)
   end
@@ -438,7 +438,7 @@ if $gttestdata then
   Name "gt ltrdigest wrong sequence regions in input GFF (legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest #{$gttestdata}ltrdigest/dmel_test_Run9_4_wrong_seqid.gff3 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     grep(last_stderr, /does not have the form/)
   end
@@ -446,7 +446,7 @@ if $gttestdata then
   Name "gt ltrdigest missing input sequence (legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted", :retval => 1
     grep(last_stderr, /missing mandatory/)
   end
@@ -454,7 +454,7 @@ if $gttestdata then
   Name "gt ltrdigest missing tRNA library but -trna given (legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -trnas -outfileprefix foo #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     grep(last_stderr, /missing argument to option/)
   end
@@ -462,7 +462,7 @@ if $gttestdata then
   Name "gt ltrdigest corrupt tRNA library (legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -trnas #{$gttestdata}ltrdigest/corrupt_trna.fas #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     grep(last_stderr, /cannot guess file type of file/)
   end
@@ -470,7 +470,7 @@ if $gttestdata then
   Name "gt ltrdigest tRNA implied options (legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -pbsalilen 10 20 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     grep(last_stderr, /option "-pbsalilen" requires option "-trnas"/)
     run_test "#{$bin}gt ltrdigest -pbsoffset 10 20 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
@@ -485,7 +485,7 @@ if $gttestdata then
     Name "gt ltrdigest corrupt pHMM (legacy syntax)"
     Keywords "gt_ltrdigest"
     Test do
-      run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+      run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
       run_test "#{$bin}gt ltrdigest -hmms #{$gttestdata}ltrdigest/corrupt.hmm -- #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
       grep(last_stderr, /error occurred during HMM preprocessing/)
     end
@@ -493,7 +493,7 @@ if $gttestdata then
     Name "gt ltrdigest HMM list not properly closed (legacy syntax)"
     Keywords "gt_ltrdigest"
     Test do
-      run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+      run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
       run_test "#{$bin}gt ltrdigest -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
       grep(last_stderr, /invalid HMM file/)
     end
@@ -501,7 +501,7 @@ if $gttestdata then
     Name "gt ltrdigest pHMM implied options (legacy syntax)"
     Keywords "gt_ltrdigest"
     Test do
-      run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+      run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
       run_test "#{$bin}gt ltrdigest -pdomevalcutoff 0.2 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
       grep(last_stderr, /option "-pdomevalcutoff" requires option "-hmms"/)
       run_test "#{$bin}gt ltrdigest -pdomevalcutoff 2.2 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
@@ -511,7 +511,7 @@ if $gttestdata then
     Name "gt ltrdigest use of deprecated '-threads' switch (legacy syntax)"
     Keywords "gt_ltrdigest"
     Test do
-      run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+      run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
       run_test "#{$bin}gt ltrdigest -threads 2 -outfileprefix result4 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0, :maxtime => 12000
       grep(last_stderr, /option is deprecated. Please use/)
     end
@@ -520,7 +520,7 @@ if $gttestdata then
   Name "gt ltrdigest PPT HMM parameters (background distribution, legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     # probabilities do not add up to 1, sum > 0
     run_test "#{$bin}gt ltrdigest -ppttprob 0.3 -pptaprob 0.3 -pptgprob 0.9 -pptcprob 0.2 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     # probability > 1
@@ -537,7 +537,7 @@ if $gttestdata then
   Name "gt ltrdigest PPT HMM parameters (U-box U frequency, legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -pptuprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     run_test "#{$bin}gt ltrdigest -pptuprob 0.0 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
     run_test "#{$bin}gt ltrdigest -pptuprob 0.91 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
@@ -547,7 +547,7 @@ if $gttestdata then
   Name "gt ltrdigest PPT HMM parameters (PPT R/Y frequencies, legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -pptrprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     run_test "#{$bin}gt ltrdigest -pptyprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     run_test "#{$bin}gt ltrdigest -pptrprob 0.97 -pptyprob 0.03 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
@@ -559,7 +559,7 @@ if $gttestdata then
   Name "gt ltrdigest GFF and sequence do not match (legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest #{$gttestdata}ltrdigest/dmel_test_Run9_2L.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     grep(last_stderr, "which is not covered by that sequence")
   end
@@ -571,7 +571,7 @@ if $gttestdata then
       Name "gt ltrdigest D. mel. #{chr} basic test w/ RT (legacy syntax)"
       Keywords "gt_ltrdigest"
       Test do
-        run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
+        run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
         run_test "#{$bin}gt ltrdigest -outfileprefix result#{chr} -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_test_Run9_#{chr}.gff3.sorted #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0, :maxtime => 12000
         check_ppt_pbs(last_stdout, chr)
         #run "diff #{last_stdout} #{$gttestdata}ltrdigest/#{chr}_ref.gff3"
@@ -580,7 +580,7 @@ if $gttestdata then
       Name "gt ltrdigest D. mel. #{chr} basic test, no HMM (legacy syntax)"
       Keywords "gt_ltrdigest"
       Test do
-        run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrdigest/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
+        run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
         run_test "#{$bin}gt -j 2 ltrdigest -outfileprefix result#{chr} -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_#{chr}.gff3.sorted #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz",\
        :retval => 0, :maxtime => 700
         check_ppt_pbs(last_stdout, chr)
@@ -595,7 +595,7 @@ if $gttestdata then
       Keywords "gt_ltrdigest aminoacidout"
       Test do
         run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v " + \
-                 "-db #{$gttestdata}ltrdigest/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", \
+                 "-db #{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", \
                  :maxtime => 600
         run_test "#{$bin}gt -j 2 ltrdigest -outfileprefix result#{chr} " + \
                  "-hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm " + \
@@ -613,7 +613,7 @@ if $gttestdata then
     Keywords "gt_ltrdigest aminoacidout aliout"
     Test do
       run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v " + \
-               "-db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz", \
+               "-db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz", \
                :maxtime => 600
       run_test "#{$bin}gt -j 2 ltrdigest -outfileprefix result4 " + \
                "-hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm -- " + \
@@ -638,7 +638,7 @@ if $gttestdata then
     Keywords "gt_ltrdigest aminoacidout aaout"
     Test do
       run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v " + \
-               "-db #{$gttestdata}ltrdigest/4_genomic_dmel_RELEASE3-1.FASTA.gz", \
+               "-db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz", \
                :maxtime => 600
       run_test "#{$bin}gt -j 2 ltrdigest -outfileprefix result4 " + \
                "-hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm -- " + \


### PR DESCRIPTION
This allows to remove a redundant copy of this genome sequence from the gttestdata repository.
