### PR TITLE
do not silently pick characters in wildcards

### DIFF
--- a/src/core/trans_table.h
+++ b/src/core/trans_table.h
@@ -18,10 +18,13 @@
 #ifndef TRANS_TABLE_H
 #define TRANS_TABLE_H
 
+#include "core/error_api.h"
 #include "core/trans_table_api.h"
 
 #define GT_START_AMINO       'M'
 #define GT_STOP_AMINO        '*'
 #define GT_STOP_AMINO_CSTR   "*"
+
+int gt_trans_table_unit_test(GtError*);
 
 #endif

--- a/src/core/trans_table_api.h
+++ b/src/core/trans_table_api.h
@@ -18,6 +18,7 @@
 #ifndef TRANS_TABLE_API_H
 #define TRANS_TABLE_API_H
 
+#include "core/error_api.h"
 #include "core/str_array_api.h"
 
 typedef struct GtTransTable GtTransTable;

--- a/src/gtt.c
+++ b/src/gtt.c
@@ -52,6 +52,7 @@
 #include "core/symbol.h"
 #include "core/tokenizer.h"
 #include "core/translator.h"
+#include "core/trans_table.h"
 #include "extended/alignment.h"
 #include "extended/anno_db_gfflike_api.h"
 #include "extended/compressed_bitsequence.h"
@@ -366,6 +367,7 @@ GtHashmap* gtt_unit_tests(void)
   gt_hashmap_add(unit_tests, "tag value map example", gt_tag_value_map_example);
   gt_hashmap_add(unit_tests, "tokenizer class", gt_tokenizer_unit_test);
   gt_hashmap_add(unit_tests, "translator class", gt_translator_unit_test);
+  gt_hashmap_add(unit_tests, "transtable class", gt_trans_table_unit_test);
   gt_hashmap_add(unit_tests, "uint64hashtable", gt_uint64hashtable_unit_test);
   gt_hashmap_add(unit_tests, "xdrop", gt_xdrop_unit_test);
 #ifndef WITHOUT_CAIRO


### PR DESCRIPTION
This PR changes the translation code in a way such that for wildcards in codons, the previous behaviour of picking the one possible base from the wildcards for the translation is replaced by returning the undefined amino acid X in the case of wildcards in the first and second base position, and to test for equivalent codons in the third base.
This does not cover all possible cases in all possible translation tables (i.e. it might return X where a combination of wildcards in one of the first two positions would result in a non-X amino acid), but at least it will not return a specific amino acid for an unspecific codon. Addresses #468.
