### PR TITLE
support empty meta data in bindings

### DIFF
--- a/gtpython/tests/test_metanode.py
+++ b/gtpython/tests/test_metanode.py
@@ -10,14 +10,17 @@ class MetaNodeTestCase(unittest.TestCase):
     def setUp(self):
         self.fn = MetaNode.create_new("test", "data")
         self.fn2 = MetaNode.create_new(333, 444)
+        self.fn3 = MetaNode.create_new("test2", None)
 
     def test_get_directive(self):
         self.assertEqual(self.fn.get_directive(), 'test')
         self.assertEqual(self.fn2.get_directive(), '333')
+        self.assertEqual(self.fn3.get_directive(), 'test2')
 
     def test_get_data(self):
         self.assertEqual(self.fn.get_data(), 'data')
         self.assertEqual(self.fn2.get_data(), '444')
+        self.assertEqual(self.fn3.get_data(), 'None')
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/extended/meta_node.c
+++ b/src/extended/meta_node.c
@@ -90,6 +90,8 @@ GtGenomeNode* gt_meta_node_new(const char *meta_directive,
   m->meta_directive = gt_cstr_dup(meta_directive);
   if (meta_data)
     m->meta_data = gt_cstr_dup(meta_data);
+  else
+    m->meta_data = NULL;
   m->meta_str = gt_str_new_cstr("");
   return gn;
 }

--- a/src/gtlua/genome_node_lua.c
+++ b/src/gtlua/genome_node_lua.c
@@ -100,13 +100,15 @@ static int region_node_lua_new(lua_State *L)
 static int meta_node_lua_new(lua_State *L)
 {
   GtGenomeNode **mn;
-  const char *directive, *data;
+  const char *directive = NULL, *data = NULL;
   gt_assert(L);
   /* get_check parameters */
   directive = luaL_checkstring(L, 1);
-  data = luaL_checkstring(L, 2);
+  if (!lua_isnil(L, 2))
+    data = luaL_checkstring(L, 2);
   /* construct object */
   mn = lua_newuserdata(L, sizeof (GtGenomeNode*));
+  gt_assert(directive);
   *mn = gt_meta_node_new(directive, data);
   gt_assert(*mn);
   luaL_getmetatable(L, GENOME_NODE_METATABLE);
@@ -541,11 +543,14 @@ static int meta_node_lua_get_directive(lua_State *L)
 {
   GtGenomeNode **gn;
   GtMetaNode *mn;
+  const char *meta_directive = NULL;
   gn = check_genome_node(L, 1);
   /* make sure we get a meta node */
   mn = gt_meta_node_try_cast(*gn);
   luaL_argcheck(L, mn, 1, "not a meta node");
-  lua_pushstring(L, gt_meta_node_get_directive(mn));
+  meta_directive = gt_meta_node_get_directive(mn);
+  gt_assert(meta_directive);
+  lua_pushstring(L, meta_directive);
   return 1;
 }
 
@@ -553,11 +558,17 @@ static int meta_node_lua_get_data(lua_State *L)
 {
   GtGenomeNode **gn;
   GtMetaNode *mn;
+  const char *meta_data = NULL;
   gn = check_genome_node(L, 1);
   /* make sure we get a meta node */
   mn = gt_meta_node_try_cast(*gn);
   luaL_argcheck(L, mn, 1, "not a meta node");
-  lua_pushstring(L, gt_meta_node_get_data(mn));
+  meta_data = gt_meta_node_get_data(mn);
+  if (meta_data) {
+    lua_pushstring(L, meta_data);
+  } else {
+    lua_pushnil(L);
+  }
   return 1;
 }
 

--- a/testdata/gtscripts/genome_node.lua
+++ b/testdata/gtscripts/genome_node.lua
@@ -348,6 +348,9 @@ assert(not rval)
 gn = gt.meta_node_new("foo","bar")
 assert(gn:get_directive() == "foo")
 assert(gn:get_data() == "bar")
+gn = gt.meta_node_new("foo", nil)
+assert(gn:get_directive() == "foo")
+assert(not gn:get_data())
 
 -- testing gt.comment_node_new
 rval, err = pcall(gt.comment_node_new, nil)


### PR DESCRIPTION
#531 allowed meta data from GFF3 pragmas to be empty, with the API functions returning NULL in this case. This PR adapts the GenomeTools bindings to support this by returning `nil` (Lua) or 'None' (Python)  instead of expecting a proper string to be returned at all times.