### PR TITLE
add generic type counts to 'gt stat' output 

### DIFF
--- a/src/core/string_distri.h
+++ b/src/core/string_distri.h
@@ -33,7 +33,7 @@ void            gt_string_distri_add(GtStringDistri*, const char*);
 /* <string_distri> must contain at least one element with given <key>. */
 void            gt_string_distri_sub(GtStringDistri *string_distri,
                                      const char *key);
-GtUword   gt_string_distri_get(const GtStringDistri*, const char*);
+GtUword         gt_string_distri_get(const GtStringDistri*, const char*);
 /* return probability */
 double          gt_string_distri_get_prob(const GtStringDistri*, const char*);
 void            gt_string_distri_foreach(const GtStringDistri*,

--- a/src/extended/stat_visitor.c
+++ b/src/extended/stat_visitor.c
@@ -242,7 +242,7 @@ GtNodeVisitor* gt_stat_visitor_new(bool gene_length_distri,
 static void gt_stat_print_string_distri_item(const char *string,
                                              GtUword occurrences,
                                              GT_UNUSED double probability,
-                                             GT_UNUSED void *data)
+                                             void *data)
 {
   GtFile *outfp = (GtFile*) data;
   gt_file_xprintf(outfp, "%ss: "GT_WU"\n", string, occurrences);

--- a/src/extended/stat_visitor.c
+++ b/src/extended/stat_visitor.c
@@ -239,7 +239,7 @@ GtNodeVisitor* gt_stat_visitor_new(bool gene_length_distri,
   return nv;
 }
 
-void gt_stat_print_string_distri_item(const char *string,
+static void gt_stat_print_string_distri_item(const char *string,
                                       GtUword occurrences,
                                       GT_UNUSED double probability,
                                       GT_UNUSED void *data)

--- a/src/extended/stat_visitor.c
+++ b/src/extended/stat_visitor.c
@@ -125,6 +125,7 @@ static void compute_type_statistics(GtFeatureNode *fn, GtStatVisitor *sv)
     sv->number_of_CDSs++;
   }
   else if (gt_feature_node_has_type(fn, gt_ft_intron)) {
+    gt_string_distri_add(sv->type_counts, gt_feature_node_get_type(fn));
     if (sv->intron_length_distribution) {
       range = gt_genome_node_get_range((GtGenomeNode*) fn);
       gt_disc_distri_add(sv->intron_length_distribution,

--- a/src/extended/stat_visitor.c
+++ b/src/extended/stat_visitor.c
@@ -240,9 +240,9 @@ GtNodeVisitor* gt_stat_visitor_new(bool gene_length_distri,
 }
 
 static void gt_stat_print_string_distri_item(const char *string,
-                                      GtUword occurrences,
-                                      GT_UNUSED double probability,
-                                      GT_UNUSED void *data)
+                                             GtUword occurrences,
+                                             GT_UNUSED double probability,
+                                             GT_UNUSED void *data)
 {
   GtFile *outfp = (GtFile*) data;
   gt_file_xprintf(outfp, "%ss: "GT_WU"\n", string, occurrences);

--- a/src/extended/stat_visitor.c
+++ b/src/extended/stat_visitor.c
@@ -20,6 +20,7 @@
 #include "core/compat.h"
 #include "core/cstr_table_api.h"
 #include "core/disc_distri_api.h"
+#include "core/string_distri.h"
 #include "core/unused_api.h"
 #include "extended/feature_node.h"
 #include "extended/node_visitor_api.h"
@@ -46,6 +47,7 @@ struct GtStatVisitor {
                *intron_length_distribution,
                *cds_length_distribution;
   GtCstrTable *used_sources;
+  GtStringDistri *type_counts;
 };
 
 #define stat_visitor_cast(GV)\
@@ -61,6 +63,7 @@ static void stat_visitor_free(GtNodeVisitor *nv)
   gt_disc_distri_delete(sv->exon_length_distribution);
   gt_disc_distri_delete(sv->gene_score_distribution);
   gt_disc_distri_delete(sv->gene_length_distribution);
+  gt_string_distri_delete(sv->type_counts);
 }
 
 static int add_exon_or_cds_number(GtFeatureNode *fn, void *data,
@@ -130,6 +133,8 @@ static void compute_type_statistics(GtFeatureNode *fn, GtStatVisitor *sv)
   }
   else if (gt_feature_node_has_type(fn, gt_ft_LTR_retrotransposon)) {
     sv->number_of_LTR_retrotransposons++;
+  } else {
+    gt_string_distri_add(sv->type_counts, gt_feature_node_get_type(fn));
   }
 }
 
@@ -228,9 +233,19 @@ GtNodeVisitor* gt_stat_visitor_new(bool gene_length_distri,
     sv->intron_length_distribution = gt_disc_distri_new();
   if (cds_length_distri)
     sv->cds_length_distribution = gt_disc_distri_new();
+  sv->type_counts = gt_string_distri_new();
   if (used_sources)
     sv->used_sources = gt_cstr_table_new();
   return nv;
+}
+
+void gt_stat_print_string_distri_item(const char *string,
+                                      GtUword occurrences,
+                                      GT_UNUSED double probability,
+                                      GT_UNUSED void *data)
+{
+  GtFile *outfp = (GtFile*) data;
+  gt_file_xprintf(outfp, "%ss: "GT_WU"\n", string, occurrences);
 }
 
 void gt_stat_visitor_show_stats(GtNodeVisitor *nv, GtFile *outfp)
@@ -266,6 +281,8 @@ void gt_stat_visitor_show_stats(GtNodeVisitor *nv, GtFile *outfp)
     gt_file_xprintf(outfp, "LTR_retrotransposons: "GT_WU"\n",
                     sv->number_of_LTR_retrotransposons);
   }
+  gt_string_distri_foreach(sv->type_counts, gt_stat_print_string_distri_item,
+                           outfp);
   if (sv->gene_length_distribution) {
     gt_file_xprintf(outfp, "gene length distribution:\n");
     gt_disc_distri_show(sv->gene_length_distribution, outfp);

--- a/src/tools/gt_stat.c
+++ b/src/tools/gt_stat.c
@@ -143,7 +143,7 @@ static int gt_stat_runner(int argc, const char **argv, int parsed_args,
     add_introns_stream = gt_add_introns_stream_new(sort_stream);
   }
 
-  /* create s status stream */
+  /* create stat stream */
   stat_stream = gt_stat_stream_new(arguments->addintrons
                                    ? add_introns_stream : gff3_in_stream,
                                    arguments->gene_length_distribution,

--- a/testdata/gt_stat_cdslengthdistri.out
+++ b/testdata/gt_stat_cdslengthdistri.out
@@ -6,5 +6,9 @@ protein-coding genes: 1
 mRNAs: 1
 protein-coding mRNAs: 1
 CDSs: 4
+TF_binding_sites: 1
+cDNA_matchs: 3
+five_prime_UTRs: 1
+three_prime_UTRs: 1
 CDS length distribution:
 2305: 1 (prob=1.0000,cumulative=1.0000)

--- a/testdata/gt_stat_exonnumberdistri_standard.out
+++ b/testdata/gt_stat_exonnumberdistri_standard.out
@@ -3,6 +3,7 @@ sequence regions: 1 (total length: 1497228)
 genes: 1
 mRNAs: 3
 exons: 11
+TF_binding_sites: 1
 exon number distribution:
 3: 1 (prob=0.3333,cumulative=0.3333)
 4: 2 (prob=0.6667,cumulative=1.0000)

--- a/testdata/gt_stat_source.out
+++ b/testdata/gt_stat_source.out
@@ -3,5 +3,6 @@ sequence regions: 1 (total length: 1497228)
 genes: 1
 mRNAs: 3
 exons: 11
+TF_binding_sites: 1
 used source tags:
 .

--- a/testdata/gt_stat_test_1.out
+++ b/testdata/gt_stat_test_1.out
@@ -3,3 +3,4 @@ sequence regions: 1 (total length: 1497228)
 genes: 1
 mRNAs: 3
 exons: 11
+TF_binding_sites: 1

--- a/testdata/gt_stat_test_2.out
+++ b/testdata/gt_stat_test_2.out
@@ -3,5 +3,6 @@ sequence regions: 1 (total length: 1497228)
 genes: 1
 mRNAs: 3
 exons: 11
+TF_binding_sites: 1
 gene length distribution:
 8001: 1 (prob=1.0000,cumulative=1.0000)

--- a/testdata/gt_stat_test_3.out
+++ b/testdata/gt_stat_test_3.out
@@ -3,6 +3,7 @@ sequence regions: 1 (total length: 1497228)
 genes: 1
 mRNAs: 3
 exons: 11
+TF_binding_sites: 1
 exon length distribution:
 201: 1 (prob=0.0909,cumulative=0.0909)
 451: 2 (prob=0.1818,cumulative=0.2727)

--- a/testdata/gt_stat_test_4.out
+++ b/testdata/gt_stat_test_4.out
@@ -3,6 +3,8 @@ sequence regions: 1 (total length: 1497228)
 genes: 1
 mRNAs: 3
 exons: 11
+TF_binding_sites: 1
+introns: 8
 intron length distribution:
 1097: 2 (prob=0.2500,cumulative=0.2500)
 1499: 5 (prob=0.6250,cumulative=0.8750)

--- a/testdata/gt_stat_test_5.out
+++ b/testdata/gt_stat_test_5.out
@@ -3,5 +3,6 @@ sequence regions: 1 (total length: 1497228)
 genes: 1
 mRNAs: 3
 exons: 11
+TF_binding_sites: 1
 gene score distribution:
 50: 1 (prob=1.0000,cumulative=1.0000)

--- a/testdata/gt_stat_test_6.out
+++ b/testdata/gt_stat_test_6.out
@@ -1,3 +1,7 @@
 parsed genome node DAGs: 61
 sequence regions: 16 (total length: 12069317)
 LTR_retrotransposons: 45
+inverted_repeats: 180
+long_terminal_repeats: 90
+repeat_regions: 45
+target_site_duplications: 90


### PR DESCRIPTION
This PR adds occurrence counting for any kind of feature type encountered by the GtStatVisitor, instead of only selected hard-coded ones. These are of course still supported, but any other type and its count is reported as well. Example:
```
[ss34@mib106184i:~/develop/genometools] gt stat Lmajor.gff3
parsed genome node DAGs: 17890
sequence regions: 36 (total length: 32841480)
genes: 9284
protein-coding genes: 9284
mRNAs: 8307
protein-coding mRNAs: 8307
CDSs: 9288
ncRNAs: 84
polypeptides: 8400
pseudogenes: 93
pseudogenic_exons: 175
pseudogenic_transcripts: 93
rRNAs: 63
repeat_units: 3
snRNAs: 6
snoRNAs: 741
tRNAs: 83
```

NOTE: This obviously changes the output of `gt stat` - any comments on whether this is OK?

Closes #624.