### PR TITLE
Absolute path resolve for exec in bindir (for gtdata directory).

### DIFF
--- a/src/core/fileutils.c
+++ b/src/core/fileutils.c
@@ -222,8 +222,9 @@ static int file_find_in_env_generic(GtStr *path, const char *file_path,
     }
     if (i < gt_splitter_size(splitter)) {
       /* file found in path */
-      gt_str_reset(path);
-      gt_str_append_cstr(path, pathcomponent);
+      char *abspath = realpath(gt_str_get(path), NULL);
+      gt_file_dirname(path, abspath);
+      free(abspath);
     }
     else {
       /* file not found in path */


### PR DESCRIPTION
I'm trying to install genometools using linuxbrew, and it was complaining about not finding the `/gtdata` directory. This was because the `gt` binary was being symlinked into a directory on `PATH`, and thus the `/gtdata` directory wouldn't exist going up a single parent directory. 

In this change, the absolute path of `gt` is detected before looking around it. This has the drawback if the `bin` dir is symlinked and a `/gtdata` dir is placed up next to it, which I think is a less likely use case.

Also doesn't handle windows but just want to discuss this.