### PR TITLE
Added /usr/local/shared to default gtdatapath

### DIFF
--- a/src/core/gtdatapath.c
+++ b/src/core/gtdatapath.c
@@ -31,6 +31,7 @@
 
 /* XXX: how to define the default path on Windows? */
 static const char* GTDATA_DEFAULT_PATHS[]={ "/usr/share/genometools" GTDATADIR,
+                                            "/usr/local/share/genometools" GTDATADIR,
                                             NULL };
 
 GtStr* gt_get_gtdata_path(const char *prog, GtError *err)


### PR DESCRIPTION
Allows gtdatapath to be in /usr/local/shared as well as /usr/shared.
This makes it much easier to install using the Homebrew system on OSX.
