### PR TITLE
add coordinates output for extractfeat tool

### DIFF
--- a/src/extended/extract_feature_stream.c
+++ b/src/extended/extract_feature_stream.c
@@ -39,3 +39,10 @@ void gt_extract_feature_stream_retain_id_attributes(GtExtractFeatureStream *es)
   gt_extract_feature_visitor_retain_id_attributes((GtExtractFeatureVisitor*)
                          gt_visitor_stream_get_visitor((GtVisitorStream*) es));
 }
+
+void gt_extract_feature_stream_show_coords(GtExtractFeatureStream *es)
+{
+  gt_assert(es);
+  gt_extract_feature_visitor_show_coords((GtExtractFeatureVisitor*)
+                         gt_visitor_stream_get_visitor((GtVisitorStream*) es));
+}

--- a/src/extended/extract_feature_stream_api.h
+++ b/src/extended/extract_feature_stream_api.h
@@ -46,4 +46,6 @@ GtNodeStream* gt_extract_feature_stream_new(GtNodeStream *in_stream,
 void          gt_extract_feature_stream_retain_id_attributes(
                                                        GtExtractFeatureStream*);
 
+void          gt_extract_feature_stream_show_coords(GtExtractFeatureStream*);
+
 #endif

--- a/src/extended/extract_feature_visitor.h
+++ b/src/extended/extract_feature_visitor.h
@@ -39,4 +39,7 @@ GtNodeVisitor*            gt_extract_feature_visitor_new(GtRegionMapping *rm,
 void                      gt_extract_feature_visitor_retain_id_attributes(
                                                 GtExtractFeatureVisitor *efv);
 
+void                      gt_extract_feature_visitor_show_coords(
+                                                GtExtractFeatureVisitor *efv);
+
 #endif

--- a/src/tools/gt_extractfeat.c
+++ b/src/tools/gt_extractfeat.c
@@ -32,6 +32,7 @@ typedef struct {
        seqid,
        target,
        verbose,
+       showcoords,
        retainids;
   GtStr *type;
   GtSeqid2FileInfo *s2fi;
@@ -101,6 +102,12 @@ static GtOptionParser* gt_extractfeat_option_parser_new(void *tool_arguments)
                               &arguments->target, false);
   gt_option_parser_add_option(op, option);
 
+  /* -coords */
+  option = gt_option_new_bool("coords", "add location of extracted features "
+                              "to FASTA descriptions", &arguments->showcoords,
+                              true);
+  gt_option_parser_add_option(op, option);
+
   /* -retainids */
   option = gt_option_new_bool("retainids", "use ID attributes of extracted "
                               "features as FASTA descriptions",
@@ -167,6 +174,10 @@ static int gt_extractfeat_runner(GT_UNUSED int argc, const char **argv,
     if (arguments->retainids)
       gt_extract_feature_stream_retain_id_attributes((GtExtractFeatureStream*)
                                                        extract_feature_stream);
+
+    if (arguments->showcoords)
+      gt_extract_feature_stream_show_coords((GtExtractFeatureStream*)
+                                                        extract_feature_stream);
 
     /* pull the features through the stream and free them afterwards */
     had_err = gt_node_stream_pull(extract_feature_stream, err);

--- a/src/tools/gt_extractfeat.c
+++ b/src/tools/gt_extractfeat.c
@@ -105,7 +105,7 @@ static GtOptionParser* gt_extractfeat_option_parser_new(void *tool_arguments)
   /* -coords */
   option = gt_option_new_bool("coords", "add location of extracted features "
                               "to FASTA descriptions", &arguments->showcoords,
-                              true);
+                              false);
   gt_option_parser_add_option(op, option);
 
   /* -retainids */


### PR DESCRIPTION
Addresses #597. Coordinates are added to the `-seqid` output if the `-coords` option is given in addition.