### PR TITLE
extractfeat: support `-seqid` and `-target` together with `-translate`

### DIFF
--- a/src/extended/extract_feature_sequence.c
+++ b/src/extended/extract_feature_sequence.c
@@ -176,6 +176,8 @@ int gt_extract_feature_sequence(GtStr *sequence, GtGenomeNode *gn,
 int gt_extract_and_translate_feature_sequence(GtFeatureNode *feature_node,
                                               const char *type,
                                               bool join,
+                                              GtStr *seqid,
+                                              GtStrArray *target_ids,
                                               GtRegionMapping *rm,
                                               GtTransTable *ttable,
                                               GtStr *translation_fr1,
@@ -194,8 +196,8 @@ int gt_extract_and_translate_feature_sequence(GtFeatureNode *feature_node,
 
   had_err = extract_feature_sequence_generic(sequence,
                                              (GtGenomeNode*) feature_node, type,
-                                             join, NULL, NULL, &phase_offset,
-                                             rm, err);
+                                             join, seqid, target_ids,
+                                             &phase_offset, rm, err);
 
   /* do translation if we have at least one codon */
   if (!had_err && gt_str_length(sequence) > phase_offset + 2) {

--- a/src/extended/extract_feature_sequence.h
+++ b/src/extended/extract_feature_sequence.h
@@ -36,6 +36,8 @@ int gt_extract_feature_sequence(GtStr *sequence, GtGenomeNode*,
    <err> accordingly. */
 int gt_extract_and_translate_feature_sequence(GtFeatureNode *feature_node,
                                               const char *type, bool join,
+                                              GtStr *seqid,
+                                              GtStrArray *target_ids,
                                               GtRegionMapping *rm,
                                               GtTransTable *ttable,
                                               GtStr *translation_fr1,

--- a/src/extended/extract_feature_visitor.c
+++ b/src/extended/extract_feature_visitor.c
@@ -111,6 +111,7 @@ static int extract_feature_visitor_feature_node(GtNodeVisitor *nv,
     if (efv->translate) {
       if (gt_extract_and_translate_feature_sequence(child,
                                                     efv->type, efv->join,
+                                                    seqid, target_ids,
                                                     efv->region_mapping, NULL,
                                                     sequence, NULL, NULL,
                                                     err)) {
@@ -124,7 +125,6 @@ static int extract_feature_visitor_feature_node(GtNodeVisitor *nv,
         had_err = -1;
       }
     }
-
     if (!had_err && gt_str_length(sequence)) {
       efv->fastaseq_counter++;
       if (efv->retain_ids && gt_feature_node_get_attribute(child, "ID")) {

--- a/src/gtlua/genome_node_lua.c
+++ b/src/gtlua/genome_node_lua.c
@@ -684,7 +684,8 @@ static int feature_node_lua_extract_and_translate_sequence(lua_State *L)
   err = gt_error_new();
   sequence = gt_str_new();
   if (gt_extract_and_translate_feature_sequence(fn, gt_symbol(type), join,
-                                                *region_mapping, NULL,
+                                                NULL, NULL, *region_mapping,
+                                                NULL,
                                                 sequence, NULL, NULL, err)) {
     gt_str_delete(sequence);
     return gt_lua_error(L, err);


### PR DESCRIPTION
This PR fixes a bug in `gt extractfeat` where the `-translate` option would not work with either the `-seqid` or `-target` options (or both).
Closes #593.