### PR TITLE
gff3 parser: allow unknown pragmas without data

### DIFF
--- a/src/extended/genome_node_api.h
+++ b/src/extended/genome_node_api.h
@@ -32,7 +32,7 @@ typedef struct GtGenomeNode GtGenomeNode;
 #include "extended/node_visitor_api.h"
 
 /* Increase the reference count for <genome_node> and return it.
-   <genome_node> cannot be <NULL>.*/
+   <genome_node> must not be <NULL>.*/
 GtGenomeNode* gt_genome_node_ref(GtGenomeNode *genome_node);
 
 /* Return the sequence ID of <genome_node>.

--- a/src/extended/gff3_parser.c
+++ b/src/extended/gff3_parser.c
@@ -2053,17 +2053,12 @@ static int parse_meta_gff3_line(GtGFF3Parser *parser, GtQueue *genome_nodes,
       invalid = invalid_gff3_pragma(line);
     if (invalid) {
       gt_warning("unknown meta-directive encountered in line %u in file "
-                 "\"%s\", keep as comment: %s", line_number, filename, line);
+                 "\"%s\", keep anyway: %s", line_number, filename, line);
     }
     data = strchr(line+2, ' ');
     if (data) {
       data[0] = '\0';
       data++;
-    }
-    else {
-      gt_error_set(err, "meta-directive encountered in line %u in file "
-                 "\"%s\" does not have data: %s", line_number, filename, line);
-      had_err = -1;
     }
     if (!had_err) {
       /* storing meta node */

--- a/src/extended/gff3_visitor.c
+++ b/src/extended/gff3_visitor.c
@@ -1,6 +1,6 @@
 /*
-  Copyright (c) 2006-2013 Gordon Gremme <gordon@gremme.org>
-  Copyright (c) 2006-2008 Center for Bioinformatics, University of Hamburg
+  Copyright (c) 2006-2013, 2015 Gordon Gremme <gordon@gremme.org>
+  Copyright (c) 2006-2008       Center for Bioinformatics, University of Hamburg
 
   Permission to use, copy, modify, and distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -394,6 +394,7 @@ static int gff3_visitor_meta_node(GtNodeVisitor *nv, GtMetaNode *mn,
                                   GT_UNUSED GtError *err)
 {
   GtGFF3Visitor *gff3_visitor;
+  const char *data;
   gt_error_check(err);
   gff3_visitor = gff3_visitor_cast(nv);
   gt_assert(nv && mn);
@@ -407,16 +408,22 @@ static int gff3_visitor_meta_node(GtNodeVisitor *nv, GtMetaNode *mn,
       gff3_version_string(nv);
     }
   }
+  data = gt_meta_node_get_data(mn);
   if (!gff3_visitor->outstr) {
-    gt_file_xprintf(gff3_visitor->outfp, "##%s %s\n",
-                    gt_meta_node_get_directive(mn),
-                    gt_meta_node_get_data(mn));
-
+    if (data) {
+      gt_file_xprintf(gff3_visitor->outfp, "##%s %s\n",
+                      gt_meta_node_get_directive(mn), data);
+    } else {
+      gt_file_xprintf(gff3_visitor->outfp, "##%s\n",
+                      gt_meta_node_get_directive(mn));
+    }
   } else {
     gt_str_append_cstr(gff3_visitor->outstr, "##");
     gt_str_append_cstr(gff3_visitor->outstr, gt_meta_node_get_directive(mn));
-    gt_str_append_char(gff3_visitor->outstr, ' ');
-    gt_str_append_cstr(gff3_visitor->outstr, gt_meta_node_get_data(mn));
+    if (data) {
+      gt_str_append_char(gff3_visitor->outstr, ' ');
+      gt_str_append_cstr(gff3_visitor->outstr, data);
+    }
     gt_str_append_char(gff3_visitor->outstr, '\n');
   }
   return 0;

--- a/src/extended/meta_node.c
+++ b/src/extended/meta_node.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012 Gordon Gremme <gordon@gremme.org>
+  Copyright (c) 2012, 2015 Gordon Gremme <gordon@gremme.org>
 
   Permission to use, copy, modify, and distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -34,7 +34,6 @@ struct GtMetaNode
 static void meta_node_free(GtGenomeNode *gn)
 {
   GtMetaNode *m = gt_meta_node_cast(gn);
-  gt_assert(m && m->meta_directive && m->meta_data);
   gt_free(m->meta_directive);
   gt_free(m->meta_data);
   gt_str_delete(m->meta_str);
@@ -87,9 +86,10 @@ GtGenomeNode* gt_meta_node_new(const char *meta_directive,
 {
   GtGenomeNode *gn = gt_genome_node_create(gt_meta_node_class());
   GtMetaNode *m = gt_meta_node_cast(gn);
-  gt_assert(meta_directive && meta_data);
+  gt_assert(meta_directive);
   m->meta_directive = gt_cstr_dup(meta_directive);
-  m->meta_data = gt_cstr_dup(meta_data);
+  if (meta_data)
+    m->meta_data = gt_cstr_dup(meta_data);
   m->meta_str = gt_str_new_cstr("");
   return gn;
 }
@@ -102,7 +102,7 @@ const char* gt_meta_node_get_directive(const GtMetaNode *m)
 
 const char* gt_meta_node_get_data(const GtMetaNode *m)
 {
-  gt_assert(m && m->meta_data);
+  gt_assert(m);
   return m->meta_data;
 }
 

--- a/src/extended/meta_node_api.h
+++ b/src/extended/meta_node_api.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012 Gordon Gremme <gordon@gremme.org>
+  Copyright (c) 2012, 2015 Gordon Gremme <gordon@gremme.org>
 
   Permission to use, copy, modify, and distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -31,7 +31,8 @@ const GtGenomeNodeClass* gt_meta_node_class(void);
 /* Return a new <GtMetaNode> object representing a <meta_directive> with the
    corresponding <meta_data>. Please note that the leading ``<##>'' which
    denotes meta lines in GFF3 files should not be part of the
-   <meta_directive>. */
+   <meta_directive>.
+   The <meta_directive> must not be <NULL>, the <meta_data> can be <NULL>. */
 GtGenomeNode*            gt_meta_node_new(const char *meta_directive,
                                           const char *meta_data);
 
@@ -39,7 +40,7 @@ GtGenomeNode*            gt_meta_node_new(const char *meta_directive,
 const char*              gt_meta_node_get_directive(const GtMetaNode
                                                     *meta_node);
 
-/* Return the meta data stored in <meta_node>. */
+/* Return the meta data stored in <meta_node>. Can return NULL! */
 const char*              gt_meta_node_get_data(const GtMetaNode *meta_node);
 
 /* Test whether the given genome node is a meta node. If so, a pointer to the

--- a/testdata/unknown_meta_directive_without_argument.gff3
+++ b/testdata/unknown_meta_directive_without_argument.gff3
@@ -1,0 +1,2 @@
+##gff-version   3
+##unknown-directive

--- a/testsuite/gt_gff3_include.rb
+++ b/testsuite/gt_gff3_include.rb
@@ -201,9 +201,8 @@ end
 Name "gt gff3 test 17"
 Keywords "gt_gff3"
 Test do
-  run_test "#{$bin}gt gff3 #{$testdata}gt_gff3_test_17.gff3", :retval => 1
+  run_test "#{$bin}gt gff3 #{$testdata}gt_gff3_test_17.gff3"
   grep(last_stderr, /unknown meta-directive encountered/);
-  grep(last_stderr, /does not have data: ##foo/);
 end
 
 Name "gt gff3 test 18"
@@ -1279,6 +1278,16 @@ Test do
   run_test "#{$bin}gt gff3 #{$testdata}unknown_meta_directive.gff3"
   grep last_stderr, "unknown meta-directive encountered in line"
   run "diff #{last_stdout} #{$testdata}unknown_meta_directive.gff3"
+end
+
+Name "gt gff3 unknown meta directive (without argument)"
+Keywords "gt_gff3"
+Test do
+  run_test "#{$bin}gt gff3 " +
+           "#{$testdata}unknown_meta_directive_without_argument.gff3"
+  grep last_stderr, "unknown meta-directive encountered in line"
+  run "diff #{last_stdout} " +
+      "#{$testdata}unknown_meta_directive_without_argument.gff3"
 end
 
 Name "gt gff3 simple cycle"

--- a/www/genometools.org/htdocs/docs.html
+++ b/www/genometools.org/htdocs/docs.html
@@ -1369,7 +1369,7 @@ Returns translated <code>dna</code>.
 <div id="footer">
 Copyright &copy; 2008-2013
 The <i>GenomeTools</i> authors.
-Last update: 2014-12-11
+Last update: 2015-01-21
 </div>
 </div>
 <!-- Piwik -->

--- a/www/genometools.org/htdocs/libgenometools.html
+++ b/www/genometools.org/htdocs/libgenometools.html
@@ -4346,7 +4346,7 @@ Create a <code>GtNodeStream*</code> which uses <code>in_stream</code> as input.
 <code>GtGenomeNode*  gt_genome_node_ref(GtGenomeNode *genome_node)</code>
 <p>
 Increase the reference count for <code>genome_node</code> and return it.
-   <code>genome_node</code> cannot be <code>NULL</code>.
+   <code>genome_node</code> must not be <code>NULL</code>.
 </p>
 <hr>
 <a name="gt_genome_node_get_seqid"></a>
@@ -5760,6 +5760,7 @@ Return a new <code>GtMetaNode</code> object representing a <code>meta_directive<
    corresponding <code>meta_data</code>. Please note that the leading ``<code>##</code>'' which
    denotes meta lines in GFF3 files should not be part of the
    <code>meta_directive</code>.
+   The <code>meta_directive</code> must not be <code>NULL</code>, the <code>meta_data</code> can be <code>NULL</code>.
 </p>
 <hr>
 <a name="gt_meta_node_get_directive"></a>
@@ -5774,7 +5775,7 @@ Return the meta directive stored in <code>meta_node</code>.
 
 <code>const char*               gt_meta_node_get_data(const GtMetaNode *meta_node)</code>
 <p>
-Return the meta data stored in <code>meta_node</code>.
+Return the meta data stored in <code>meta_node</code>. Can return NULL!
 </p>
 <hr>
 <a name="gt_meta_node_try_cast"></a>
@@ -9222,6 +9223,19 @@ Print a fasta entry with optional <code>description</code> and mandatory <code>s
    <code>outfp</code>. If <code>width</code> is != 0 the sequence is formatted accordingly.
 </p>
 <hr>
+<a name="gt_fasta_show_entry_nt"></a>
+
+<code>void  gt_fasta_show_entry_nt(const char *description, GtUword description_length,
+                            const char *sequence, GtUword sequence_length,
+                            GtUword width, GtFile *outfp)</code>
+<p>
+Print a fasta entry with optional <code>description</code> and mandatory <code>sequence</code> to
+   <code>outfp</code>. If <code>width</code> is != 0 the sequence is formatted accordingly.
+   Will print at most <code>sequence_length</code> characters from <code>sequence</code> if no
+   '\0'-byte is encountered. <code>description</code> and <code>description_length</code> are handled
+   accordingly if present.
+</p>
+<hr>
 <a name="gt_fasta_show_entry_str"></a>
 
 <code>void  gt_fasta_show_entry_str(const char *description, const char *sequence,
@@ -9230,6 +9244,22 @@ Print a fasta entry with optional <code>description</code> and mandatory <code>s
 <p>
 Append a fasta entry with optional <code>description</code> and mandatory <code>sequence</code> to
    <code>outstr</code>. If <code>width</code> is != 0 the sequence is formatted accordingly.
+</p>
+<hr>
+<a name="gt_fasta_show_entry_nt_str"></a>
+
+<code>void  gt_fasta_show_entry_nt_str(const char *description,
+                                GtUword description_length,
+                                const char *sequence,
+                                GtUword sequence_length,
+                                GtUword width,
+                                GtStr *outstr)</code>
+<p>
+Print a fasta entry with optional <code>description</code> and mandatory <code>sequence</code> to
+   <code>outstr</code>. If <code>width</code> is != 0 the sequence is formatted accordingly.
+   Will print at most <code>sequence_length</code> characters from <code>sequence</code> if no
+   '\0'-byte is encountered. <code>description</code> and <code>description_length</code> are handled
+   accordingly if present.
 </p>
 <hr>
 <a name="Fileutils"></a>
@@ -10757,6 +10787,10 @@ Similar to <code>vsnprintf(3)</code>, terminates on error.
 
   <a href="#gt_fasta_show_entry"><code>gt_fasta_show_entry</code></a><br>
 
+  <a href="#gt_fasta_show_entry_nt"><code>gt_fasta_show_entry_nt</code></a><br>
+
+  <a href="#gt_fasta_show_entry_nt_str"><code>gt_fasta_show_entry_nt_str</code></a><br>
+
   <a href="#gt_fasta_show_entry_str"><code>gt_fasta_show_entry_str</code></a><br>
 
   <a href="#gt_feature_in_stream_new"><code>gt_feature_in_stream_new</code></a><br>
@@ -11992,7 +12026,7 @@ Similar to <code>vsnprintf(3)</code>, terminates on error.
 <div id="footer">
 Copyright &copy; 2008-2013
 The <i>GenomeTools</i> authors.
-Last update: 2014-12-11
+Last update: 2015-01-21
 </div>
 </div>
 <!-- Piwik -->

--- a/www/genometools.org/htdocs/tools.html
+++ b/www/genometools.org/htdocs/tools.html
@@ -120,7 +120,7 @@
 <li>
 <p>
 <a href="tools/gt_convertseq.html">gt convertseq</a>
-  Parse and convert sequence file formats.
+  Parse and convert sequence file formats (FASTA/FASTQ, GenBank, EMBL).
 </p>
 </li>
 <li>
@@ -174,7 +174,7 @@
 <li>
 <p>
 <a href="tools/gt_encseq_encode.html">gt encseq encode</a>
-  Encode sequence files efficiently.
+  Encode sequence files (FASTA/FASTQ, GenBank, EMBL) efficiently.
 </p>
 </li>
 <li>

--- a/www/genometools.org/htdocs/tools/gt_convertseq.html
+++ b/www/genometools.org/htdocs/tools/gt_convertseq.html
@@ -32,7 +32,7 @@
 <div class="sect1">
 <h2 id="_name">NAME</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>gt-convertseq - Parse and convert sequence file formats.</p></div>
+<div class="paragraph"><p>gt-convertseq - Parse and convert sequence file formats (FASTA/FASTQ, GenBank, EMBL).</p></div>
 </div>
 </div>
 <div class="sect1">

--- a/www/genometools.org/htdocs/tools/gt_encseq_encode.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_encode.html
@@ -32,7 +32,7 @@
 <div class="sect1">
 <h2 id="_name">NAME</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>gt-encseq-encode - Encode sequence files efficiently.</p></div>
+<div class="paragraph"><p>gt-encseq-encode - Encode sequence files (FASTA/FASTQ, GenBank, EMBL) efficiently.</p></div>
 </div>
 </div>
 <div class="sect1">


### PR DESCRIPTION
Until now an unknown-meta directive had to have data. Make the parser more
forgiving.