### PR TITLE
fix issues with implicit `-sort`

### DIFF
--- a/src/tools/gt_gff3.c
+++ b/src/tools/gt_gff3.c
@@ -314,7 +314,8 @@ static int gt_gff3_runner(int argc, const char **argv, int parsed_args,
   }
 
   /* create sort stream (if necessary) */
-  if (!had_err && (arguments->sort || arguments->sortlines)) {
+  if (!had_err && (arguments->sort || arguments->sortlines ||
+                   arguments->sortnum)) {
     sort_stream = gt_sort_stream_new(last_stream);
     last_stream = sort_stream;
   }

--- a/testdata/gff3_numeric_a.gff
+++ b/testdata/gff3_numeric_a.gff
@@ -1,0 +1,5 @@
+##gff-version   3
+##sequence-region	1 1 1238593
+##sequence-region	10 1 150036
+##sequence-region	2 1 676873
+##sequence-region	20 1 62468

--- a/testsuite/gt_gff3_include.rb
+++ b/testsuite/gt_gff3_include.rb
@@ -1512,6 +1512,14 @@ Test do
   run "diff #{last_stdout} #{$testdata}gff3_numeric_mixed.out"
 end
 
+Name "gt gff3 -sortnum (implicit -sort)"
+Keywords "gt_gff3 numsorting"
+Test do
+  run_test "#{$bin}gt gff3 -sort -retainids -sortnum #{$testdata}gff3_numeric_a.gff #{$testdata}gff3_numeric_a.gff  > 1"
+  run_test "#{$bin}gt gff3 -retainids -sortnum #{$testdata}gff3_numeric_a.gff #{$testdata}gff3_numeric_a.gff "
+  run "diff #{last_stdout} 1"
+end
+
 Name "gt gff3 (double free regression)"
 Keywords "gt_gff3"
 Test do


### PR DESCRIPTION
Addresses the issue raised in #581. Note that the problem described does not occur when using `-sort sortnum` instead of `-sortnum` which implied that some additional region joining step performed in the former case did not take place in the latter.
This PR fixes the issue and adds the minimal example provided by the reporter as a test case. 