### PR TITLE
add the deprecated module

### DIFF
--- a/gtdata/modules/gtdoclib/docparser.lua
+++ b/gtdata/modules/gtdoclib/docparser.lua
@@ -119,12 +119,14 @@ local ExportedDefine = lpeg.Cc("function") * lpeg.C("#define") * Space *
                        lpeg.C(lpeg.P(Any - lpeg.P("("))^1) * lpeg.P("(") *
                        lpeg.C((Any - lpeg.P(")"))^1) * lpeg.P(")") *
                        OptionalSpace * DefineSeparator
-local ExportedPlainDefine = lpeg.Cc("function") * lpeg.C("#define") * Space *
+local ExportedPlainDefine = lpeg.Cc("function") *
+                            (lpeg.P("#if") * (Any - Newline)^1 * Newline)^0 *
+                            lpeg.C("#define") * Space *
                             lpeg.C(lpeg.P(Any - (DefineSeparator + Space))^1) *
                             OptionalSpace * DefineSeparator
 local ExportCMethod = lpeg.Ct(ExportedComment * Newline^0 * (Function + FunctionPtr + Variable))
 local ExportCDefine = lpeg.Ct(ExportedComment * Newline^0 *
-                              (ExportedDefine+ ExportedPlainDefine))
+                              (ExportedDefine + ExportedPlainDefine))
 local ModuleDef = lpeg.Ct(lpeg.Cc("module") * CCommentStart * Space *
                           lpeg.C(Character^1) * Space * lpeg.P("module") *
                           Space * CCommentEnd)

--- a/src/core/deprecated_api.h
+++ b/src/core/deprecated_api.h
@@ -1,0 +1,31 @@
+/*
+  Copyright (c) 2014 Gordon Gremme <gordon@gremme.org>
+
+  Permission to use, copy, modify, and distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef DEPRECATED_API_H
+#define DEPRECATED_API_H
+
+/* Deprecated module */
+
+/* Deprecated functions, typedefs and structs should be annotated with this
+   macro to get warnings when the gcc compiler is used. */
+#if defined(__GNUC__) && ((__GNUC__ * 100 + __GNUC_MINOR__) >= 301)
+#define GT_DEPRECATED \
+         __attribute__((deprecated))
+#else /* not gcc >= 3.1 */
+#define GT_DEPRECATED
+#endif
+
+#endif

--- a/src/core/types_api.h
+++ b/src/core/types_api.h
@@ -20,6 +20,7 @@
 #define TYPES_API_H
 
 #include <limits.h>
+#include "core/deprecated_api.h"
 
 /* Define the conversion string for '%lld' in platform independent fashion. */
 #ifndef _WIN32
@@ -93,10 +94,12 @@ typedef unsigned long long GtUint64;
 
 typedef unsigned char GtUchar;
 
-/* This type is deprecated, please use GtUwordPair instead */
+/* This type is deprecated, please use GtUwordPair instead. */
+GT_DEPRECATED
 typedef GtUword GtUlong;
 
-/* This type is deprecated, please use GtUwordPair instead */
+/* This type is deprecated, please use GtUwordPair instead. */
+GT_DEPRECATED
 typedef struct
 {
   GtUword a, b;

--- a/www/genometools.org/htdocs/docs.html
+++ b/www/genometools.org/htdocs/docs.html
@@ -1369,7 +1369,7 @@ Returns translated <code>dna</code>.
 <div id="footer">
 Copyright &copy; 2008-2013
 The <i>GenomeTools</i> authors.
-Last update: 2014-12-08
+Last update: 2014-12-09
 </div>
 </div>
 <!-- Piwik -->

--- a/www/genometools.org/htdocs/libgenometools.html
+++ b/www/genometools.org/htdocs/libgenometools.html
@@ -301,6 +301,8 @@ interfaces.
 
   <li><a href="#Cstr">Cstr</a>
 
+  <li><a href="#Deprecated">Deprecated</a>
+
   <li><a href="#Endianess">Endianess</a>
 
   <li><a href="#FASTA">FASTA</a>
@@ -358,6 +360,15 @@ Duplicate internal feature nodes of type <code>source_type</code> as features wi
    <code>dest_type</code>. The duplicated features does not inherit the children.
 </p>
 <hr>
+<a name="GtTrackSelectorFunc"></a>
+
+<code>void  GtTrackSelectorFunc(GtBlock*, GtStr*, void*)</code>
+<p>
+A <code>GtTrackSelectorFunc</code> is a callback function which sets a <code>GtStr</code> to a
+   string to be used as a track identifier for assignment of a <code>GtBlock</code>
+   to a given track.
+</p>
+<hr>
 <a name="GtTrackOrderingFunc"></a>
 
 <code>int  GtTrackOrderingFunc(const char *s1, const char *s2, void *data)</code>
@@ -367,15 +378,6 @@ A function describing the order of tracks based on their track identifier
    should appear before the track with ID <code>s2</code> and a positive value if <code>s1</code>
    should appear after <code>s2</code>. Returning a value of 0 will result in an undefined
    ordering of <code>s1</code> and <code>s2</code>.
-</p>
-<hr>
-<a name="GtTrackSelectorFunc"></a>
-
-<code>void  GtTrackSelectorFunc(GtBlock*, GtStr*, void*)</code>
-<p>
-A <code>GtTrackSelectorFunc</code> is a callback function which sets a <code>GtStr</code> to a
-   string to be used as a track identifier for assignment of a <code>GtBlock</code>
-   to a given track.
 </p>
 <hr>
 <a name="GtAddIntronsStream"></a>
@@ -9189,6 +9191,16 @@ Returns the length of the prefix of <code>cstr</code> ending just before <code>c
 Removes all occurrences of <code>remove</code> from the right end of <code>cstr</code>.
 </p>
 <hr>
+<a name="Deprecated"></a>
+<h2>Module Deprecated</h2>
+<a name="GT_DEPRECATED"></a>
+
+<code>#define GT_DEPRECATED</code>
+<p>
+Deprecated functions, typedefs and structs should be annotated with this
+   macro to get warnings when the gcc compiler is used.
+</p>
+<hr>
 <a name="Endianess"></a>
 <h2>Module Endianess</h2>
 <a name="gt_is_little_endian"></a>
@@ -10019,6 +10031,8 @@ Similar to <code>vsnprintf(3)</code>, terminates on error.
 <hr>
 <a name="Index"></a>
 <h2>Index</h2>
+
+  <a href="#GT_DEPRECATED"><code>GT_DEPRECATED</code></a><br>
 
   <a href="#GT_OPTION_PARSER_TERMINAL_WIDTH"><code>GT_OPTION_PARSER_TERMINAL_WIDTH</code></a><br>
 
@@ -11977,7 +11991,7 @@ Similar to <code>vsnprintf(3)</code>, terminates on error.
 <div id="footer">
 Copyright &copy; 2008-2013
 The <i>GenomeTools</i> authors.
-Last update: 2014-12-08
+Last update: 2014-12-09
 </div>
 </div>
 <!-- Piwik -->

--- a/www/genometools.org/htdocs/tools/gt.html
+++ b/www/genometools.org/htdocs/tools/gt.html
@@ -75,7 +75,7 @@ perform unit tests and exit (default: no)
 <dd>
 <p>
 set seed for random number generator manually
-0 generates a seed from current time and process id (default: 181001884)
+0 generates a seed from current time and process id (default: 122436580)
 </p>
 </dd>
 <dt class="hdlist1">


### PR DESCRIPTION
introduces the GT_DEPRECATED macro which should be used to annotate deprecated
functions, typedefs and structs. It produces warnings when the gcc compiler is
used.
