### PR TITLE
[RFC] Preserve line-breaks and alignment in HTML docs.

### DIFF
--- a/www/genometools.org/htdocs/style.css
+++ b/www/genometools.org/htdocs/style.css
@@ -137,3 +137,19 @@ ul.pubs li {
   margin-top: 10px;
   line-height: 1.2em;
 }
+
+/* Docs */
+div.sect1 {
+  font-family: monospace;
+}
+
+div.sectionbody p {
+  white-space: pre;
+}
+
+div.sect1 ul li p {
+  white-space: normal;
+}
+div.sect1 dl dd p {
+  margin-top: -24px;
+}


### PR DESCRIPTION
I was trying to fix this - http://genometools.org/tools/gt_matchtool.html. Compare with this - http://yeban.github.io/genometools/www/genometools.org/htdocs/tools/gt_matchtool.html

I have tagged this RFC because ... I don't know if this is the right solution. I guess I could have worked on tools.conf asciidoc file but I wasn't sure it was worth the effort. I like how the html docs are formatted overall after this commit, but I am not able to decide if this commit does justice to say http://yeban.github.io/genometools/www/genometools.org/htdocs/tools/gt_gff3.html. See how lines are now split compared to http://genometools.org/tools/gt_gff3.html.
