### PR TITLE
wip on deprecated

### DIFF
--- a/src/core/toolbox.h
+++ b/src/core/toolbox.h
@@ -18,6 +18,7 @@
 #ifndef TOOLBOX_H
 #define TOOLBOX_H
 
+#include "core/deprecated_api.h"
 #include "core/error.h"
 #include "core/tool_api.h"
 #include "core/toolbox_api.h"
@@ -33,6 +34,7 @@ typedef int (*GtToolfunc)(int argc, const char **argv, GtError*);
 /* deprecated */
 bool       gt_toolbox_has_tool(const GtToolbox*, const char *toolname);
 /* deprecated */
+GT_DEPRECATED("use gt_toolbox_add_tool() instead")
 void       gt_toolbox_add(GtToolbox*, const char *toolname, GtToolfunc);
 /* deprecated */
 GtToolfunc gt_toolbox_get(const GtToolbox*, const char *toolname);


### PR DESCRIPTION
I was thinking about adding GT_DEPRECATED everywhere I encounter something that should be deprecated as already seen in the documentation.
But I realized much of this is still in use everywhere even in our code - what do you guys think about these cases?
And also interesting: what is the alternative for the functions in this header?
