### PR TITLE
adjust use of parentheses around comparisons in macros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ endif
 GT_CFLAGS_NO_WERROR:=$(GT_CFLAGS) -w
 
 ifneq ($(errorcheck),no)
-  GT_CFLAGS += -Werror -Wno-parentheses-equality
+  GT_CFLAGS += -Werror
 endif
 
 # set prefix for install target

--- a/src/external/lpeg-0.10.2/lpeg.c
+++ b/src/external/lpeg-0.10.2/lpeg.c
@@ -962,7 +962,7 @@ static int ktablelen (lua_State *L, int idx) {
 ** 'p' keeps its original ktable.  If 'p' has no elements, it shares
 ** 'p1' ktable.  Otherwise, this function creates a new ktable for 'p'.
 ** Return the offset of original 'p' elements in the new ktable.
-*/ 
+*/
 static int jointable (lua_State *L, int p1) {
   int n, n1, i;
   lua_getfenv(L, p1);
@@ -1326,9 +1326,9 @@ static int pattern_l (lua_State *L) {
 }
 
 
-#define isany(p)	((p)->i.code == IAny && ((p) + 1)->i.code == IEnd)
-#define isfail(p)	((p)->i.code == IFail)
-#define issucc(p)	((p)->i.code == IEnd)
+#define isany(p)	(p)->i.code == IAny && ((p) + 1)->i.code == IEnd
+#define isfail(p)	(p)->i.code == IFail
+#define issucc(p)	(p)->i.code == IEnd
 
 static int concat_l (lua_State *L) {
   /* p1; p2; */
@@ -1841,13 +1841,13 @@ typedef struct CapState {
 } CapState;
 
 
-#define captype(cap)	((cap)->kind)
+#define captype(cap)	(cap)->kind
 
-#define isclosecap(cap)	(captype(cap) == Cclose)
+#define isclosecap(cap)	captype(cap) == Cclose
 
 #define closeaddr(c)	((c)->s + (c)->siz - 1)
 
-#define isfullcap(cap)	((cap)->siz != 0)
+#define isfullcap(cap)	(cap)->siz != 0
 
 #define getfromenv(cs,v)	lua_rawgeti((cs)->L, penvidx((cs)->ptop), v)
 #define pushluaval(cs)		getfromenv(cs, (cs)->cap->idx)

--- a/src/external/lua-5.1.5/src/lapi.c
+++ b/src/external/lua-5.1.5/src/lapi.c
@@ -211,7 +211,7 @@ LUA_API void lua_replace (lua_State *L, int idx) {
   api_checkvalidindex(L, o);
   if (idx == LUA_ENVIRONINDEX) {
     Closure *func = curr_func(L);
-    api_check(L, ttistable(L->top - 1)); 
+    api_check(L, ttistable(L->top - 1));
     func->c.env = hvalue(L->top - 1);
     luaC_barrier(L, func, L->top - 1);
   }
@@ -342,7 +342,7 @@ LUA_API int lua_toboolean (lua_State *L, int idx) {
 
 LUA_API const char *lua_tolstring (lua_State *L, int idx, size_t *len) {
   StkId o = index2adr(L, idx);
-  if (!ttisstring(o)) {
+  if (!(ttisstring(o))) {
     lua_lock(L);  /* `luaV_tostring' may create a new string */
     if (!luaV_tostring(L, o)) {  /* conversion failed? */
       if (len != NULL) *len = 0;
@@ -394,7 +394,7 @@ LUA_API void *lua_touserdata (lua_State *L, int idx) {
 
 LUA_API lua_State *lua_tothread (lua_State *L, int idx) {
   StkId o = index2adr(L, idx);
-  return (!ttisthread(o)) ? NULL : thvalue(o);
+  return (!(ttisthread(o))) ? NULL : thvalue(o);
 }
 
 
@@ -771,7 +771,7 @@ LUA_API int lua_setfenv (lua_State *L, int idx) {
 
 #define checkresults(L,na,nr) \
      api_check(L, (nr) == LUA_MULTRET || (L->ci->top - L->top >= (nr) - (na)))
-	
+
 
 LUA_API void lua_call (lua_State *L, int nargs, int nresults) {
   StkId func;
@@ -1038,7 +1038,7 @@ LUA_API void *lua_newuserdata (lua_State *L, size_t size) {
 
 static const char *aux_upvalue (StkId fi, int n, TValue **val) {
   Closure *f;
-  if (!ttisfunction(fi)) return NULL;
+  if (!(ttisfunction(fi))) return NULL;
   f = clvalue(fi);
   if (f->c.isC) {
     if (!(1 <= n && n <= f->c.nupvalues)) return NULL;

--- a/src/external/lua-5.1.5/src/ldebug.c
+++ b/src/external/lua-5.1.5/src/ldebug.c
@@ -184,7 +184,7 @@ static void collectvalidlines (lua_State *L, Closure *f) {
     int i;
     for (i=0; i<f->l.p->sizelineinfo; i++)
       setbvalue(luaH_setnum(L, t, lineinfo[i]), 1);
-    sethvalue(L, L->top, t); 
+    sethvalue(L, L->top, t);
   }
   incr_top(L);
 }
@@ -580,7 +580,7 @@ void luaG_typeerror (lua_State *L, const TValue *o, const char *op) {
 
 void luaG_concaterror (lua_State *L, StkId p1, StkId p2) {
   if (ttisstring(p1) || ttisnumber(p1)) p1 = p2;
-  lua_assert(!ttisstring(p1) && !ttisnumber(p1));
+  lua_assert(!(ttisstring(p1)) && !(ttisnumber(p1)));
   luaG_typeerror(L, p1, "concatenate");
 }
 
@@ -618,7 +618,7 @@ static void addinfo (lua_State *L, const char *msg) {
 void luaG_errormsg (lua_State *L) {
   if (L->errfunc != 0) {  /* is there an error handling function? */
     StkId errfunc = restorestack(L, L->errfunc);
-    if (!ttisfunction(errfunc)) luaD_throw(L, LUA_ERRERR);
+    if (!(ttisfunction(errfunc))) luaD_throw(L, LUA_ERRERR);
     setobjs2s(L, L->top, L->top - 1);  /* move argument */
     setobjs2s(L, L->top - 1, errfunc);  /* push function */
     incr_top(L);

--- a/src/external/lua-5.1.5/src/ldo.c
+++ b/src/external/lua-5.1.5/src/ldo.c
@@ -245,7 +245,7 @@ static StkId tryfuncTM (lua_State *L, StkId func) {
   const TValue *tm = luaT_gettmbyobj(L, func, TM_CALL);
   StkId p;
   ptrdiff_t funcr = savestack(L, func);
-  if (!ttisfunction(tm))
+  if (!(ttisfunction(tm)))
     luaG_typeerror(L, func, "call");
   /* Open a hole inside the stack at `func' */
   for (p = L->top; p > func; p--) setobjs2s(L, p, p-1);
@@ -265,7 +265,7 @@ static StkId tryfuncTM (lua_State *L, StkId func) {
 int luaD_precall (lua_State *L, StkId func, int nresults) {
   LClosure *cl;
   ptrdiff_t funcr;
-  if (!ttisfunction(func)) /* `func' is not a function? */
+  if (!(ttisfunction(func))) /* `func' is not a function? */
     func = tryfuncTM(L, func);  /* check the `function' tag method */
   funcr = savestack(L, func);
   cl = &clvalue(func)->l;
@@ -366,7 +366,7 @@ int luaD_poscall (lua_State *L, StkId firstResult) {
 ** The arguments are on the stack, right after the function.
 ** When returns, all the results are on the stack, starting at the original
 ** function position.
-*/ 
+*/
 void luaD_call (lua_State *L, StkId func, int nResults) {
   if (++L->nCcalls >= LUAI_MAXCCALLS) {
     if (L->nCcalls == LUAI_MAXCCALLS)

--- a/src/external/lua-5.1.5/src/lobject.h
+++ b/src/external/lua-5.1.5/src/lobject.h
@@ -76,15 +76,15 @@ typedef struct lua_TValue {
 
 
 /* Macros to test type */
-#define ttisnil(o)	(ttype(o) == LUA_TNIL)
-#define ttisnumber(o)	(ttype(o) == LUA_TNUMBER)
-#define ttisstring(o)	(ttype(o) == LUA_TSTRING)
-#define ttistable(o)	(ttype(o) == LUA_TTABLE)
-#define ttisfunction(o)	(ttype(o) == LUA_TFUNCTION)
-#define ttisboolean(o)	(ttype(o) == LUA_TBOOLEAN)
-#define ttisuserdata(o)	(ttype(o) == LUA_TUSERDATA)
-#define ttisthread(o)	(ttype(o) == LUA_TTHREAD)
-#define ttislightuserdata(o)	(ttype(o) == LUA_TLIGHTUSERDATA)
+#define ttisnil(o)	ttype(o) == LUA_TNIL
+#define ttisnumber(o)	ttype(o) == LUA_TNUMBER
+#define ttisstring(o)	ttype(o) == LUA_TSTRING
+#define ttistable(o)	ttype(o) == LUA_TTABLE
+#define ttisfunction(o)	ttype(o) == LUA_TFUNCTION
+#define ttisboolean(o)	ttype(o) == LUA_TBOOLEAN
+#define ttisuserdata(o)	ttype(o) == LUA_TUSERDATA
+#define ttisthread(o)	ttype(o) == LUA_TTHREAD
+#define ttislightuserdata(o)	ttype(o) == LUA_TLIGHTUSERDATA
 
 /* Macros to access values */
 #define ttype(o)	((o)->tt)
@@ -337,7 +337,7 @@ typedef struct Node {
 
 typedef struct Table {
   CommonHeader;
-  lu_byte flags;  /* 1<<p means tagmethod(p) is not present */ 
+  lu_byte flags;  /* 1<<p means tagmethod(p) is not present */
   lu_byte lsizenode;  /* log2 of size of `node' array */
   struct Table *metatable;
   TValue *array;  /* array part */

--- a/src/external/lua-5.1.5/src/ltable.c
+++ b/src/external/lua-5.1.5/src/ltable.c
@@ -48,7 +48,7 @@
 
 
 #define hashpow2(t,n)      (gnode(t, lmod((n), sizenode(t))))
-  
+
 #define hashstr(t,str)  hashpow2(t, (str)->tsv.hash)
 #define hashboolean(t,p)        hashpow2(t, p)
 
@@ -162,14 +162,14 @@ static int findindex (lua_State *L, Table *t, StkId key) {
 int luaH_next (lua_State *L, Table *t, StkId key) {
   int i = findindex(L, t, key);  /* find original element */
   for (i++; i < t->sizearray; i++) {  /* try first array part */
-    if (!ttisnil(&t->array[i])) {  /* a non-nil value? */
+    if (!(ttisnil(&t->array[i]))) {  /* a non-nil value? */
       setnvalue(key, cast_num(i+1));
       setobj2s(L, key+1, &t->array[i]);
       return 1;
     }
   }
   for (i -= t->sizearray; i < sizenode(t); i++) {  /* then hash part */
-    if (!ttisnil(gval(gnode(t, i)))) {  /* a non-nil value? */
+    if (!(ttisnil(gval(gnode(t, i))))) {  /* a non-nil value? */
       setobj2s(L, key, key2tval(gnode(t, i)));
       setobj2s(L, key+1, gval(gnode(t, i)));
       return 1;
@@ -234,7 +234,7 @@ static int numusearray (const Table *t, int *nums) {
     }
     /* count elements in range (2^(lg-1), 2^lg] */
     for (; i <= lim; i++) {
-      if (!ttisnil(&t->array[i-1]))
+      if (!(ttisnil(&t->array[i-1])))
         lc++;
     }
     nums[lg] += lc;
@@ -250,7 +250,7 @@ static int numusehash (const Table *t, int *nums, int *pnasize) {
   int i = sizenode(t);
   while (i--) {
     Node *n = &t->node[i];
-    if (!ttisnil(gval(n))) {
+    if (!(ttisnil(gval(n)))) {
       ause += countint(key2tval(n), nums);
       totaluse++;
     }
@@ -302,12 +302,12 @@ static void resize (lua_State *L, Table *t, int nasize, int nhsize) {
   if (nasize > oldasize)  /* array part must grow? */
     setarrayvector(L, t, nasize);
   /* create new hash part with appropriate size */
-  setnodevector(L, t, nhsize);  
+  setnodevector(L, t, nhsize);
   if (nasize < oldasize) {  /* array part must shrink? */
     t->sizearray = nasize;
     /* re-insert elements from vanishing slice */
     for (i=nasize; i<oldasize; i++) {
-      if (!ttisnil(&t->array[i]))
+      if (!(ttisnil(&t->array[i])))
         setobjt2t(L, luaH_setnum(L, t, i+1), &t->array[i]);
     }
     /* shrink array */
@@ -316,7 +316,7 @@ static void resize (lua_State *L, Table *t, int nasize, int nhsize) {
   /* re-insert elements from hash part */
   for (i = twoto(oldhsize) - 1; i >= 0; i--) {
     Node *old = nold+i;
-    if (!ttisnil(gval(old)))
+    if (!(ttisnil(gval(old))))
       setobjt2t(L, luaH_set(L, t, key2tval(old)), gval(old));
   }
   if (nold != dummynode)
@@ -390,11 +390,11 @@ static Node *getfreepos (Table *t) {
 
 
 /*
-** inserts a new key into a hash table; first, check whether key's main 
-** position is free. If not, check whether colliding node is in its main 
-** position or not: if it is not, move colliding node to an empty place and 
-** put new key in its main position; otherwise (colliding node is in its main 
-** position), new key goes to an empty position. 
+** inserts a new key into a hash table; first, check whether key's main
+** position is free. If not, check whether colliding node is in its main
+** position or not: if it is not, move colliding node to an empty place and
+** put new key in its main position; otherwise (colliding node is in its main
+** position), new key goes to an empty position.
 */
 static TValue *newkey (lua_State *L, Table *t, const TValue *key) {
   Node *mp = mainposition(t, key);

--- a/src/external/lua-5.1.5/src/luaconf.h
+++ b/src/external/lua-5.1.5/src/luaconf.h
@@ -537,7 +537,7 @@
 #define luai_nummod(a,b)	((a) - floor((a)/(b))*(b))
 #define luai_numpow(a,b)	(pow(a,b))
 #define luai_numunm(a)		(-(a))
-#define luai_numeq(a,b)		((a)==(b))
+#define luai_numeq(a,b)		(a)==(b)
 #define luai_numlt(a,b)		((a)<(b))
 #define luai_numle(a,b)		((a)<=(b))
 #define luai_numisnan(a)	(!luai_numeq((a), (a)))

--- a/src/external/lua-5.1.5/src/lvm.c
+++ b/src/external/lua-5.1.5/src/lvm.c
@@ -45,7 +45,7 @@ const TValue *luaV_tonumber (const TValue *obj, TValue *n) {
 
 
 int luaV_tostring (lua_State *L, StkId obj) {
-  if (!ttisnumber(obj))
+  if (!(ttisnumber(obj)))
     return 0;
   else {
     char s[LUAI_MAXNUMBER2STR];
@@ -125,7 +125,7 @@ void luaV_gettable (lua_State *L, const TValue *t, TValue *key, StkId val) {
       callTMres(L, val, tm, t, key);
       return;
     }
-    t = tm;  /* else repeat with `tm' */ 
+    t = tm;  /* else repeat with `tm' */
   }
   luaG_runerror(L, "loop in gettable");
 }

--- a/src/external/tre/lib/tre-ast.h
+++ b/src/external/tre/lib/tre-ast.h
@@ -30,12 +30,12 @@ typedef enum {
 #define BACKREF	  -4   /* Back reference leaf. */
 #define PARAMETER -5   /* Parameter. */
 
-#define IS_SPECIAL(x)	((x)->code_min < 0)
-#define IS_EMPTY(x)	((x)->code_min == EMPTY)
-#define IS_ASSERTION(x) ((x)->code_min == ASSERTION)
-#define IS_TAG(x)	((x)->code_min == TAG)
-#define IS_BACKREF(x)	((x)->code_min == BACKREF)
-#define IS_PARAMETER(x) ((x)->code_min == PARAMETER)
+#define IS_SPECIAL(x)	(x)->code_min < 0
+#define IS_EMPTY(x)	(x)->code_min == EMPTY
+#define IS_ASSERTION(x) (x)->code_min == ASSERTION
+#define IS_TAG(x)	(x)->code_min == TAG
+#define IS_BACKREF(x)	(x)->code_min == BACKREF
+#define IS_PARAMETER(x) (x)->code_min == PARAMETER
 
 
 /* A generic AST node.  All AST nodes consist of this node on the top

--- a/src/external/tre/lib/tre-compile.c
+++ b/src/external/tre/lib/tre-compile.c
@@ -269,7 +269,7 @@ tre_add_tags(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree,
 	      {
 		tre_literal_t *lit = node->obj;
 
-		if (!IS_SPECIAL(lit) || IS_BACKREF(lit))
+		if (!(IS_SPECIAL(lit)) || IS_BACKREF(lit))
 		  {
 		    int i;
 		    DPRINT(("Literal %d-%d\n",
@@ -309,7 +309,7 @@ tre_add_tags(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree,
 		  }
 		else
 		  {
-		    assert(!IS_TAG(lit));
+		    assert(!(IS_TAG(lit)));
 		  }
 		break;
 	      }
@@ -691,7 +691,7 @@ tre_copy_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 		int pos = lit->position;
 		int min = lit->code_min;
 		int max = lit->code_max;
-		if (!IS_SPECIAL(lit) || IS_BACKREF(lit))
+		if (!(IS_SPECIAL(lit)) || IS_BACKREF(lit))
 		  {
 		    /* XXX - e.g. [ab] has only one position but two
 		       nodes, so we are creating holes in the state space
@@ -839,7 +839,7 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 	    case LITERAL:
 	      {
 		tre_literal_t *lit= node->obj;
-		if (!IS_SPECIAL(lit) || IS_BACKREF(lit))
+		if (!(IS_SPECIAL(lit)) || IS_BACKREF(lit))
 		  {
 		    lit->position += pos_add;
 		    if (lit->position > max_pos)

--- a/src/match/merger-trie.c
+++ b/src/match/merger-trie.c
@@ -533,7 +533,7 @@ void gt_mergertrie_insertsuffix(Mergertrierep *trierep,
         return;
       }
       succ = np.current;
-      if (MTRIE_ISLEAF(succ))
+      if MTRIE_ISLEAF(succ)
       {
         lcpvalue = getlcp(eri->encseqptr,
                           eri->readmode,

--- a/src/match/sfx-bentsedg.c
+++ b/src/match/sfx-bentsedg.c
@@ -110,9 +110,9 @@ typedef GtEndofTwobitencoding GtSfxcmp;
                                                              bsr->complement,\
                                                              COMMONUNITS,&X,&Y)
 
-#define GtSfxcmpEQUAL(X,Y)      (ret##X##Y == 0)
-#define GtSfxcmpSMALLER(X,Y)    (ret##X##Y < 0)
-#define GtSfxcmpGREATER(X,Y)    (ret##X##Y > 0)
+#define GtSfxcmpEQUAL(X,Y)      ret##X##Y == 0
+#define GtSfxcmpSMALLER(X,Y)    ret##X##Y < 0
+#define GtSfxcmpGREATER(X,Y)    ret##X##Y > 0
 
 typedef struct
 {


### PR DESCRIPTION
addresses concerns raised in #570 