### PR TITLE
remove too strict assertion

### DIFF
--- a/src/extended/feature_node.c
+++ b/src/extended/feature_node.c
@@ -481,8 +481,6 @@ GtFeatureNode* gt_feature_node_get_multi_representative(GtFeatureNode *fn)
             !gt_feature_node_is_pseudo(fn));
   if (fn->representative) {
     gt_assert(gt_feature_node_is_multi(fn->representative));
-    gt_assert(gt_feature_node_get_multi_representative(fn->representative) ==
-              fn->representative);
     return fn->representative;
   }
   return fn; /* is itself the representative */


### PR DESCRIPTION
During reassignment of representatives (done by GtMultiSanitizerVisitor) after parsing, an assertion given in a too strict form prevents the representatives to be updated properly as the condition it checks may be temporarily invalid during the update. Closes #367.
