### PR TITLE
fix issues with seqid mappings

### DIFF
--- a/src/core/bioseq_col.c
+++ b/src/core/bioseq_col.c
@@ -196,6 +196,25 @@ static int gt_bioseq_col_grep_desc_md5(GtSeqCol *sc, const char **md5,
   return had_err;
 }
 
+static int gt_bioseq_col_grep_desc_desc(GtSeqCol *sc, GtStr *desc,
+                                        GtStr *seqid, GtError *err)
+{
+  GtUword filenum = 0, seqnum = 0;
+  int had_err;
+  GtBioseqCol *bsc;
+  bsc = gt_bioseq_col_cast(sc);
+  gt_error_check(err);
+  gt_assert(bsc && desc && seqid);
+  had_err = grep_desc(bsc, &filenum, &seqnum, seqid, err);
+  if (!had_err) {
+    const char *mydesc = gt_bioseq_get_description(bsc->bioseqs[filenum],
+                                                   seqnum);
+    if (mydesc)
+      gt_str_append_cstr(desc, mydesc);
+  }
+  return had_err;
+}
+
 static int gt_bioseq_col_grep_desc_sequence_length(GtSeqCol *sc,
                                                    GtUword *length,
                                                    GtStr *seqid,
@@ -375,6 +394,7 @@ const GtSeqColClass* gt_bioseq_col_class(void)
                                        gt_bioseq_col_delete,
                                        gt_bioseq_col_enable_match_desc_start,
                                        gt_bioseq_col_grep_desc,
+                                       gt_bioseq_col_grep_desc_desc,
                                        gt_bioseq_col_grep_desc_md5,
                                        gt_bioseq_col_grep_desc_sequence_length,
                                        gt_bioseq_col_md5_to_seq,

--- a/src/core/encseq_col.c
+++ b/src/core/encseq_col.c
@@ -203,6 +203,24 @@ static int gt_encseq_col_grep_desc_md5(GtSeqCol *sc, const char **md5,
   return had_err;
 }
 
+static int gt_encseq_col_grep_desc_desc(GtSeqCol *sc, GtStr *desc,
+                                        GtStr *seqid, GtError *err)
+{
+  GtUword filenum = 0, seqnum = 0;
+  int had_err;
+  GtEncseqCol *esc;
+  esc = gt_encseq_col_cast(sc);
+  gt_error_check(err);
+  gt_assert(esc && desc && seqid);
+  had_err = gt_encseq_col_do_grep_desc(esc, &filenum, &seqnum, seqid, err);
+  if (!had_err) {
+    const char *mydesc = gt_seq_col_get_description(sc, seqnum, filenum);
+    if (mydesc)
+      gt_str_append_cstr(desc, mydesc);
+  }
+  return had_err;
+}
+
 static int gt_encseq_col_grep_desc_sequence_length(GtSeqCol *sc,
                                                    GtUword *length,
                                                    GtStr *seqid,
@@ -418,6 +436,7 @@ const GtSeqColClass* gt_encseq_col_class(void)
                                        gt_encseq_col_delete,
                                        gt_encseq_col_enable_match_desc_start,
                                        gt_encseq_col_grep_desc,
+                                       gt_encseq_col_grep_desc_desc,
                                        gt_encseq_col_grep_desc_md5,
                                        gt_encseq_col_grep_desc_sequence_length,
                                        gt_encseq_col_md5_to_seq,

--- a/src/core/seq_col.c
+++ b/src/core/seq_col.c
@@ -27,6 +27,8 @@ const GtSeqColClass* gt_seq_col_class_new(size_t size,
                                           GtSeqColEnableMatchDescStartFunc
                                                         enable_match_desc_start,
                                           GtSeqColGrepDescFunc grep_desc,
+                                          GtSeqColGrepDescDescFunc
+                                                                 grep_desc_desc,
                                           GtSeqColGrepDescMD5Func grep_desc_md5,
                                           GtSeqColGrepDescSeqlenFunc
                                                                grep_desc_seqlen,
@@ -45,6 +47,7 @@ const GtSeqColClass* gt_seq_col_class_new(size_t size,
   c_class->free = free;
   c_class->enable_match_desc_start = enable_match_desc_start;
   c_class->grep_desc = grep_desc;
+  c_class->grep_desc_desc = grep_desc_desc;
   c_class->grep_desc_md5 = grep_desc_md5;
   c_class->grep_desc_seqlen = grep_desc_seqlen;
   c_class->md5_to_desc = md5_to_desc;
@@ -105,6 +108,15 @@ int gt_seq_col_grep_desc_md5(GtSeqCol *sc, const char **md5, GtStr *seqid,
   gt_assert(sc && md5 && seqid);
   if (sc->c_class->grep_desc_md5)
     return sc->c_class->grep_desc_md5(sc, md5, seqid, err);
+  return 0;
+}
+
+int gt_seq_col_grep_desc_description(GtSeqCol *sc, GtStr *desc, GtStr *seqid,
+                                     GtError *err)
+{
+  gt_assert(sc && desc && seqid);
+  if (sc->c_class->grep_desc_desc)
+    return sc->c_class->grep_desc_desc(sc, desc, seqid, err);
   return 0;
 }
 

--- a/src/core/seq_col.h
+++ b/src/core/seq_col.h
@@ -30,6 +30,8 @@ int         gt_seq_col_grep_desc(GtSeqCol*, char **seq,
                                  GtStr *seqid, GtError*);
 int         gt_seq_col_grep_desc_md5(GtSeqCol*, const char **md5,
                                      GtStr *seqid, GtError*);
+int         gt_seq_col_grep_desc_description(GtSeqCol*, GtStr *desc,
+                                             GtStr *seqid, GtError*);
 int         gt_seq_col_grep_desc_sequence_length(GtSeqCol *sc,
                                                  GtUword *length,
                                                  GtStr *seqid,

--- a/src/core/seq_col_rep.h
+++ b/src/core/seq_col_rep.h
@@ -29,6 +29,8 @@ typedef int         (*GtSeqColGrepDescFunc)(GtSeqCol*, char **seq,
                                             GtUword start,
                                             GtUword end,
                                             GtStr *seqid, GtError*);
+typedef int         (*GtSeqColGrepDescDescFunc)(GtSeqCol*, GtStr *desc,
+                                                GtStr *seqid, GtError *err);
 typedef int         (*GtSeqColGrepDescMD5Func)(GtSeqCol*, const char **md5,
                                                GtStr *seqid, GtError*);
 typedef int         (*GtSeqColGrepDescSeqlenFunc)(GtSeqCol*, GtUword*,
@@ -65,6 +67,7 @@ struct GtSeqColClass {
   GtSeqColFreeFunc free;
   GtSeqColEnableMatchDescStartFunc enable_match_desc_start;
   GtSeqColGrepDescFunc grep_desc;
+  GtSeqColGrepDescDescFunc grep_desc_desc;
   GtSeqColGrepDescMD5Func grep_desc_md5;
   GtSeqColGrepDescSeqlenFunc grep_desc_seqlen;
   GtSeqColMD5ToSeqFunc md5_to_seq;
@@ -87,6 +90,8 @@ const GtSeqColClass* gt_seq_col_class_new(size_t size,
                                           GtSeqColEnableMatchDescStartFunc
                                                         enable_match_desc_start,
                                           GtSeqColGrepDescFunc grep_desc,
+                                          GtSeqColGrepDescDescFunc
+                                                                 grep_desc_desc,
                                           GtSeqColGrepDescMD5Func grep_desc_md5,
                                           GtSeqColGrepDescSeqlenFunc
                                                                grep_desc_seqlen,

--- a/src/extended/region_mapping.c
+++ b/src/extended/region_mapping.c
@@ -424,11 +424,7 @@ int gt_region_mapping_get_description(GtRegionMapping *rm, GtStr *desc,
     if (gt_md5_seqid_has_prefix(gt_str_get(seqid))) {
       had_err = gt_seq_col_md5_to_description(rm->seq_col, desc, seqid,
                                               err);
-    }
-    return had_err;
-  }
-  if (!had_err) {
-    if (rm->usedesc) {
+    } else if (rm->usedesc) {
       GtUword filenum, seqnum;
       gt_assert(rm->seqid2seqnum_mapping);
       had_err = gt_seqid2seqnum_mapping_map(rm->seqid2seqnum_mapping,
@@ -441,8 +437,7 @@ int gt_region_mapping_get_description(GtRegionMapping *rm, GtStr *desc,
         gt_str_append_cstr(desc, cdesc);
         gt_free(cdesc);
       }
-    }
-    else if (rm->useseqno) {
+    } else if (rm->useseqno) {
       GtUword seqno = GT_UNDEF_UWORD;
       gt_assert(rm->encseq);
       if (1 != sscanf(gt_str_get(seqid), "seq"GT_WU"", &seqno)) {
@@ -465,15 +460,8 @@ int gt_region_mapping_get_description(GtRegionMapping *rm, GtStr *desc,
         gt_str_append_cstr_nt(desc, edesc, desclen);
       }
     } else if (rm->matchdesc) {
-      const char *md5;
-      /* XXX: not beautiful, but works -- this may be LOTS faster */
-      had_err = gt_seq_col_grep_desc_md5(rm->seq_col, &md5, seqid, err);
-      if (!had_err) {
-        GtStr *md5_seqid = gt_str_new_cstr(md5);
-        had_err = gt_seq_col_md5_to_description(rm->seq_col, desc, md5_seqid,
-                                                err);
-        gt_str_delete(md5_seqid);
-      }
+      had_err = gt_seq_col_grep_desc_description(rm->seq_col, desc,
+                                                 seqid, err);
     } else if (rm->mapping) {
       char *cdesc;
       cdesc = gt_seq_col_get_description(rm->seq_col, 0, 0);

--- a/src/extended/seqid2seqnum_mapping.c
+++ b/src/extended/seqid2seqnum_mapping.c
@@ -84,11 +84,11 @@ static int seqid_info_get(SeqidInfo *seqid_info, GtUword *seqnum,
   SeqidInfoElem *seqid_info_elem;
   GtUword i;
   gt_error_check(err);
-  gt_assert(seqid_info && seqnum && outrange && inrange);
+  gt_assert(seqid_info && seqnum && outrange);
   for (i = 0; i < gt_array_size(seqid_info); i++) {
     seqid_info_elem = gt_array_get(seqid_info, i);
     if (seqid_info_elem->descrange.end == GT_UNDEF_UWORD ||
-        gt_range_contains(&seqid_info_elem->descrange, inrange)) {
+        (inrange && gt_range_contains(&seqid_info_elem->descrange, inrange))) {
       *seqnum = seqid_info_elem->seqnum;
       *filenum = seqid_info_elem->filenum;
       *outrange = seqid_info_elem->descrange;


### PR DESCRIPTION
In http://genometools.org/pipermail/gt-users/2015-April/000775.html a problem was reported with LTRdigest and its output options. Sequence IDs were missing from the headers of the written FASTA files. Apparently the case in which a sequence description is queried from a GtSeqCol using `-usedesc` or `-matchdesc` and no MD5 information is present to process this query had not been implemented in the GtRegionMapping class.
This PR addresses this issue.