### PR TITLE
make assert message more verbose

### DIFF
--- a/src/core/assert_api.h
+++ b/src/core/assert_api.h
@@ -36,8 +36,12 @@
         do {                                                                 \
           if (!(expression)) {                                               \
             fprintf(stderr, "Assertion failed: (%s), function %s, file %s, " \
-                    "line %d.\nThis is a bug, please report it at "          \
-                    "https://github.com/genometools/genometools/issues.\n",  \
+                    "line %d.\nThis is a bug, please report it at\n"         \
+                    "https://github.com/genometools/genometools/issues\n"    \
+                    "Please make sure you are running the latest release "   \
+                    "which can be found at\nhttp://genometools.org/pub/\n"   \
+                    "You can check your version number with "                \
+                    "`gt -version`.\n",                                      \
                     #expression, __func__, __FILE__, __LINE__);              \
             /*@ignore@*/                                                     \
             exit(GT_EXIT_PROGRAMMING_ERROR);                                 \


### PR DESCRIPTION
Remind the user to run the latest release. Hopefully this will reduce the number
of false bug reports.

New message:

This is a bug, please report it at
https://github.com/genometools/genometools/issues
Please make sure you are running the latest release which can be found at
http://genometools.org/pub/
You can check your version number with `gt -version`.