### PR TITLE
fix error reporting in LTRdigest

### DIFF
--- a/src/ltr/gt_ltrdigest.c
+++ b/src/ltr/gt_ltrdigest.c
@@ -638,11 +638,14 @@ static int gt_ltrdigest_runner(GT_UNUSED int argc, const char **argv,
       }
     }
 
-    last_stream = gff3_out_stream = gt_gff3_out_stream_new(last_stream,
-                                                           arguments->outfp);
+    if (!had_err) {
+      last_stream = gff3_out_stream = gt_gff3_out_stream_new(last_stream,
+                                                             arguments->outfp);
+      gt_assert(last_stream);
 
-    /* pull the features through the stream and free them afterwards */
-    had_err = gt_node_stream_pull(last_stream, err);
+      /* pull the features through the stream and free them afterwards */
+      had_err = gt_node_stream_pull(last_stream, err);
+    }
   }
 
   gt_pdom_model_set_delete(ms);

--- a/testsuite/gt_ltrdigest_include.rb
+++ b/testsuite/gt_ltrdigest_include.rb
@@ -444,6 +444,18 @@ if $gttestdata then
     end
   end
 
+  Name "gt ltrdigest -outfileprefix fail (nonwritable path)"
+  Keywords "gt_ltrdigest aminoacidout aaout permissions"
+  Test do
+    run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v " + \
+             "-db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz", \
+             :maxtime => 600
+    run_test "#{$bin}gt -j 2 ltrdigest -outfileprefix ./not/exist/foo " + \
+             "-encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz " + \
+             "#{$gttestdata}ltrdigest/dmel_md5_4.gff3 ",
+             :retval => 1
+  end
+
   # LEGACY INTERFACE TESTS
 
   Name "gt ltrdigest missing input GFF (legacy syntax)"


### PR DESCRIPTION
This PR fixes a failed assertion in LTRdigest triggered when the location given with `-outfileprefix` is not valid, i.e. in a non-existent or non-writable directory.