### PR TITLE
allow compiling with GCC 5

### DIFF
--- a/src/external/lua-5.1.5/src/luaconf.h
+++ b/src/external/lua-5.1.5/src/luaconf.h
@@ -540,7 +540,7 @@
 #define luai_numeq(a,b)		(a)==(b)
 #define luai_numlt(a,b)		((a)<(b))
 #define luai_numle(a,b)		((a)<=(b))
-#define luai_numisnan(a)	(!luai_numeq((a), (a)))
+#define luai_numisnan(a)	(!(luai_numeq((a), (a))))
 #endif
 
 


### PR DESCRIPTION
This fixes a minor issue with GCC 5:
```
In file included from /home/vagrant/genometools/src/external/lua-5.1.5/src/lua.h:16:0,
                 from /home/vagrant/genometools/src/external/lua-5.1.5/src/lapi.c:16,
                 from src/lualib.c:7:
/home/vagrant/genometools/src/external/lua-5.1.5/src/lcode.c: In function ‘constfolding’:
/home/vagrant/genometools/src/external/lua-5.1.5/src/luaconf.h:540:29: error: logical not is only applied to the left hand side of comparison [-Werror=logical-not-parentheses]
 #define luai_numeq(a,b)  (a)==(b)
                             ^
/home/vagrant/genometools/src/external/lua-5.1.5/src/luaconf.h:543:28: note: in expansion of macro ‘luai_numeq’
 #define luai_numisnan(a) (!luai_numeq((a), (a)))
                            ^
/home/vagrant/genometools/src/external/lua-5.1.5/src/lcode.c:647:7: note: in expansion of macro ‘luai_numisnan’
   if (luai_numisnan(r)) return 0;  /* do not attempt to produce NaN */
       ^
[compile md5.o]
/home/vagrant/genometools/src/external/lua-5.1.5/src/ltable.c: In function ‘luaH_set’:
/home/vagrant/genometools/src/external/lua-5.1.5/src/luaconf.h:540:29: error: logical not is only applied to the left hand side of comparison [-Werror=logical-not-parentheses]
 #define luai_numeq(a,b)  (a)==(b)
                             ^
/home/vagrant/genometools/src/external/lua-5.1.5/src/luaconf.h:543:28: note: in expansion of macro ‘luai_numeq’
 #define luai_numisnan(a) (!luai_numeq((a), (a)))
                            ^
/home/vagrant/genometools/src/external/lua-5.1.5/src/ltable.c:501:33: note: in expansion of macro ‘luai_numisnan’
     else if (ttisnumber(key) && luai_numisnan(nvalue(key)))
                                 ^
```
This is important since Debian is preparing to switch to GCC5 as their default compiler soon (https://lists.debian.org/debian-devel-announce/2015/07/msg00000.html).