### PR TITLE
make -sort implicit

### DIFF
--- a/src/tools/gt_gff3.c
+++ b/src/tools/gt_gff3.c
@@ -113,7 +113,6 @@ static GtOptionParser* gt_gff3_option_parser_new(void *tool_arguments)
                                         "on a strict line basis (not sorted as"
                                         "defined by GenomeTools)",
                                         &arguments->sortlines, false);
-  gt_option_imply(sortlines_option, sort_option);
   gt_option_parser_add_option(op, sortlines_option);
 
   /* -sortnum */
@@ -121,7 +120,6 @@ static GtOptionParser* gt_gff3_option_parser_new(void *tool_arguments)
                                         "sorting for sequence regions (not "
                                         "sorted as defined by GenomeTools)",
                                         &arguments->sortnum, false);
-  gt_option_imply(sortnum_option, sort_option);
   gt_option_parser_add_option(op, sortnum_option);
   gt_option_exclude(sortlines_option, sortnum_option);
 
@@ -316,7 +314,7 @@ static int gt_gff3_runner(int argc, const char **argv, int parsed_args,
   }
 
   /* create sort stream (if necessary) */
-  if (!had_err && arguments->sort) {
+  if (!had_err && (arguments->sort || arguments->sortlines)) {
     sort_stream = gt_sort_stream_new(last_stream);
     last_stream = sort_stream;
   }

--- a/testsuite/gt_gff3_include.rb
+++ b/testsuite/gt_gff3_include.rb
@@ -1427,13 +1427,6 @@ Test do
   grep last_stderr, "ends with a blank, removing"
 end
 
-Name "gt gff3 -sortlines (missing -sort) "
-Keywords "gt_gff3 linesorting"
-Test do
-  run_test "#{$bin}gt gff3 -sortlines #{$testdata}eden.gff3", :retval => 1
-  grep last_stderr, "requires option \"-sort\""
-end
-
 Name "gt gff3 -sortlines (standard gene)"
 Keywords "gt_gff3 linesorting"
 Test do
@@ -1495,13 +1488,6 @@ Test do
   run "#{$bin}gt #{$testdata}/gtscripts/check_linesorting.lua 2"
   run_test "#{$bin}gt gff3 -sort -retainids 2 > 3"
   run "diff 1 3"
-end
-
-Name "gt gff3 -sortnum (missing -sort) "
-Keywords "gt_gff3 numsorting"
-Test do
-  run_test "#{$bin}gt gff3 -sortnum #{$testdata}eden.gff3", :retval => 1
-  grep last_stderr, "requires option \"-sort\""
 end
 
 Name "gt gff3 -sortnum (standard gene)"


### PR DESCRIPTION
Allows to just use `-sort` or `-sortlines` without having to also give `-sort`. See #581.