### PR TITLE
Fix and enhance Blast calling and GtMatchIteratorBlast

### DIFF
--- a/src/extended/blast_process_call.c
+++ b/src/extended/blast_process_call.c
@@ -222,6 +222,16 @@ void gt_blast_process_call_set_outfmt(GtBlastProcessCall *call,
   gt_str_append_int(call->str, outfmt);
 }
 
+void gt_blast_process_call_set_outfmt_tabular(GtBlastProcessCall *call)
+{
+  gt_assert(!call->outfmt);
+  call->outfmt = true;
+  if (call->all)
+    gt_str_append_cstr(call->str, " -m 8");
+  else
+    gt_str_append_cstr(call->str, " -outfmt 6");
+}
+
 void gt_blast_process_call_set_opt(GtBlastProcessCall *call,
                                    const char *opt)
 {

--- a/src/extended/blast_process_call.h
+++ b/src/extended/blast_process_call.h
@@ -90,6 +90,14 @@ void                gt_blast_process_call_set_num_threads(
 void                gt_blast_process_call_set_xdrop_gap_final(
                                                        GtBlastProcessCall *call,
                                                        double xdrop_gap_final);
+/* Sets output format option for <call> to <outfmt>. See blast documentation for
+   explanation of option! */
+void                gt_blast_process_call_set_outfmt(GtBlastProcessCall *call,
+                                                     int outfmt);
+/* Sets output format option for <call> to tabular output. See blast
+   documentation for explanation of option! */
+void                gt_blast_process_call_set_outfmt_tabular(
+                                                      GtBlastProcessCall *call);
 /* Add string <opt> to options of <call>. */
 void                gt_blast_process_call_set_opt(GtBlastProcessCall *call,
                                                   const char *opt);

--- a/src/extended/match_iterator_blast.c
+++ b/src/extended/match_iterator_blast.c
@@ -215,6 +215,8 @@ GtMatchIterator *gt_match_iterator_blast_process_new(GtBlastProcessCall *call,
   mpb->pvt->matchfile = "stdin";
   mpb->pvt->process = true;
 
+  gt_blast_process_call_set_outfmt_tabular(call);
+
   mpb->pvt->matchfilep = gt_blast_process_call_run(call, err);
   if (mpb->pvt->matchfilep == NULL)
     return NULL;

--- a/src/extended/match_iterator_blast.h
+++ b/src/extended/match_iterator_blast.h
@@ -27,7 +27,9 @@ GtMatchIterator* gt_match_iterator_blast_file_new(const char *matchfile,
                                                   GtError *err);
 
 /* Returns new <GtMatchIterator> object, by calling blast with <call> and
-   parsing the output. */
+   parsing the output.
+   Do NOT set outfmt-option for blast, this will be set by <GtMatchIterator> to
+   ensure parsing compatibility! */
 GtMatchIterator *gt_match_iterator_blast_process_new(GtBlastProcessCall *call,
                                                      GtError *err);
 


### PR DESCRIPTION
there was an error which apparently got missed by all tests, the Blast calls did not produce the correct parse-able output (tabular).
This is fixed now and some checks were added to test for double setting of options and a minimal set of options before calling blast.
