### PR TITLE
make use of Lua CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,19 +271,19 @@ ifeq ($(SYSTEM),Darwin)
 endif
 
 ifeq ($(SYSTEM),Darwin)
-  EXT_FLAGS += -DLUA_DL_DYLD
+  EXP_CPPFLAGS += -DLUA_DL_DYLD
 else
-  EXT_FLAGS += -DLUA_DL_DLOPEN
-  ifneq ($(SYSTEM),FreeBSD)
   ifneq ($(SYSTEM),Windows)
-    LUA_LDLIB:=-ldl
-    EXP_LDLIBS += -ldl
-  endif
+    EXP_CPPFLAGS += -DLUA_DL_DLOPEN
+    ifneq ($(SYSTEM),FreeBSD)
+      LUA_LDLIB:=-ldl
+      EXP_LDLIBS += -ldl
+    endif
   endif
 endif
 
-ifneq ($(SYSTEM), Windows)
-  EXT_FLAGS += -DLUA_USE_MKSTEMP
+ifneq ($(SYSTEM),Windows)
+  EXP_CPPFLAGS += -DLUA_USE_MKSTEMP
 endif
 
 ifeq ($(64bit),yes)


### PR DESCRIPTION
Turns out the changes in #181 do not really take effect on non-Windows systems as EXT_FLAGS is never used in the compiler calls. Changed this to use EXP_CPPFLAGS instead which is used. This prevents some Lua-related compiler warnings on newer gccs.

@gordon, could you please check Windows compatibility before merging?
