### PR TITLE
fix node order for sequence/EOF nodes

### DIFF
--- a/src/extended/genome_node.c
+++ b/src/extended/genome_node.c
@@ -126,9 +126,13 @@ static int compare_genome_node_type(GtGenomeNode *gn_a, GtGenomeNode *gn_b)
   en_a = gt_eof_node_try_cast(gn_a);
   en_b = gt_eof_node_try_cast(gn_b);
 
-  if ((sn_a && !sn_b) || (en_a && !en_b))
+  if (sn_a && !sn_b)
+    return en_b ? -1 : 1;
+  if (!sn_a && sn_b)
+    return en_a ? 1 : -1;
+  if (en_a && !en_b)
     return 1;
-  if ((!sn_a && sn_b) || (!en_a && en_b))
+  if (!en_a && en_b)
     return -1;
 
   return 0;

--- a/testdata/merge_with_seq.gff3
+++ b/testdata/merge_with_seq.gff3
@@ -1,0 +1,14 @@
+##gff-version   3
+##sequence-region   ctg123 1 1497228
+##sequence-region   seq1 1 10
+##sequence-region   seq2 1 10
+ctg123	.	gene	1000	9000	.	+	.	.
+seq1	.	gene	1	10	.	+	.	.
+seq2	.	gene	1	10	.	+	.	.
+##FASTA
+>ctg123
+cttctgggcgtacccgattctcggagaacttgccgcaccattccgccttgtgttcattgctgcctgcatgttcattgtctacctcggctacgtgtggctatctttcctcggtgccctcgtgcacggagtcgagaaaccaaagaacaaaaaaagaaattaaaatatttattttgctgtggtttttgatgtgtgttttttataatgatttttgatgtgaccaattgtacttttcctttaaatgaaatgtaatcttaaatgtatttccgacgaattcgaggcctgaaaagtgtgacgccattcgtatttgatttgggtttactatcgaataatgagaattttcaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttaggcttagaatctagctagctatccgaaattcgaggcctgaaaagtgtgacgccattc
+>seq1
+cttctgggcg
+>seq2
+tgttcattgc

--- a/testsuite/gt_merge_include.rb
+++ b/testsuite/gt_merge_include.rb
@@ -30,3 +30,10 @@ Test do
   run_test("#{$bin}gt merge #{$testdata}unsorted_gff3_file.txt", :retval => 1)
   grep(last_stderr, "is not sorted")
 end
+
+Name "gt merge with sequence"
+Keywords "gt_merge"
+Test do
+  run_test "#{$bin}gt merge #{$testdata}minimal_fasta.gff3 #{$testdata}two_fasta_seqs.gff3"
+  run "diff #{last_stdout} #{$testdata}merge_with_seq.gff3"
+end


### PR DESCRIPTION
Make sure that sequence nodes always sort before EOF nodes. Closes #242.
