### PR TITLE
Featorig

### DIFF
--- a/src/extended/feature_in_stream.c
+++ b/src/extended/feature_in_stream.c
@@ -126,9 +126,8 @@ void feature_in_stream_init(GtFeatureInStream *stream)
   gt_error_delete(error);
 }
 
-void gt_feature_in_stream_use_orig_ranges(GtFeatureOutStream *stream)
+void gt_feature_in_stream_use_orig_ranges(GtFeatureInStream *stream)
 {
-  GtFeatureInStream *stream = feature_in_stream_cast(ns);
   stream->useorig = true;
 }
 

--- a/src/extended/feature_in_stream_api.h
+++ b/src/extended/feature_in_stream_api.h
@@ -31,6 +31,6 @@ GtNodeStream* gt_feature_in_stream_new(GtFeatureIndex *fi);
    inferred from the features. Specifically, use
    <gt_feature_index_get_orig_range_for_seqid> on the underlying feature
    index rather than the default <gt_feature_index_get_range_for_seqid>. */
-void gt_feature_in_stream_use_orig_ranges(GtFeatureOutStream *stream);
+void gt_feature_in_stream_use_orig_ranges(GtFeatureInStream *stream);
 
 #endif


### PR DESCRIPTION
The feature index class provides two functions: `gt_feature_index_get_range_for_seqid`, which returns the range inferred from features; and `gt_feature_index_get_orig_range_for_seqid`, which returns the range specified by the original input (such as specified by the `##sequence-region` pragmas in a GFF3 file).

This commit extends the `GtFeatureInStream` API so that the programmer can specify which function to use when delivering region nodes into a stream from a feature index.
