### PR TITLE
silence warnings for pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2006-2013 Gordon Gremme <gordon@gremme.org>
-# Copyright (c) 2008-2013 Sascha Steinbiss <steinbiss@zbh.uni-hamburg.de>
+# Copyright (c) 2008-2014 Sascha Steinbiss <steinbiss@zbh.uni-hamburg.de>
 # Copyright (c) 2006-2013 Center for Bioinformatics, University of Hamburg
 #
 # Permission to use, copy, modify, and distribute this software for any
@@ -35,11 +35,13 @@ else
 endif
 
 ifneq ($(cairo),no)
+  # XXX: check for existence of packages, and emit warning and disable cairo
+  # if packages are not available
   ifeq ($(HAS_PKGCONFIG),yes)
-	INCLUDEOPT+=$(shell pkg-config --cflags-only-I pango) \
-	            $(shell pkg-config --cflags-only-I cairo) \
-	            $(shell pkg-config --cflags-only-I pangocairo) \
-	            $(shell pkg-config --cflags-only-I glib-2.0)
+	INCLUDEOPT+=$(shell pkg-config --silence-errors --cflags-only-I pango) \
+	            $(shell pkg-config --silence-errors --cflags-only-I cairo) \
+	            $(shell pkg-config --silence-errors --cflags-only-I pangocairo) \
+	            $(shell pkg-config --silence-errors --cflags-only-I glib-2.0)
   endif
 endif
 
@@ -335,13 +337,13 @@ ifneq ($(cairo),no)
   endif
   ifeq ($(HAS_PKGCONFIG),yes)
     GTSHAREDLIB_LIBDEP:= $(GTSHAREDLIB_LIBDEP) \
-                         $(shell pkg-config --libs pango) \
-                         $(shell pkg-config --libs cairo) \
-                         $(shell pkg-config --libs pangocairo)
+                         $(shell pkg-config --silence-errors --libs pango) \
+                         $(shell pkg-config --silence-errors --libs cairo) \
+                         $(shell pkg-config --silence-errors --libs pangocairo)
     EXP_LDLIBS:=$(EXP_LDLIBS) \
-                $(shell pkg-config --libs pango) \
-                $(shell pkg-config --libs cairo) \
-                $(shell pkg-config --libs pangocairo)
+                $(shell pkg-config --silence-errors --libs pango) \
+                $(shell pkg-config --silence-errors --libs cairo) \
+                $(shell pkg-config --silence-errors --libs pangocairo)
   endif
   ANNOTATIONSKETCH_EXAMPLES := bin/examples/sketch_constructed \
                                bin/examples/sketch_parsed_with_ctrack \
@@ -1093,7 +1095,8 @@ cleanindexes:
 gtkviewer:
 	@echo "[compile $(notdir $@)]"
 	@$(CC) -o bin/examples/gtkviewer $(GT_CPPFLAGS) $(GT_LDFLAGS) \
-  src/examples/gtkviewer.c  -lcairo `pkg-config --cflags --libs gtk+-2.0` \
+  src/examples/gtkviewer.c \
+  -lcairo `pkg-config --silence-errors --cflags --libs gtk+-2.0` \
   -lgenometools
 
 cleanup: clean cleangenerated cleanindexes


### PR DESCRIPTION
Makes sure that warnings about missing packages are not always printed in make runs.
