### PR TITLE
output proper error message on malformed input data

### DIFF
--- a/src/extended/orf_finder_stream.c
+++ b/src/extended/orf_finder_stream.c
@@ -51,7 +51,7 @@ static int gt_orf_finder_stream_next(GtNodeStream *gs, GtGenomeNode **gn,
 
   had_err = gt_node_stream_next(ls->in_stream, gn, err);
   if (!had_err && *gn) {
-    (void) gt_genome_node_accept(*gn, (GtNodeVisitor*) ls->lv, err);
+    had_err = gt_genome_node_accept(*gn, (GtNodeVisitor*) ls->lv, err);
   }
   if (had_err) {
     gt_genome_node_delete(*gn);

--- a/testsuite/gt_orffinder_include.rb
+++ b/testsuite/gt_orffinder_include.rb
@@ -1,41 +1,61 @@
+Name "gt orffinder missing input sequence"
+Keywords "gt_orffinder"
+Test do
+  run_test "#{$bin}gt orffinder", :retval => 1, :maxtime => 120
+  grep(last_stderr, /missing argument/)
+end
+
+Name "gt orffinder missing value for -min"
+Keywords "gt_orffinder"
+Test do
+  run_test "#{$bin}gt orffinder -min foo foo.gff3", :retval => 1
+  grep(last_stderr, /error/)
+end
+
+Name "gt orffinder missing value for -max"
+Keywords "gt_orffinder"
+Test do
+  run_test "#{$bin}gt orffinder -max foo foo.gff3", :retval => 1
+  grep(last_stderr, /error/)
+end
+
+Name "gt orffinder value for -min < 30"
+Keywords "gt_orffinder"
+Test do
+  run_test "#{$bin}gt orffinder -min 1 foo foo.gff3", :retval => 1
+  grep(last_stderr, /error/)
+end
+
+Name "gt orffinder value for -min > -max"
+Keywords "gt_orffinder"
+Test do
+  run_test "#{$bin}gt orffinder -min 130 -max 120 foo foo.gff3", :retval => 1
+  grep(last_stderr, /Value for/)
+end
+
+Name "gt orffinder legacy input with no seqX IDs"
+Keywords "gt_orffinder legacy_seqids"
+Test do
+  run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -indexname foo -db #{$testdata}U89959_genomic.fas"
+  run_test "#{$bin}gt orffinder -types gene -- foo #{$testdata}U89959_cds.gff3", :retval => 1
+  grep last_stderr, "seqX"
+end
+
+Name "gt orffinder -encseq -matchdesc"
+Keywords "gt_orffinder"
+Test do
+  run_test "#{$bin}gt encseq encode -v -lossless -indexname foo #{$testdata}U89959_genomic.fas"
+  run_test "#{$bin}gt orffinder -types gene -matchdesc -encseq foo #{$testdata}U89959_cds.gff3"
+  grep last_stdout, "reading_frame"
+end
+
 if $gttestdata then
-  Name "gt orffinder missing input sequence"
+  Name "gt orffinder -types ltrs is not a node"
   Keywords "gt_orffinder"
   Test do
-    run_test "#{$bin}gt orffinder", :retval => 1, :maxtime => 120
-    grep(last_stderr, /missing argument/)
-  end
-
-  Name "gt orffinder missing value for -min"
-  Keywords "gt_orffinder"
-  Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
-    run_test "#{$bin}gt orffinder -min 4_genomic_dmel_RELEASE3-1.FASTA.gz #{$gttestdata}orffinder/chr4.gff3", :retval => 1
-    grep(last_stderr, /error/)
-  end
-
-  Name "gt orffinder missing value for -max"
-  Keywords "gt_orffinder"
-  Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
-    run_test "#{$bin}gt orffinder -max #{$gttestdata}orffinder/chr4.gff3 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
-    grep(last_stderr, /error/)
-  end
-
-  Name "gt orffinder value for -min < 30"
-  Keywords "gt_orffinder"
-  Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
-    run_test "#{$bin}gt orffinder -min 1 -o foo 4_genomic_dmel_RELEASE3-1.FASTA.gz #{$gttestdata}orffinder/chr4.gff3", :retval => 1
-    grep(last_stderr, /error/)
-  end
-
-  Name "gt orffinder value for -min > -max"
-  Keywords "gt_orffinder"
-  Test do
-    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
-    run_test "#{$bin}gt orffinder -min 130 -max 120  -o foo 4_genomic_dmel_RELEASE3-1.FASTA.gz #{$gttestdata}orffinder/chr4.gff3", :retval => 1
-    grep(last_stderr, /Value for/)
+    run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/3R_genomic_dmel_RELEASE3-1.FASTA.gz"
+    run_test "#{$bin}gt orffinder -types altrs -- 3R_genomic_dmel_RELEASE3-1.FASTA.gz #{$gttestdata}orffinder/chr3R.gff3", :maxtime => 120
+    run "diff #{last_stdout} #{$gttestdata}orffinder/chr3R_no_node_altrs.gff3"
   end
 
   Name "gt orffinder -types ltrs is not a node"
@@ -43,7 +63,6 @@ if $gttestdata then
   Test do
     run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/3R_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt orffinder -types altrs -- 3R_genomic_dmel_RELEASE3-1.FASTA.gz #{$gttestdata}orffinder/chr3R.gff3", :maxtime => 120
-    run "diff #{last_stdout} #{$gttestdata}orffinder/chr3R_no_node_altrs.gff3"
   end
 
   Name "gt orffinder find longest orfs for 2R"


### PR DESCRIPTION
This addresses an issue reported on the GenomeTools mailing list (http://genometools.org/pipermail/gt-users/2013-December/000673.html) where an error in the input files failed to generate a sensible error message. Since the input options have been changed for 1.5.2 but still allow this 'old-style' input for compatibility reasons I fixed this problem.
