### PR TITLE
parse RF lines correctly in hmmscan output

### DIFF
--- a/src/ltr/ltrdigest_pdom_visitor.c
+++ b/src/ltr/ltrdigest_pdom_visitor.c
@@ -1,6 +1,7 @@
 /*
-  Copyright (c) 2013 Sascha Steinbiss <steinbiss@zbh.uni-hamburg.de>
-  Copyright (c) 2013 Center for Bioinformatics, University of Hamburg
+  Copyright (c) 2013-2014 Sascha Steinbiss <ss34@sanger.ac.uk>
+  Copyright (c) 2013      Center for Bioinformatics, University of Hamburg
+  Copyright (c)      2014 Genome Research Ltd.
 
   Permission to use, copy, modify, and distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -358,7 +359,7 @@ static int gt_ltrdigest_pdom_visitor_parse_alignments(GT_UNUSED
            into account */
         line = 0;
         if (1 == sscanf(buf, "%*s %s", junkbuf)) {
-          if (0 == strcmp(junkbuf, "CS")) {
+          if (0 == strcmp(junkbuf, "CS") || 0 == strcmp(junkbuf, "RF")) {
             mod_val = 5;
             line = -1;
             run = false;


### PR DESCRIPTION
This PR fixes a bug in LTRdigest by adding support for 'RF' lines in hmmscan output. Before this fix, this would have resulted in a failed assertion as the input format was not properly recognized and parsed.
