### PR TITLE
allow compiling on OSX Yosemite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ endif
 GT_CFLAGS_NO_WERROR:=$(GT_CFLAGS) -w
 
 ifneq ($(errorcheck),no)
-  GT_CFLAGS += -Werror
+  GT_CFLAGS += -Werror -Wno-parentheses-equality
 endif
 
 # set prefix for install target


### PR DESCRIPTION
Apparently OS X 10.10 includes a new compiler version which introduces a check for extra parentheses around equality checks. These are used in numerous places in the gt code, including macros, causing the build to fail with `-Werror`. Disabling this in the Makefile since I consider these a bit too restrictive.