### PR TITLE
ensure consistent sorting in LTRharvest

### DIFF
--- a/src/ltr/ltrharvest_stream.c
+++ b/src/ltr/ltrharvest_stream.c
@@ -30,6 +30,7 @@
 #include "core/md5_seqid.h"
 #include "core/minmax.h"
 #include "core/multithread_api.h"
+#include "core/qsort_r_api.h"
 #include "core/str_api.h"
 #include "core/thread_api.h"
 #include "core/types_api.h"
@@ -146,7 +147,7 @@ struct GtLTRharvestStream
 #define gt_ltrharvest_stream_cast(GS)\
         gt_node_stream_cast(gt_ltrharvest_stream_class(), GS);
 
-static int bdcompare(const void *a, const void *b)
+static int bdcompare(const void *a, const void *b, GT_UNUSED void *data)
 {
   const LTRboundaries *bda, *bdb;
 
@@ -1288,9 +1289,9 @@ static int gt_ltrharvest_stream_next(GtNodeStream *ns,
 
     /* sort results after seed extension */
     if (!had_err && threadinfo.arrayLTRboundaries->spaceLTRboundaries) {
-      qsort(threadinfo.arrayLTRboundaries->spaceLTRboundaries,
+      gt_qsort_r(threadinfo.arrayLTRboundaries->spaceLTRboundaries,
             (size_t) threadinfo.arrayLTRboundaries->nextfreeLTRboundaries,
-             sizeof (LTRboundaries),  bdcompare);
+             sizeof (LTRboundaries), NULL, bdcompare);
     }
 
     /* remove exact duplicates */


### PR DESCRIPTION
This PR switches the sorting function used to sort LTR retrotransposon candidates from the system `qsort()` to the one implemented in GenomeTools. Use of the system specific one resulted in inconsistent results on Mac OS X and Linux platforms. Thanks to @stefan-kurtz for the heads up.
Note that running the tests with this change require updating (i.e. pulling changes from) the official `gttestdata` repository.
