### PR TITLE
bug fix: create transient edges for parent

### DIFF
--- a/src/extended/type_graph.c
+++ b/src/extended/type_graph.c
@@ -160,7 +160,7 @@ bool gt_type_graph_is_partof(GtTypeGraph *type_graph, const char *parent_type,
                              const char *child_type)
 {
   const char *parent_id, *child_id;
-  GtTypeNode *child_node;
+  GtTypeNode *parent_node, *child_node;
   gt_assert(type_graph && parent_type && child_type);
   /* make sure graph is built */
   if (!type_graph->ready) {
@@ -173,11 +173,14 @@ bool gt_type_graph_is_partof(GtTypeGraph *type_graph, const char *parent_type,
   /* get child ID, if the type is not mappable to an ID, assmue it is the ID */
   if (!(child_id = gt_hashmap_get(type_graph->name2id, child_type)))
     child_id = child_type;
+  /* get parent node */
+  parent_node = gt_hashmap_get(type_graph->nodemap, parent_id);
+  gt_assert(parent_node);
   /* get child node */
   child_node = gt_hashmap_get(type_graph->nodemap, child_id);
   gt_assert(child_node);
   /* check for parent */
-  return gt_type_node_has_parent(child_node, parent_id,
+  return gt_type_node_has_parent(child_node, parent_node,
                                  type_graph->part_of_out_edges,
                                  type_graph->part_of_in_edges,
                                  type_graph->nodes, type_graph->id2name, 0);

--- a/src/extended/type_node.h
+++ b/src/extended/type_node.h
@@ -37,7 +37,7 @@ void          gt_type_node_add_is_a_vertex(GtTypeNode *src,
    The <id2name> mapping is optional and is only used for debugging output.
    The <indentlevel> is also used for debugging output and is increased in every
    recursive call. */
-bool          gt_type_node_has_parent(GtTypeNode *node, const char *id,
+bool          gt_type_node_has_parent(GtTypeNode *node, GtTypeNode *pnode,
                                       GtBoolMatrix *part_of_out_edges,
                                       GtBoolMatrix *part_of_in_edges,
                                       GtArray *node_list, GtHashmap *id2name,

--- a/testdata/transient_edges_bug.gff3
+++ b/testdata/transient_edges_bug.gff3
@@ -1,0 +1,4 @@
+##gff-version 3
+##sequence-region Si_gnF.scaffold02694 1 6355204
+Si_gnF.scaffold02694	afra	mRNA	401035	403323	.	+	.	ID=mRNA1;Name=Si_estOR100817isotig13026
+Si_gnF.scaffold02694	afra	exon	401035	401411	.	+	.	ID=exon1;               Name=Si_estOR100817isotig13026:exon1;               Parent=mRNA1

--- a/testsuite/gt_gff3validator_include.rb
+++ b/testsuite/gt_gff3validator_include.rb
@@ -22,6 +22,14 @@ Test do
   grep last_stdout, "input is valid GFF3"
 end
 
+Name "gt gff3validator -typecheck so.obo (bug)"
+Keywords "gt_gff3validator typecheck"
+Test do
+  run_test "#{$bin}gt gff3validator -typecheck so " +
+           "#{$testdata}transient_edges_bug.gff3"
+  grep last_stdout, "input is valid GFF3"
+end
+
 Name "gt gff3validator -typecheck so-xp.obo"
 Keywords "gt_gff3validator typecheck"
 Test do


### PR DESCRIPTION
The transient part_of edges have to be created for the parent in a "has parent"
check (and not for the child). In earlier versions they have been created for
the child and this worked for the standard gene example, because in that case
the mRNA parent was a gene child before. In added test file that is not the case
and therefore it failed erroneously.

This commit also documents how the transient edges are created in more detail.

Resolves #514