### PR TITLE
add suppressions for GObject/Glib/pixman 'leaks'

### DIFF
--- a/testdata/gt.supp
+++ b/testdata/gt.supp
@@ -229,3 +229,11 @@
    fun:g_type_register_static
    ...
 }
+{
+   pixman_leak
+   Memcheck:Leak
+   fun:*alloc
+   ...
+   obj:*libpixman*
+   ...
+}

--- a/testdata/gt.supp
+++ b/testdata/gt.supp
@@ -201,9 +201,31 @@
    ...
 }
 {
+   gobject_leak
+   Memcheck:Leak
+   fun:*alloc
+   ...
+   obj:*libgobject*
+   ...
+}
+{
    glib_leak
    Memcheck:Leak
    ...
    fun:gobject_init_ctor
+   ...
+}
+{
+   glib_leak
+   Memcheck:Leak
+   ...
+   fun:g_type_register_fundamental
+   ...
+}
+{
+   glib_leak
+   Memcheck:Leak
+   ...
+   fun:g_type_register_static
    ...
 }


### PR DESCRIPTION
I cannot find a way to control these allocations in GObject and Glib, which are done even without doing any drawing. So for now I'm adding suppressions for these fairly small leaks to not clutter Valgrind output.
Closes #521.