### PR TITLE
fix compilation on Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,15 +270,11 @@ ifeq ($(SYSTEM),Darwin)
   endif
 endif
 
-ifeq ($(SYSTEM),Darwin)
-  EXP_CPPFLAGS += -DLUA_DL_DYLD
-else
-  ifneq ($(SYSTEM),Windows)
-    EXP_CPPFLAGS += -DLUA_DL_DLOPEN
-    ifneq ($(SYSTEM),FreeBSD)
-      LUA_LDLIB:=-ldl
-      EXP_LDLIBS += -ldl
-    endif
+ifneq ($(SYSTEM),Windows)
+  EXP_CPPFLAGS += -DLUA_DL_DLOPEN
+  ifneq ($(SYSTEM),FreeBSD)
+    LUA_LDLIB:=-ldl
+    EXP_LDLIBS += -ldl
   endif
 endif
 


### PR DESCRIPTION
Newer Mac OS X versions (e.g. Mountain Lion) will not build without
warnings if -DLUA_DL_DYLD is specified. However, looking at the
Lua 5.1.5 Makefile it is no longer required to do that.
