### PR TITLE
fix compilation on Mac OS X (10.8.5)

### DIFF
--- a/src/external/tre/lib/tre-compile.c
+++ b/src/external/tre/lib/tre-compile.c
@@ -1843,8 +1843,9 @@ tre_ast_to_tnfa(tre_ast_node_t *node, tre_tnfa_transition_t *transitions,
 
 #define ERROR_EXIT(err)		  \
   do				  \
-    {				  \
-      errcode = err;		  \
+    {	 \
+      reg_errcode_t my_errcode = err;			  \
+      errcode = my_errcode;		  \
       if (/*CONSTCOND*/(void)1,1)	  \
       	goto error_exit;	  \
     }				  \


### PR DESCRIPTION
The tre library code triggers a self-assignment warning in a macro, patched `tre-compile.c` to fix this.
