### PR TITLE
make sure scores are defined before querying

### DIFF
--- a/src/extended/stat_visitor.c
+++ b/src/extended/stat_visitor.c
@@ -100,7 +100,7 @@ static void compute_type_statistics(GtFeatureNode *fn, GtStatVisitor *sv)
       range = gt_genome_node_get_range((GtGenomeNode*) fn);
       gt_disc_distri_add(sv->gene_length_distribution, gt_range_length(&range));
     }
-    if (sv->gene_score_distribution) {
+    if (sv->gene_score_distribution && gt_feature_node_score_is_defined(fn)) {
       gt_disc_distri_add(sv->gene_score_distribution,
                          gt_feature_node_get_score(fn) * 100.0);
     }


### PR DESCRIPTION
When calculating gene score distributions, the GtStatVisitor fails to check if scores are defined before querying them, causing an assertion to fail if scores are missing. Closes #377.
