### PR TITLE
convert HMMER files to local version

### DIFF
--- a/src/ltr/pdom_model_set.c
+++ b/src/ltr/pdom_model_set.c
@@ -141,7 +141,7 @@ GtPdomModelSet* gt_pdom_model_set_new(GtStrArray *hmmfiles, bool force,
           }
           (void) fclose(source);
           if (len == 0) {
-            gt_error_set(err, "empty model was produced trying to "
+            gt_error_set(err, "invalid HMMER format encountered trying to "
                               "convert HMM file %s",
                               gt_str_array_get(hmmfiles, i));
             had_err = -1;

--- a/testsuite/gt_ltrdigest_include.rb
+++ b/testsuite/gt_ltrdigest_include.rb
@@ -255,7 +255,7 @@ if $gttestdata then
     Test do
       run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
       run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -hmms #{$gttestdata}ltrdigest/corrupt.hmm -- #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 1
-      grep(last_stderr, /error occurred during HMM preprocessing/)
+      grep(last_stderr, /invalid HMMER format encountered/)
     end
 
     Name "gt ltrdigest pHMM implied options"
@@ -488,7 +488,7 @@ if $gttestdata then
     Test do
       run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
       run_test "#{$bin}gt ltrdigest -hmms #{$gttestdata}ltrdigest/corrupt.hmm -- #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
-      grep(last_stderr, /error occurred during HMM preprocessing/)
+      grep(last_stderr, /invalid HMMER format encountered/)
     end
 
     Name "gt ltrdigest HMM list not properly closed (legacy syntax)"


### PR DESCRIPTION
This PR introduces a change to the GtPdomModelSet constructor, making sure that `hmmconvert` is used on each input file to convert it to the version of the installed HMMER binaries. That is, if there are HMMER2 models among the list of parameters, they will be automatically converted to HMMER3 format.
Closes #449.
