### PR TITLE
do not override error message

### DIFF
--- a/src/extended/match_iterator_blast.c
+++ b/src/extended/match_iterator_blast.c
@@ -88,7 +88,7 @@ static GtMatchIteratorStatus gt_match_iterator_blast_next(GtMatchIterator *gm,
       fseek(m->pvt->matchfilep, -1, SEEK_CUR);
     readvalues = fscanf(m->pvt->matchfilep,
                         "%s %s %f " GT_WD " %*d %*d " GT_WD " " GT_WD " " GT_WD
-                        " " GT_WD " " "%lg %f\n", query_seq, db_seq, &identity,
+                        " " GT_WD " %lg %f\n", query_seq, db_seq, &identity,
                         &storeinteger[0],
                         &storeinteger[1], &storeinteger[2], &storeinteger[3],
                         &storeinteger[4], &e_value, &bitscore);

--- a/src/extended/match_iterator_open.c
+++ b/src/extended/match_iterator_open.c
@@ -122,7 +122,7 @@ static GtMatchIteratorStatus gt_match_iterator_open_next(GtMatchIterator *gmpi,
     }
   }
 
-  for (columncount = 0; columncount < (GtUword) (READNUMS);
+  for (columncount = 0; !had_err && columncount < (GtUword) (READNUMS);
        columncount++) {
     if (storeinteger[columncount] < 0) {
          GT_MATCHER_OPEN_CANNOTPARSECOLUMN("non-negative integer expected");


### PR DESCRIPTION
found this in the 32bit compiled version.
The for-loop should not be run if there was an error. Seems like the 64bit-code did set `storeinteger` to zero or some positive values. But on 32bit, if the parsing of a line fails, the elements in `storeinteger` can be negative. This would overwrite the errormessage and thus results in failing tests that expect another error.
