### PR TITLE
gtruby: missing methods and fixes

### DIFF
--- a/gtruby/extended/feature_node.rb
+++ b/gtruby/extended/feature_node.rb
@@ -166,7 +166,7 @@ module GT
 
     def add_attribute(tag, val)
       if tag.to_s == "" or val.to_s == "" then
-        gterror("Attribute keys or values must not be empty!")
+        GT::gterror("Attribute keys or values must not be empty!")
       end
       GT.gt_feature_node_add_attribute(@genome_node, tag.to_s, val.to_s)
       self.update_attribs
@@ -174,7 +174,7 @@ module GT
 
     def set_attribute(tag, val)
       if tag.to_s == "" or val.to_s == "" then
-        gterror("Attribute keys or values must not be empty!")
+        GT::gterror("Attribute keys or values must not be empty!")
       end
       GT.gt_feature_node_set_attribute(@genome_node, tag.to_s, val.to_s)
       self.update_attribs
@@ -182,7 +182,7 @@ module GT
 
     def remove_attribute(tag)
       if tag.to_s == "" then
-        gterror("Attribute key must not be empty!")
+        GT::gterror("Attribute key must not be empty!")
       end
       GT.gt_feature_node_remove_attribute(@genome_node, tag.to_s)
       self.update_attribs


### PR DESCRIPTION
This PR fixes a problem with error reporting in the Ruby bindings and also adds the methods `FeatureNode.remove_attribute()` and `FeatureNode.set_attribute()`
