### PR TITLE
Fix sortedness issue in `gt merge`

### DIFF
--- a/src/extended/merge_stream.c
+++ b/src/extended/merge_stream.c
@@ -89,7 +89,7 @@ static int merge_stream_next_in_order(GtNodeStream *ns, GtGenomeNode **gn,
   }
 
   /* stream the queue contents */
-  if (!gt_priority_queue_is_empty(ms->pq)) {
+  if (!had_err && !gt_priority_queue_is_empty(ms->pq)) {
     GtMergeStreamItem *min_item = gt_priority_queue_extract_min(ms->pq);
     GtGenomeNode *nextnode = NULL;
     gt_assert(min_item && min_item->gn);
@@ -152,7 +152,7 @@ static int merge_stream_next(GtNodeStream *ns, GtGenomeNode **gn, GtError *err)
     }
   }
 
-  for (;;) {
+  while (!had_err) {
     gt_assert(ms->first_node && !ms->second_node);
     had_err = merge_stream_next_in_order(ns, &ms->second_node, err);
     if (!had_err && ms->second_node) {

--- a/src/extended/merge_stream.c
+++ b/src/extended/merge_stream.c
@@ -105,6 +105,7 @@ static int merge_stream_next_in_order(GtNodeStream *ns, GtGenomeNode **gn,
         min_item->gn = nextnode;
         gt_priority_queue_add(ms->pq, min_item);
       } else {
+        min_item->gn = NULL;
         gt_genome_node_delete(nextnode);
       }
     }
@@ -177,8 +178,11 @@ static void merge_stream_free(GtNodeStream *ns)
 {
   GtMergeStream *ms = gt_merge_stream_cast(ns);
   GtUword i;
-  for (i = 0; i < gt_array_size(ms->node_streams); i++)
+  for (i = 0; i < gt_array_size(ms->node_streams); i++) {
+    if (ms->items[i].gn)
+      gt_genome_node_delete(ms->items[i].gn);
     gt_node_stream_delete(*(GtNodeStream**) gt_array_get(ms->node_streams, i));
+  }
   gt_array_delete(ms->node_streams);
   gt_free(ms->items);
   gt_priority_queue_delete(ms->pq);

--- a/testsuite/gt_merge_include.rb
+++ b/testsuite/gt_merge_include.rb
@@ -40,6 +40,13 @@ Test do
   run_test("#{$bin}gt merge #{$testdata}/standard_gene_as_tree.gff3 1")
 end
 
+Name "gt merge many unsorted files"
+Keywords "gt_merge"
+Test do
+  run_test("#{$bin}gt merge #{$testdata}/standard_gene_as_tree.gff3 #{$testdata}unsorted_gff3_file.txt #{$testdata}unsorted_gff3_file.txt #{$testdata}unsorted_gff3_file.txt", :retval => 1)
+  grep(last_stderr, "is not sorted")
+end
+
 Name "gt merge with sequence"
 Keywords "gt_merge"
 Test do

--- a/testsuite/gt_merge_include.rb
+++ b/testsuite/gt_merge_include.rb
@@ -31,6 +31,15 @@ Test do
   grep(last_stderr, "is not sorted")
 end
 
+Name "gt merge unsorted second file"
+Keywords "gt_merge"
+Test do
+  run_test("#{$bin}gt merge #{$testdata}/standard_gene_as_tree.gff3 #{$testdata}unsorted_gff3_file.txt", :retval => 1)
+  grep(last_stderr, "is not sorted")
+  run("#{$bin}gt gff3 -sort -tidy -retainids #{$testdata}unsorted_gff3_file.txt > 1")
+  run_test("#{$bin}gt merge #{$testdata}/standard_gene_as_tree.gff3 1")
+end
+
 Name "gt merge with sequence"
 Keywords "gt_merge"
 Test do


### PR DESCRIPTION
This PR fixes #626 in which an assertion is triggered if an unsorted GFF file (other than the first) is input. This fix resolves this issue by correctly printing an error message.