### PR TITLE
Add scripts to generate zsh completion function for gt.

### DIFF
--- a/scripts/gen_zsh_completion.rb
+++ b/scripts/gen_zsh_completion.rb
@@ -1,0 +1,132 @@
+#!/usr/bin/env ruby
+
+scriptdir = File.dirname(__FILE__)
+help2comp = File.join(scriptdir, 'help2comp.py')
+
+tools = %w{
+  bed_to_gff3
+  cds
+  chain2dim
+  chseqids
+  clean
+  compreads
+  condenser
+  congruence
+  convertseq
+  csa
+  dot
+  dupfeat
+  encseq
+  encseq2spm
+  eval
+  extractfeat
+  extractseq
+  fastq_sample
+  featureindex
+  fingerprint
+  genomediff
+  gff3
+  gff3_to_gtf
+  gff3validator
+  gtf_to_gff3
+  hop
+  id_to_md5
+  interfeat
+  loccheck
+  ltrclustering
+  ltrdigest
+  ltrharvest
+  matchtool
+  matstat
+  md5_to_id
+  merge
+  mergefeat
+  mgth
+  mkfeatureindex
+  mkfmindex
+  mmapandread
+  orffinder
+  packedindex
+  prebwt
+  readjoiner
+  repfind
+  scriptfilter
+  select
+  seq
+  seqfilter
+  seqids
+  seqmutate
+  seqorder
+  seqstat
+  seqtransform
+  seqtranslate
+  sequniq
+  shredder
+  shulengthdist
+  simreads
+  snpper
+  speck
+  splicesiteinfo
+  splitfasta
+  stat
+  suffixerator
+  tagerator
+  tallymer
+  tirvish
+  uniq
+  uniquesub
+  wtree
+}
+
+completion =<<OUTER
+#compdef gt
+
+typeset -A opt_args
+
+_arguments -C \\
+  '1:cmd:->cmds' \\
+  '*:: :->args' \\
+
+case "$state" in
+  (cmds)
+    local arguments
+    arguments=(
+#{
+`gt -help | #{help2comp} gt`.rstrip
+}
+    )
+
+    local commands
+    commands=(
+    #{tools.join("\n    ")}
+    )
+
+    _describe -t commands 'command' commands && ret=0
+    _arguments -s $arguments
+  ;;
+  (args)
+    case $line[1] in
+
+#{tools.map { |tool|
+  opts = `gt #{tool} -help | #{help2comp} gt_#{tool}`.split("\n")
+
+<<INNER
+      (#{tool})
+        local arguments
+        arguments=(
+    #{opts.join("\n    ")}
+          '*:filename:_files'
+        )
+        _arguments -s $arguments
+        ret=0
+      ;;
+INNER
+}.join}
+
+    esac
+esac
+
+return 1
+OUTER
+
+puts completion

--- a/scripts/help2comp.py
+++ b/scripts/help2comp.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+# Parse getopt-style help texts for options
+# and generate zsh(1) completion function.
+# http://github.com/RobSis/zsh-completion-generator
+
+# Usage: program --help | ./help2comp.py program_name
+
+# Changelog:
+# 9th September, 2014:
+#   - Copied from http://github.com/RobSis/zsh-completion-generator.
+#   - Print argument list instead of completion function.
+
+import os
+import sys
+import re
+import argparse
+from string import Template
+
+
+URL = 'http://github.com/RobSis/zsh-completion-generator'
+STRIP_CHARS = " \t\n,="
+
+COMPLETE_FUNCTION_TEMPLATE = """
+#compdef $program_name
+
+# zsh completions for '$program_name'
+# automatically generated with $url
+local arguments
+
+arguments=(
+$argument_list
+    '*:filename:_files'
+)
+
+_arguments -s $arguments
+"""
+
+ARGUMENT_TEMPLATE = """    {$opts}'[$description]$style'"""
+SINGLE_ARGUMENT_TEMPLATE = """    '$opt[$description]$style'"""
+
+
+def cut_option(line):
+    """
+    Cuts out the first option (short or long) and its argument.
+    """
+    # TODO: dare to make it regex-free?
+    newline = line.strip(STRIP_CHARS)
+    opt = re.findall(r'^(-[a-zA-Z0-9\-]+(?:[\[\ =][^\-\ ][a-zA-Z\<\>\[\|\:\]\-\_\?#]*\]?)?)', line)
+    if len(opt) > 0:
+        newline = line.replace(opt[0], "", 1).strip(STRIP_CHARS)
+        # return without parameter
+        return newline, re.split('[\ \[=]', opt[0])[0]
+    else:
+        return newline, None
+
+
+def parse_options(help_text):
+    """
+    Parses the options line by line.
+    When description is missing and options are missing on
+    consecutive line, link them together.
+    """
+    all_options = []
+    previous_description_missing = False
+    for line in help_text:
+        line = line.strip(STRIP_CHARS)
+        if re.match(r'^--?[a-zA-Z0-9]+', line) != None:  # starts with option
+            previous_description_missing = False
+            options = []
+            while True:
+                line, opt = cut_option(line)
+                if opt == None:
+                    break
+
+                options.append(opt)
+
+            if (len(line) == 0):
+                previous_description_missing = True
+
+            options.append(line)
+            all_options.append(options)
+        elif previous_description_missing:
+            all_options[-1][-1] = line
+            previous_description_missing = False
+
+    return all_options
+
+
+def _escape(line):
+    """
+    Escape the syntax-breaking characters.
+    """
+    line = line.replace('[','\[').replace(']','\]')
+    line = re.sub('\'', '', line)  # ' is unescapable afaik
+    return line
+
+
+def generate_argument_list(options):
+    """
+    Generate list of arguments from the template.
+    """
+    argument_list = []
+    for opts in options:
+        model = {}
+        # remove unescapable chars.
+
+        model['description'] = _escape(opts[-1])
+        model['style'] = ""
+        if (len(opts) > 2):
+            model['opts'] = ",".join(opts[:-1])
+            argument_list.append(Template(ARGUMENT_TEMPLATE).safe_substitute(model))
+        elif (len(opts) == 2):
+            model['opt'] = opts[0]
+            argument_list.append(Template(SINGLE_ARGUMENT_TEMPLATE).safe_substitute(model))
+        else:
+            pass
+
+    return "\n".join(argument_list)
+
+
+def generate_completion_function(options, program_name):
+    """
+    Generate completion function from the template.
+    """
+    model = {}
+    model['program_name'] = program_name
+    model['argument_list'] = generate_argument_list(options)
+    model['url'] = URL
+    return Template(COMPLETE_FUNCTION_TEMPLATE).safe_substitute(model).strip()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        options = parse_options(sys.stdin.readlines())
+        if (len(options) == 0):
+            sys.exit(2)
+
+        #print generate_completion_function(options, sys.argv[1])
+        print generate_argument_list(options)
+    else:
+        print "Please specify program name."


### PR DESCRIPTION
Regarding #322.

Parse output of `-help` for each tool (gt <tool> -help) and combine them into a
zsh completion function.

Usage:

```
$ <path to genometools repo>/script/gen_zsh_completion > _gt
$ mv _gt <some dir containing other zsh completion functions>
$ exec $SHELL
$ gt <TAB>
```

Limitations:
- assumes `gt` to be in PATH.
- list of tools is hardcoded in the script. Probably should parse the list of
  tools from `gt -help` instead.
- doesn't know to deal with `-help+` option of some tools.
- only first line of help text for an option is used (`gt -seed` for example).

Notes:
- help2comp.py was borrowed from [1](https://github.com/RobSis/zsh-completion-generator) with a minor modification. The change is
  marked in the script.
- [1](https://github.com/RobSis/zsh-completion-generator) is GPL2 licensed. Not sure if that's incompatible with gt's license.
- Template for completion function borrowed from [2](http://wikimatze.de/writing-zsh-completion-for-padrino/).

Signed-off-by: Anurag Priyam anurag08priyam@gmail.com
