### PR TITLE
do not require sorted input in custom streams

### DIFF
--- a/src/extended/script_wrapper_stream.c
+++ b/src/extended/script_wrapper_stream.c
@@ -70,7 +70,7 @@ GtNodeStream* gt_script_wrapper_stream_new(GtScriptWrapperStreamNextFunc next,
   GtNodeStream *ns;
   GtScriptWrapperStream *script_wrapper_stream;
   gt_assert(next);
-  ns = gt_node_stream_create(gt_script_wrapper_stream_class(), true);
+  ns = gt_node_stream_create(gt_script_wrapper_stream_class(), false);
   script_wrapper_stream = script_wrapper_stream_cast(ns);
   script_wrapper_stream->next_func = next;
   script_wrapper_stream->free_func = free;


### PR DESCRIPTION
Custom streams implemented in scripting languages should not assume sortedness as we cannot tell from the C side what the user does with them. Let's declare them unsorted to be on the safe side. 
