### PR TITLE
improve error checking in gt_inlineseq tools

### DIFF
--- a/src/tools/gt_inlineseq_add.c
+++ b/src/tools/gt_inlineseq_add.c
@@ -86,16 +86,18 @@ static int gt_inlineseq_add_runner(int argc, const char **argv, int parsed_args,
       had_err = -1;
   }
 
-  last_stream = gff3_in_stream = gt_gff3_in_stream_new_unsorted(
+  if (!had_err) {
+    last_stream = gff3_in_stream = gt_gff3_in_stream_new_unsorted(
                                                             argc - parsed_args,
                                                             argv + parsed_args);
-  gt_assert(gff3_in_stream);
-  gt_gff3_in_stream_enable_tidy_mode((GtGFF3InStream*) gff3_in_stream);
+    gt_assert(gff3_in_stream);
+    gt_gff3_in_stream_enable_tidy_mode((GtGFF3InStream*) gff3_in_stream);
 
-  last_stream = add_stream = gt_sequence_node_add_stream_new(last_stream, rm,
-                                                             err);
-  if (!add_stream) {
-    had_err = -1;
+    last_stream = add_stream = gt_sequence_node_add_stream_new(last_stream, rm,
+                                                               err);
+    if (!add_stream) {
+      had_err = -1;
+    }
   }
 
   if (!had_err) {

--- a/src/tools/gt_inlineseq_split.c
+++ b/src/tools/gt_inlineseq_split.c
@@ -102,7 +102,7 @@ static int gt_inlineseq_split_runner(int argc, const char **argv, int parsed_arg
       had_err = -1;
   }
 
-  if (gt_str_length(arguments->gffoutfile) > 0) {
+  if (!had_err && gt_str_length(arguments->gffoutfile) > 0) {
     gff3_out_file = gt_file_new(gt_str_get(arguments->gffoutfile), "w+", err);
     if (!gff3_out_file)
       had_err = -1;

--- a/testsuite/gt_inlineseq_include.rb
+++ b/testsuite/gt_inlineseq_include.rb
@@ -6,6 +6,29 @@ Test do
   run "diff tmp.gff3 #{$testdata}standard_fasta_example_only_annotation.gff3"
 end
 
+Name "gt inlineseq_split (nonexistant input)"
+Keywords "gt_inlineseq_split gt_inlineseq"
+Test do
+  run_test "#{$bin}gt inlineseq_split -seqfile tmp.fas -gff3file tmp.gff3 #{$testdata}/imnotthere", :retval => 1
+end
+
+Name "gt inlineseq_split (unwritable GFF)"
+Keywords "gt_inlineseq_split gt_inlineseq"
+Test do
+  run "touch unwriteable.gff"
+  run "chmod u-w unwriteable.gff"
+  run_test "#{$bin}gt inlineseq_split -seqfile tmp.fas -gff3file unwriteable.gff #{$testdata}/standard_fasta_example.gff3", :retval => 1
+  grep(last_stderr, "unwriteable.gff")
+end
+Name "gt inlineseq_split (unwritable FASTA)"
+Keywords "gt_inlineseq_split gt_inlineseq"
+Test do
+  run "touch unwriteable.fas"
+  run "chmod u-w unwriteable.fas"
+  run_test "#{$bin}gt inlineseq_split -seqfile unwriteable.fas -gff3file test.gff #{$testdata}/standard_fasta_example.gff3", :retval => 1
+  grep(last_stderr, "unwriteable.fas")
+end
+
 Name "gt inlineseq_split (no annotation)"
 Keywords "gt_inlineseq_split gt_inlineseq"
 Test do


### PR DESCRIPTION
Adds some better error checking in the tools, avoiding failed assertions instead of proper error messages.
