### PR TITLE
Fix bug in HMM class

### DIFF
--- a/src/extended/hmm.c
+++ b/src/extended/hmm.c
@@ -346,7 +346,7 @@ void gt_hmm_decode(const GtHMM *hmm,
         tmp_prob = max_probabilities[previous_row][precolidx] +
                    hmm->transition_prob[previous_row][row] +
                    hmm->emission_prob[row][emission];
-        if (tmp_prob - max_probabilities[row][colidx] < -DBL_EPSILON) {
+        if (tmp_prob - max_probabilities[row][colidx] > DBL_EPSILON) {
           max_probabilities[row][colidx] = tmp_prob;
           backtrace[row][column] = previous_row;
         }

--- a/src/ltr/ltrdigest_ppt_visitor.c
+++ b/src/ltr/ltrdigest_ppt_visitor.c
@@ -80,7 +80,6 @@ struct GtPPTHit {
 
 struct GtPPTResults {
   GtArray *hits;
-  GtFeatureNode *elem;
   GtRange leftltrrng,
           rightltrrng;
 };


### PR DESCRIPTION
13f80cf556aaa96578a0ab9ba0220a11712b5253 introduced a bug leading to wrong Viterbi decoded states, which in turn results in missing predicted polypurine tracts in LTRdigest. This PR fixes this issue. 
Thanks to Yanzhu Ji for reporting the issue on the gt-users mailing list.