### PR TITLE
make sure an error is set before printing it

### DIFF
--- a/gtpython/gt/core/error.py
+++ b/gtpython/gt/core/error.py
@@ -51,7 +51,10 @@ class Error:
     from_param = classmethod(from_param)
 
     def get(self):
-        return gtlib.gt_error_get(self.error)
+        if self.is_set():
+            return gtlib.gt_error_get(self.error)
+        else:
+            return "undefined error -- please report this as a bug!"
 
     def set(self, errmsg):
         return gtlib.gt_error_set_nonvariadic(self.error, str(errmsg))

--- a/gtpython/gt/extended/feature_index.py
+++ b/gtpython/gt/extended/feature_index.py
@@ -81,7 +81,8 @@ class FeatureIndex:
         err = Error()
         str = gtlib.gt_feature_index_get_first_seqid(self.fi, err)
         if str == None:
-            gterror(err)
+            if err.is_set():
+                gterror(err)
         return str
 
     def get_seqids(self):

--- a/gtruby/extended/feature_index.rb
+++ b/gtruby/extended/feature_index.rb
@@ -98,7 +98,9 @@ module GT
     def get_first_seqid
       err = Error.new()
       val = GT.gt_feature_index_get_first_seqid(@feature_index, err.to_ptr)
-      if val.nil? then GT.gterror(err) end
+      if val.nil? then
+        GT.gterror(err) if err.is_set?
+      end
       val
     end
 


### PR DESCRIPTION
The C call for `gt_feature_index_get_first_seqid()` in the scripting language bindings can return NULL in a non-error case (i.e. when the index is still empty). This must not be treated as an error condition in the scripting language bindings.
