### PR TITLE
use correct GtBlastProcessCall constructor

### DIFF
--- a/src/extended/match_iterator_blast.c
+++ b/src/extended/match_iterator_blast.c
@@ -312,7 +312,7 @@ GtMatchIterator* gt_match_iterator_blastn_process_new(const char *query,
                                                       const char *moreblast,
                                                       GtError *err)
 {
-  GtBlastProcessCall *call = gt_blast_process_call_new_all_prot();
+  GtBlastProcessCall *call = gt_blast_process_call_new_all_nucl();
   char buffer[BUFSIZ];
 
   gt_blast_process_call_set_query(call, query);


### PR DESCRIPTION
I have received a bug report from a LTRsift user running into a failing assertion:
```
Assertion failed: (call->nucl), function gt_blast_process_call_set_penalty, file src/extended/blast_process_call.c, line 191.
This is a bug, please report it at https://github.com/genometools/genometools/issues.
```
while trying to align a reference sequence set to some LTR retrotransposon candidates in LTRsift. It seems to me that there might be a problematic constructor in the reworked API, creating a protein BLAST call where a nucleotide one is expected.
This PR addresses this issue.