### PR TITLE
fix double free in sketch tool

### DIFF
--- a/src/annotationsketch/gt_sketch.c
+++ b/src/annotationsketch/gt_sketch.c
@@ -363,7 +363,7 @@ static int gt_sketch_runner(int argc, const char **argv, int parsed_args,
     had_err = -1;
   }
   else if (!had_err)
-    seqid = gt_str_get(arguments->seqid);
+    seqid = gt_cstr_dup(gt_str_get(arguments->seqid));
 
   results = gt_array_new(sizeof (GtGenomeNode*));
   if (!had_err) {


### PR DESCRIPTION
This PR fixes a bug where use of the `-seqid` parameter causes a double free attempt, resulting in an error message (and error code being set!) at the end of a successful sketch run.
