### PR TITLE
adjust README to 64bit default compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ instead.
 available from GitHub. For instructions on how to build the source by yourself,
 have a look at the
 [INSTALL](https://github.com/genometools/genometools/blob/master/INSTALL) file.
-In many cases (e.g. on a 64-bit Linux system) something like
+In most cases (e.g. on a 64-bit Linux system) something like
 ```bash
-$ make -j4 64bit=yes
+$ make -j4
 ```
-should suffice. On 32-bit systems, omit the `64bit=yes` option. Add `cairo=no`
+should suffice. On 32-bit systems, add the `32bit=yes` option. Add `cairo=no`
 if you do not have the Cairo libraries and their
 development headers installed. This will, however, remove *AnnotationSketch*
-support from the resulting binary. When your binary is built, use the `install`
-target and `prefix` option to install the compiled binary on your system. Make
-sure you repeat all the options from the original `make` run. So
+support from the resulting binary. When your binary has been built, use the
+`install` target and `prefix` option to install the compiled binary on your
+system. Make sure you repeat all the options from the original `make` run. So
 ```bash
-$ make -j4 64bit=yes install prefix=~/gt
+$ make -j4 install prefix=~/gt
 ```
 would install the software in the `gt` subdirectory in the current user's home
 directory. If no `prefix` option is given, the software will be installed
@@ -65,6 +65,7 @@ technical guidelines).
 To report a bug, ask a question, or suggest new features, use the
 [GenomeTools issue tracker](https://github.com/genometools/genometools/issues).
 
-If you only have a small question and a gitter.im account you can check
+If you only have a small question and a [gitter.im](https://gitter.im) account,
+you can check
 [![Gitter chat](https://badges.gitter.im/genometools/genometools.png)]
 (https://gitter.im/genometools/genometools) if one of the developers is online.


### PR DESCRIPTION
The README.md file still lists `64bit=yes` etc. Changed this to reflect the recent change.
