### PR TITLE
readjoiner: fix segfault on non-existent readset

### DIFF
--- a/src/tools/gt_readjoiner_overlap.c
+++ b/src/tools/gt_readjoiner_overlap.c
@@ -255,10 +255,12 @@ static int gt_readjoiner_overlap_runner(GT_UNUSED int argc,
   gt_encseq_loader_disable_autosupport(el);
   encseq = gt_encseq_loader_load(el, gt_str_get(arguments->encseqinput),
                                  err);
-  eqlen = gt_encseq_accesstype_get(encseq) == GT_ACCESS_TYPE_EQUALLENGTH;
-
   if (encseq == NULL)
     haserr = true;
+
+  if (!haserr)
+    eqlen = gt_encseq_accesstype_get(encseq) == GT_ACCESS_TYPE_EQUALLENGTH;
+
   if (!haserr && !arguments->singlestrand)
   {
     if (gt_encseq_mirror(encseq, err) != 0)


### PR DESCRIPTION
This PR fixes a segfault with readjoiner when a non-existent readset index name is passed to the overlap tool:

```
$ bin/gt readjoiner overlap -readset nonexist -l 23
# gt readjoiner overlap (version 1.2)
zsh: segmentation fault  bin/gt readjoiner overlap -readset nonexist -l 23
```
