### PR TITLE
clean (gt)testdata

### DIFF
--- a/testsuite/gt_cds_include.rb
+++ b/testsuite/gt_cds_include.rb
@@ -4,8 +4,9 @@ require 'fileutils'
   Name "gt cds test #{i}"
   Keywords "gt_cds"
   Test do
+    FileUtils.copy "#{$testdata}gt_cds_test_#{i}.fas", "."
     run_test "#{$bin}gt cds -minorflen 1 -startcodon yes " \
-             "-seqfile #{$testdata}gt_cds_test_#{i}.fas -matchdesc " \
+             "-seqfile gt_cds_test_#{i}.fas -matchdesc " \
              "#{$testdata}gt_cds_test_#{i}.in"
     run "diff #{last_stdout} #{$testdata}gt_cds_test_#{i}.out"
   end
@@ -14,8 +15,9 @@ end
 Name "gt cds error message"
 Keywords "gt_cds"
 Test do
+  FileUtils.copy "#{$testdata}gt_cds_test_1.fas", "."
   run "#{$bin}gt gff3 -offset 1000 #{$testdata}gt_cds_test_1.in | " \
-      "#{$bin}gt cds -matchdesc -seqfile #{$testdata}gt_cds_test_1.fas -", :retval => 1
+      "#{$bin}gt cds -matchdesc -seqfile gt_cds_test_1.fas -", :retval => 1
   grep last_stderr, "Has the sequence-region to sequence mapping been defined correctly"
 end
 
@@ -23,8 +25,9 @@ end
   Name "gt cds test #{i} (-usedesc)"
   Keywords "gt_cds usedesc"
   Test do
+    FileUtils.copy "#{$testdata}gt_cds_test_#{i}.fas", "."
     run_test "#{$bin}gt cds -minorflen 1 -startcodon yes -usedesc " \
-             "-seqfile #{$testdata}gt_cds_test_#{i}.fas " \
+             "-seqfile gt_cds_test_#{i}.fas " \
              "#{$testdata}gt_cds_test_#{i}.in"
     run "diff #{last_stdout} #{$testdata}gt_cds_test_#{i}.out"
   end
@@ -33,8 +36,9 @@ end
 Name "gt cds test (description range)"
 Keywords "gt_cds usedesc"
 Test do
+  FileUtils.copy "#{$testdata}gt_cds_test_descrange.fas", "."
   run_test "#{$bin}gt cds -minorflen 1 -usedesc -seqfile " \
-           "#{$testdata}gt_cds_test_descrange.fas " \
+           "gt_cds_test_descrange.fas " \
            "#{$testdata}gt_cds_test_descrange.in"
   run "diff #{last_stdout} #{$testdata}gt_cds_test_descrange.out"
 end
@@ -42,8 +46,9 @@ end
 Name "gt cds test (multi description)"
 Keywords "gt_cds usedesc"
 Test do
+  FileUtils.copy "#{$testdata}gt_cds_descrange_multi.fas", "."
   run_test "#{$bin}gt cds -minorflen 1 -usedesc -seqfile " \
-           "#{$testdata}gt_cds_descrange_multi.fas " \
+           "gt_cds_descrange_multi.fas " \
            "#{$testdata}gt_cds_descrange_multi.in"
   run "diff #{last_stdout} #{$testdata}gt_cds_descrange_multi.out"
 end
@@ -51,8 +56,9 @@ end
 Name "gt cds test (multi description fail 1)"
 Keywords "gt_cds usedesc"
 Test do
+  FileUtils.copy "#{$testdata}gt_cds_descrange_multi_fail_1.fas", "."
   run_test("#{$bin}gt cds -usedesc -seqfile " \
-           "#{$testdata}gt_cds_descrange_multi_fail_1.fas " \
+           "gt_cds_descrange_multi_fail_1.fas " \
            "#{$testdata}gt_cds_test_descrange.in", :retval => 1)
   grep last_stderr, "contain multiple sequences with ID"
 end
@@ -60,8 +66,9 @@ end
 Name "gt cds test (multi description fail 2)"
 Keywords "gt_cds usedesc"
 Test do
+  FileUtils.copy "#{$testdata}gt_cds_descrange_multi_fail_2.fas", "."
   run_test("#{$bin}gt cds -usedesc -seqfile " \
-           "#{$testdata}gt_cds_descrange_multi_fail_2.fas " \
+           "gt_cds_descrange_multi_fail_2.fas " \
            "#{$testdata}gt_cds_test_descrange.in", :retval => 1)
   grep last_stderr, "contain multiple sequences with ID"
 end
@@ -69,8 +76,9 @@ end
 Name "gt cds test (wrong ID)"
 Keywords "gt_cds usedesc"
 Test do
+  FileUtils.copy "#{$testdata}gt_cds_descrange_wrong_id.fas", "."
   run_test("#{$bin}gt cds -usedesc -seqfile " \
-           "#{$testdata}gt_cds_descrange_wrong_id.fas " \
+           "gt_cds_descrange_wrong_id.fas " \
            "#{$testdata}gt_cds_test_descrange.in", :retval => 1)
   grep last_stderr, "sequence with ID"
 end
@@ -78,8 +86,9 @@ end
 Name "gt cds test (wrong range)"
 Keywords "gt_cds usedesc"
 Test do
+  FileUtils.copy "#{$testdata}gt_cds_descrange_wrong_range.fas", "."
   run_test("#{$bin}gt cds -usedesc -seqfile " \
-           "#{$testdata}gt_cds_descrange_wrong_range.fas " \
+           "gt_cds_descrange_wrong_range.fas " \
            "#{$testdata}gt_cds_test_descrange.in", :retval => 1)
   grep last_stderr, "sequence with ID"
 end
@@ -98,8 +107,9 @@ end
 Name "gt cds test (nGASP)"
 Keywords "gt_cds nGASP"
 Test do
+  FileUtils.copy "#{$testdata}nGASP/III.fas", "."
   run_test "#{$bin}gt cds -startcodon yes -finalstopcodon no -minorflen 64 " \
-           "-seqfile #{$testdata}nGASP/III.fas -usedesc " \
+           "-seqfile III.fas -usedesc " \
            "#{$testdata}nGASP/resIII.gff3"
   run "diff #{last_stdout} #{$testdata}nGASP/resIIIcds.gff3"
 end
@@ -126,8 +136,9 @@ if $gttestdata then
   Name "gt cds bug"
   Keywords "gt_cds"
   Test do
+    FileUtils.copy "#{$gttestdata}cds/marker_region.fas", "."
     run_test "#{$bin}gt cds -startcodon yes -minorflen 1 " \
-             "-seqfile #{$gttestdata}cds/marker_region.fas " \
+             "-seqfile marker_region.fas " \
              "-matchdesc #{$gttestdata}cds/marker_bug.gff3"
     run "diff #{last_stdout} #{$gttestdata}cds/marker_bug.out"
   end

--- a/testsuite/gt_condenseq_include.rb
+++ b/testsuite/gt_condenseq_include.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'fileutils'
 
 files = {"#{$testdata}condenseq/unique_encseq_test.fas" => [14,7,41,4,2],
          "#{$testdata}tRNA.dos.fas" => [71,100,300, -1,-1],
@@ -44,7 +45,8 @@ Keywords "gt_condenseq description"
 Test do
   desc_files.each_pair do |file, info|
     basename = File.basename(file)
-    run_test "#{$bin}gt seqfilter -o #{basename}_10th.fas -step 10 #{file}"
+    FileUtils.copy "#{file}", "."
+    run_test "#{$bin}gt seqfilter -o #{basename}_10th.fas -step 10 #{basename}"
     run_test "#{$bin}gt encseq encode -indexname #{basename}_10th " \
       "-md5 no " \
       "#{basename}_10th.fas"

--- a/testsuite/gt_condenseq_include.rb
+++ b/testsuite/gt_condenseq_include.rb
@@ -15,7 +15,7 @@ searchfiles = {"#{$testdata}condenseq/varlen_0.01_50.fas" =>
 
 largefiles = {}
 if $gttestdata
-  largefiles["#{$gttestdata}condenseq/yeastproteomes.fas"] = [100,3000,10000,-1,-1]
+  largefiles["#{$gttestdata}condenser/yeastproteomes.fas"] = [100,3000,10000,-1,-1]
 end
 
 desc_files = {"#{$testdata}condenseq/varlen_200.fas" => [100,3000,10000],

--- a/testsuite/gt_condenseq_include.rb
+++ b/testsuite/gt_condenseq_include.rb
@@ -15,7 +15,7 @@ searchfiles = {"#{$testdata}condenseq/varlen_0.01_50.fas" =>
 
 largefiles = {}
 if $gttestdata
-  largefiles["#{$gttestdata}condenser/yeastproteomes.fas"] = [100,3000,10000,-1,-1]
+  largefiles["#{$gttestdata}condenseq/yeastproteomes.fas"] = [100,3000,10000,-1,-1]
 end
 
 desc_files = {"#{$testdata}condenseq/varlen_200.fas" => [100,3000,10000],

--- a/testsuite/gt_extractfeat_include.rb
+++ b/testsuite/gt_extractfeat_include.rb
@@ -128,20 +128,20 @@ end
 Name "gt extractfeat -regionmapping test 1 (mapping table)"
 Keywords "gt_extractfeat"
 Test do
-  FileUtils.copy "#{$testdata}gt_extractfeat_succ_1.gff3", "."
-  run "env GT_TESTDATA=#{$testdata} #{$memcheck} #{$bin}gt extractfeat " \
+  FileUtils.copy "#{$testdata}gt_extractfeat_succ_1.fas", "."
+  run "env GT_TESTDATA=./ #{$memcheck} #{$bin}gt extractfeat " \
     "-type gene -regionmapping #{$testdata}regionmapping_4.lua " \
-    "gt_extractfeat_succ_1.gff3"
+    "#{$testdata}gt_extractfeat_succ_1.gff3"
   run "diff #{last_stdout} #{$testdata}gt_extractfeat_succ_1.out"
 end
 
 Name "gt extractfeat -regionmapping test 1 (mapping function)"
 Keywords "gt_extractfeat"
 Test do
-  FileUtils.copy "#{$testdata}gt_extractfeat_succ_1.gff3", "."
-  run "env GT_TESTDATA=#{$testdata} #{$memcheck} #{$bin}gt extractfeat " \
+  FileUtils.copy "#{$testdata}gt_extractfeat_succ_1.fas", "."
+  run "env GT_TESTDATA=./ #{$memcheck} #{$bin}gt extractfeat " \
     "-type gene -regionmapping #{$testdata}regionmapping_6.lua " \
-    "gt_extractfeat_succ_1.gff3"
+    "#{$testdata}gt_extractfeat_succ_1.gff3"
 end
 
 Name "gt extractfeat error message"
@@ -268,18 +268,25 @@ end
 Name "gt extractfeat compare query method combinations"
 Keywords "gt_extractfeat query_methods"
 Test do
-  run "#{$bin}gt encseq encode -lossless -indexname ./idx " \
+  FileUtils.copy "#{$testdata}gt_extractfeat_mappings.fas", "."
+  FileUtils.copy "#{$testdata}gt_extractfeat_mappings_sep1.fas", "."
+  FileUtils.copy "#{$testdata}gt_extractfeat_mappings_sep2.fas", "."
+  FileUtils.copy "#{$testdata}gt_extractfeat_mappings_seprm_bar.fas", "."
+  FileUtils.copy "#{$testdata}gt_extractfeat_mappings_seprm_baz.fas", "."
+  FileUtils.copy "#{$testdata}gt_extractfeat_mappings_seprm_foo.fas", "."
+  FileUtils.copy "#{$testdata}gt_extractfeat_mappings_seprm_quux.fas", "."
+  run "#{$bin}gt encseq encode -lossless -indexname idx " \
     "#{$testdata}gt_extractfeat_mappings.fas"
   ["", ".md5"].each do |md5|
     ["-usedesc","-matchdesc"].each do |method|
       run "#{$bin}gt extractfeat #{method} " \
-        "-seqfile #{$testdata}gt_extractfeat_mappings.fas " \
+        "-seqfile gt_extractfeat_mappings.fas " \
         "-type gene #{$testdata}gt_extractfeat_mappings#{md5}.gff3 "
       run "diff #{last_stdout} " \
         "#{$testdata}gt_extractfeat_mappings_ref#{md5}.fas"
       run "#{$bin}gt extractfeat #{method} -seqfiles " \
-        "#{$testdata}gt_extractfeat_mappings_sep1.fas " \
-        "#{$testdata}gt_extractfeat_mappings_sep2.fas " \
+        "gt_extractfeat_mappings_sep1.fas " \
+        "gt_extractfeat_mappings_sep2.fas " \
         "-type gene #{$testdata}gt_extractfeat_mappings#{md5}.gff3 "
       run "diff #{last_stdout} " \
         "#{$testdata}gt_extractfeat_mappings_ref#{md5}.fas"
@@ -288,7 +295,7 @@ Test do
       run "diff #{last_stdout} " \
         "#{$testdata}gt_extractfeat_mappings_ref#{md5}.fas"
     end
-    run "env GT_TESTDATA=#{$testdata} #{$memcheck} #{$bin}gt extractfeat " \
+    run "env GT_TESTDATA=./ #{$memcheck} #{$bin}gt extractfeat " \
       "-regionmapping #{$testdata}gt_extractfeat_mappings_seprm.lua " \
       "-type gene #{$testdata}gt_extractfeat_mappings#{md5}.gff3 "
     run "diff #{last_stdout} #{$testdata}gt_extractfeat_mappings_ref#{md5}.fas"
@@ -298,23 +305,25 @@ end
 Name "gt extractfeat -matchdescstart"
 Keywords "gt_extractfeat matchdescstart"
 Test do
+  FileUtils.copy "#{$testdata}gt_extractfeat_matchdescstart_1.fas", "."
+  FileUtils.copy "#{$testdata}gt_extractfeat_matchdescstart_2.fas", "."
   ["-seqfiles","-seqfile"].each do |method|
     run "#{$bin}gt extractfeat #{method} " \
-      "#{$testdata}gt_extractfeat_matchdescstart_1.fas -type gene -matchdesc " \
+      "gt_extractfeat_matchdescstart_1.fas -type gene -matchdesc " \
       "#{$testdata}gt_extractfeat_matchdescstart_1.gff3", :retval => 1
     grep(last_stderr, "could match more than one sequence")
     run "#{$bin}gt extractfeat #{method} " \
-      "#{$testdata}gt_extractfeat_matchdescstart_1.fas -type gene " \
+      "gt_extractfeat_matchdescstart_1.fas -type gene " \
       "-matchdescstart #{$testdata}gt_extractfeat_matchdescstart_1.gff3"
     run "diff #{last_stdout} #{$testdata}gt_extractfeat_matchdescstart_1.out"
     run "#{$bin}gt extractfeat #{method} " \
-      "#{$testdata}gt_extractfeat_matchdescstart_2.fas -type gene " \
+      "gt_extractfeat_matchdescstart_2.fas -type gene " \
       "-matchdescstart #{$testdata}gt_extractfeat_matchdescstart_1.gff3", \
       :retval => 1
     grep(last_stderr, "could match more than one sequence")
   end
   run "#{$bin}gt encseq encode -lossless -indexname foo " \
-    "#{$testdata}gt_extractfeat_matchdescstart_1.fas"
+    "gt_extractfeat_matchdescstart_1.fas"
   run "#{$bin}gt extractfeat -encseq foo " \
     "-type gene -matchdesc #{$testdata}gt_extractfeat_matchdescstart_1.gff3", \
     :retval => 1
@@ -323,7 +332,7 @@ Test do
     "-matchdescstart #{$testdata}gt_extractfeat_matchdescstart_1.gff3"
   run "diff #{last_stdout} #{$testdata}gt_extractfeat_matchdescstart_1.out"
   run "#{$bin}gt encseq encode -lossless -indexname foo " \
-    "#{$testdata}gt_extractfeat_matchdescstart_2.fas"
+    "gt_extractfeat_matchdescstart_2.fas"
   run "#{$bin}gt extractfeat -encseq foo -type gene " \
     "-matchdescstart #{$testdata}gt_extractfeat_matchdescstart_1.gff3", \
     :retval => 1

--- a/testsuite/gt_extractseq_include.rb
+++ b/testsuite/gt_extractseq_include.rb
@@ -22,42 +22,49 @@ end
 Name "gt extractseq test foo"
 Keywords "gt_extractseq"
 Test do
-  run_test "#{$bin}gt extractseq -match foo #{$testdata}foo.fas"
+  FileUtils.copy "#{$testdata}foo.fas", "."
+  run_test "#{$bin}gt extractseq -match foo foo.fas"
   run "diff #{last_stdout} #{$testdata}foo.fas"
 end
 
 Name "gt extractseq test foo width 4"
 Keywords "gt_extractseq"
 Test do
-  run_test "#{$bin}gt extractseq -match foo -width 4 #{$testdata}foo.fas"
+  FileUtils.copy "#{$testdata}foo.fas", "."
+  run_test "#{$bin}gt extractseq -match foo -width 4 foo.fas"
   run "diff #{last_stdout} #{$testdata}foo_width4.fas"
 end
 
 Name "gt extractseq test bar"
 Keywords "gt_extractseq"
 Test do
-  run_test "#{$bin}gt extractseq -match bar -width 4 #{$testdata}bar.fas"
+  FileUtils.copy "#{$testdata}bar.fas", "."
+  run_test "#{$bin}gt extractseq -match bar -width 4 bar.fas"
   run "diff #{last_stdout} #{$testdata}bar.fas"
 end
 
 Name "gt extractseq test baz"
 Keywords "gt_extractseq"
 Test do
-  run "cat #{$testdata}foo.fas | #{$memcheck} #{$bin}gt extractseq -match baz - #{$testdata}bar.fas"
+  FileUtils.copy "#{$testdata}bar.fas", "."
+  run "cat #{$testdata}foo.fas | #{$memcheck} #{$bin}gt extractseq -match baz - bar.fas"
   grep(last_stdout, ".", true)
 end
 
 Name "gt extractseq test foo|bar"
 Keywords "gt_extractseq"
 Test do
-  run_test "#{$bin}gt extractseq -match 'foo|bar' #{$testdata}foo.fas #{$testdata}bar.fas"
+  FileUtils.copy "#{$testdata}foo.fas", "."
+  FileUtils.copy "#{$testdata}bar.fas", "."
+  run_test "#{$bin}gt extractseq -match 'foo|bar' foo.fas bar.fas"
   run "diff #{last_stdout} #{$testdata}foobar.fas"
 end
 
 Name "gt extractseq test '(foo'"
 Keywords "gt_extractseq"
 Test do
-  run_test("#{$bin}gt extractseq -match '(foo' #{$testdata}foo.fas", :retval => 1)
+  FileUtils.copy "#{$testdata}foo.fas", "."
+  run_test("#{$bin}gt extractseq -match '(foo' foo.fas", :retval => 1)
 end
 
 Name "gt extractseq test corrupt"
@@ -77,7 +84,8 @@ end
 Name "gt extractseq -frompos"
 Keywords "gt_extractseq"
 Test do
-  run_test "#{$bin}gt extractseq -frompos 5 -topos 12 #{$testdata}foobar.fas"
+  FileUtils.copy "#{$testdata}foobar.fas", "."
+  run_test "#{$bin}gt extractseq -frompos 5 -topos 12 foobar.fas"
   run "diff #{last_stdout} #{$testdata}frompos.fas"
 end
 
@@ -92,7 +100,8 @@ end
 Name "gt extractseq -frompos (fail 1)"
 Keywords "gt_extractseq"
 Test do
-  run_test "#{$bin}gt extractseq -frompos 5 -topos 17 #{$testdata}foobar.fas",
+  FileUtils.copy "#{$testdata}foobar.fas", "."
+  run_test "#{$bin}gt extractseq -frompos 5 -topos 17 foobar.fas",
            :retval => 1
   grep last_stderr, "larger than"
 end
@@ -108,7 +117,8 @@ end
 Name "gt extractseq marker.fas"
 Keywords "gt_extractseq"
 Test do
-  run_test "#{$bin}gt extractseq -frompos 21 -topos 40 #{$testdata}marker.fas"
+  FileUtils.copy "#{$testdata}marker.fas", "."
+  run_test "#{$bin}gt extractseq -frompos 21 -topos 40 marker.fas"
   run "diff #{last_stdout} #{$testdata}marker.out"
 end
 

--- a/testsuite/gt_fingerprint_include.rb
+++ b/testsuite/gt_fingerprint_include.rb
@@ -35,7 +35,7 @@ Keywords "gt_fingerprint"
 Test do
   FileUtils.copy "#{$testdata}U89959_ests.fas", "."
   run "cat #{$testdata}U89959_ests.checklist | #{$memcheck} #{$bin}gt " +
-      "fingerprint -check - #{$testdata}U89959_ests.fas"
+      "fingerprint -check - U89959_ests.fas"
 end
 
 Name "fingerprint -check (failure)"

--- a/testsuite/gt_fingerprint_include.rb
+++ b/testsuite/gt_fingerprint_include.rb
@@ -1,7 +1,10 @@
+require 'fileutils'
+
 Name "fingerprint"
 Keywords "gt_fingerprint"
 Test do
-  run_test "#{$bin}gt fingerprint #{$testdata}U89959_ests.fas | sort | uniq"
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
+  run_test "#{$bin}gt fingerprint U89959_ests.fas | sort | uniq"
   run "diff #{last_stdout} #{$testdata}U89959_ests.checklist_uniq"
 end
 
@@ -14,20 +17,23 @@ end
 Name "fingerprint (case insensitive)"
 Keywords "gt_fingerprint"
 Test do
-  run_test("#{$bin}gt fingerprint #{$testdata}U89959_ests_gi_8690080_soft_masked.fas")
+  FileUtils.copy "#{$testdata}U89959_ests_gi_8690080_soft_masked.fas", "."
+  run_test("#{$bin}gt fingerprint U89959_ests_gi_8690080_soft_masked.fas")
   run "diff #{last_stdout} #{$testdata}U89959_ests_gi_8690080_unmasked.checklist"
 end
 
 Name "fingerprint -check (success)"
 Keywords "gt_fingerprint"
 Test do
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
   run_test "#{$bin}gt fingerprint -check #{$testdata}U89959_ests.checklist " +
-           "#{$testdata}U89959_ests.fas"
+           "U89959_ests.fas"
 end
 
 Name "fingerprint -check (stdin)"
 Keywords "gt_fingerprint"
 Test do
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
   run "cat #{$testdata}U89959_ests.checklist | #{$memcheck} #{$bin}gt " +
       "fingerprint -check - #{$testdata}U89959_ests.fas"
 end
@@ -35,16 +41,18 @@ end
 Name "fingerprint -check (failure)"
 Keywords "gt_fingerprint"
 Test do
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
   run_test("#{$bin}gt fingerprint -check " +
            "#{$testdata}U89959_ests.checklist_uniq " +
-           "#{$testdata}U89959_ests.fas", :retval => 1)
+           "U89959_ests.fas", :retval => 1)
   grep last_stderr, /fingerprint comparison failed/
 end
 
 Name "fingerprint -check (failure)"
 Keywords "gt_fingerprint"
 Test do
-  run_test("#{$bin}gt sequniq #{$testdata}U89959_ests.fas | #{$memcheck}" +
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
+  run_test("#{$bin}gt sequniq U89959_ests.fas | #{$memcheck}" +
            "#{$bin}gt fingerprint -check #{$testdata}U89959_ests.checklist -",
            :retval => 1)
   grep last_stderr, /fingerprint comparison failed/
@@ -53,13 +61,15 @@ end
 Name "fingerprint -collisions"
 Keywords "gt_fingerprint"
 Test do
-  run_test "#{$bin}gt fingerprint -collisions #{$testdata}U89959_ests.fas"
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
+  run_test "#{$bin}gt fingerprint -collisions U89959_ests.fas"
 end
 
 Name "fingerprint -duplicates (found)"
 Keywords "gt_fingerprint"
 Test do
-  run_test("#{$bin}gt fingerprint -duplicates #{$testdata}U89959_ests.fas",
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
+  run_test("#{$bin}gt fingerprint -duplicates U89959_ests.fas",
            :retval => 1)
   grep last_stderr, /duplicates found/
 end
@@ -67,21 +77,24 @@ end
 Name "fingerprint -duplicates (none found)"
 Keywords "gt_fingerprint"
 Test do
-  run_test "#{$bin}gt fingerprint -duplicates #{$testdata}U89959_genomic.fas"
+  FileUtils.copy "#{$testdata}U89959_genomic.fas", "."
+  run_test "#{$bin}gt fingerprint -duplicates U89959_genomic.fas"
 end
 
 Name "fingerprint -extract (found)"
 Keywords "gt_fingerprint"
 Test do
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
   run_test "#{$bin}gt fingerprint -extract 6d3b4b9db4531cda588528f2c69c0a57 " +
-           "#{$testdata}U89959_ests.fas"
+           "U89959_ests.fas"
   run "diff #{last_stdout} #{$testdata}gt_fingerprint_extract.out"
 end
 
 Name "fingerprint -extract (not found)"
 Keywords "gt_fingerprint"
 Test do
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
   run_test "#{$bin}gt fingerprint -extract 7d3b4b9db4531cda588528f2c69c0a57 " +
-           "#{$testdata}U89959_ests.fas", :retval => 1
+           "U89959_ests.fas", :retval => 1
   grep last_stderr, /could not find sequence with fingerprint/
 end

--- a/testsuite/gt_idxsearch_include.rb
+++ b/testsuite/gt_idxsearch_include.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 allfiles = ["Atinsert.fna",
             "Duplicate.fna",
             "Random-Small.fna",
@@ -104,10 +106,12 @@ allfiles.each do |reffile|
       Name "gt greedyfwdmat #{reffile} #{queryfile}"
       Keywords "gt_greedyfwdmat small"
       Test do
-        createandcheckgreedyfwdmat("#{$testdata}#{reffile}",
-                                   "#{$testdata}#{queryfile}")
-        checktagerator("#{$testdata}#{reffile}",
-                       "#{$testdata}#{queryfile}")
+        FileUtils.copy "#{$testdata}#{reffile}", "."
+        FileUtils.copy "#{$testdata}#{queryfile}", "."
+        createandcheckgreedyfwdmat("#{reffile}",
+                                   "#{queryfile}")
+        checktagerator("#{reffile}",
+                       "#{queryfile}")
         run "rm -f sfx.* fmi.* pck.*"
       end
     end

--- a/testsuite/gt_kmer_database_include.rb
+++ b/testsuite/gt_kmer_database_include.rb
@@ -19,8 +19,8 @@ files_kmersize = ["#{$testdata}TTT-small.fna"]
 
 file_big = []
 if $gttestdata
-  files_big = ["#{$gttestdata}condenseq/varlen_0.01_50.fas",
-               "#{$gttestdata}condenseq/varlen_0.01_200.fas"]
+  files_big = ["#{$testdata}condenseq/varlen_0.01_50.fas",
+               "#{$testdata}condenseq/varlen_0.01_200.fas"]
 end
 
 1.step(7, 3) do |i|

--- a/testsuite/gt_ltrdigest_include.rb
+++ b/testsuite/gt_ltrdigest_include.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 # simple reverse complement
 def revcomp(seq)
   seq.tr("aAcCgGtTnN","tTgGcCaSAnN").reverse
@@ -50,11 +52,11 @@ def get_protdom_dna_seqs(gff3filename, chr)
         mainstop = stop.to_i
         mainstrand = strand
       elsif type == "protein_match" then
+        FileUtils.copy "#{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", "."
         run_test "#{$bin}gt extractseq -frompos " + \
                  "#{start} -topos " + \
                  "#{stop} " + \
-                 "#{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_" + \
-                 "RELEASE3-1.FASTA.gz > tmp.fas"
+                 "#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz > tmp.fas"
         outa = File.open("tmp.fas").read.split("\n")
         outa.shift
         if seqs[[mainstart, mainstop]].nil? then
@@ -98,13 +100,13 @@ def check_ppt_pbs(gff3filename, chr)
         fline = seqa.shift
         next if fline.nil?
         if m = /_(\d+)_(\d+)$/.match(fline) then
+          FileUtils.copy "#{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", "."
           start, stop = m[1].to_i, m[2].to_i
           seq = seqa.collect{|l| l.chomp.downcase}.join
           run_test "#{$bin}gt extractseq -frompos " + \
                    "#{coords[feat][[start,stop]][0]} -topos " + \
                    "#{coords[feat][[start,stop]][1]} " + \
-                   "#{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_" + \
-                   "RELEASE3-1.FASTA.gz > tmp.fas"
+                   "#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz > tmp.fas"
           outa = File.open("tmp.fas").read.split("\n")
           outa.shift
           out = outa.collect{|l| l.chomp.downcase}.join
@@ -262,6 +264,7 @@ if $gttestdata then
   Name "gt ltrdigest tRNA implied options"
   Keywords "gt_ltrdigest"
   Test do
+    FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
     run_test "#{$bin}gt suffixerator -lossless  -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pbsalilen 10 20 #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 1
     grep(last_stderr, /option "-pbsalilen" requires option "-trnas"/)
@@ -269,7 +272,7 @@ if $gttestdata then
     grep(last_stderr, /option "-pbsoffset" requires option "-trnas"/)
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pbstrnaoffset 10 20 #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 1
     grep(last_stderr, /option "-pbstrnaoffset" requires option "-trnas"/)
-    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
+    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3"
   end
 
@@ -295,8 +298,9 @@ if $gttestdata then
     Name "gt ltrdigest use of deprecated '-threads' switch"
     Keywords "gt_ltrdigest"
     Test do
+      FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
       run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
-      run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -threads 2 -outfileprefix result4 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0, :maxtime => 12000
+      run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -threads 2 -outfileprefix result4 -trnas Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0, :maxtime => 12000
       grep(last_stderr, /option is deprecated. Please use/)
     end
   end
@@ -304,6 +308,7 @@ if $gttestdata then
   Name "gt ltrdigest PPT HMM parameters (background distribution)"
   Keywords "gt_ltrdigest"
   Test do
+    FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
     run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     # probabilities do not add up to 1, sum > 0
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -ppttprob 0.3 -pptaprob 0.3 -pptgprob 0.9 -pptcprob 0.2 #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 1
@@ -314,29 +319,31 @@ if $gttestdata then
     # probabilities do not add up to 1, sum < 0
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -ppttprob 0.1 -pptaprob 0.1 -pptgprob 0.2 -pptcprob 0.2 #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 1
     # positive test
-    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -ppttprob 0.25 -pptaprob 0.25 -pptgprob 0.25 -pptcprob 0.25 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
+    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -ppttprob 0.25 -pptaprob 0.25 -pptgprob 0.25 -pptcprob 0.25 -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3"
   end
 
   Name "gt ltrdigest PPT HMM parameters (U-box U frequency)"
   Keywords "gt_ltrdigest"
   Test do
+    FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
     run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptuprob 1.3 #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 1
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptuprob 0.0 #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
-    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptuprob 0.91 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
+    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptuprob 0.91 -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3"
   end
 
   Name "gt ltrdigest PPT HMM parameters (PPT R/Y frequencies)"
   Keywords "gt_ltrdigest"
   Test do
+    FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
     run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptrprob 1.3 #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 1
     run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptyprob 1.3 #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 1
-    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptrprob 0.97 -pptyprob 0.03 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
+    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptrprob 0.97 -pptyprob 0.03 -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3"
-    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptrprob 0.6 -pptyprob 0.4 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
+    run_test "#{$bin}gt ltrdigest -encseq 4_genomic_dmel_RELEASE3-1.FASTA.gz -pptrprob 0.6 -pptyprob 0.4 -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_4.gff3", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3", :retval => 1
   end
 
@@ -355,8 +362,9 @@ if $gttestdata then
       Name "gt ltrdigest D. mel. #{chr} basic test w/ RT"
       Keywords "gt_ltrdigest"
       Test do
+        FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
         run_test "#{$bin}gt suffixerator -lossless  -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
-        run_test "#{$bin}gt ltrdigest -encseq #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz -outfileprefix result#{chr} -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_md5_#{chr}.gff3", :retval => 0, :maxtime => 12000
+        run_test "#{$bin}gt ltrdigest -encseq #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz -outfileprefix result#{chr} -trnas Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_md5_#{chr}.gff3", :retval => 0, :maxtime => 12000
         check_ppt_pbs(last_stdout, chr)
         #run "diff #{last_stdout} #{$gttestdata}ltrdigest/#{chr}_ref.gff3"
       end
@@ -364,8 +372,9 @@ if $gttestdata then
       Name "gt ltrdigest D. mel. chromosome #{chr} basic test, no HMM"
       Keywords "gt_ltrdigest"
       Test do
+        FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
         run_test "#{$bin}gt suffixerator -lossless -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
-        run_test "#{$bin}gt -j 2 ltrdigest -encseq #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz -outfileprefix result#{chr} -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_#{chr}.gff3",\
+        run_test "#{$bin}gt -j 2 ltrdigest -encseq #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz -outfileprefix result#{chr} -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_md5_#{chr}.gff3",\
        :retval => 0, :maxtime => 700
         check_ppt_pbs(last_stdout, chr)
         #run "diff #{last_stdout} #{$gttestdata}ltrdigest/#{chr}_ref_noHMM.gff3"
@@ -507,6 +516,7 @@ if $gttestdata then
   Name "gt ltrdigest tRNA implied options (legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
+    FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
     run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -pbsalilen 10 20 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     grep(last_stderr, /option "-pbsalilen" requires option "-trnas"/)
@@ -514,7 +524,7 @@ if $gttestdata then
     grep(last_stderr, /option "-pbsoffset" requires option "-trnas"/)
     run_test "#{$bin}gt ltrdigest -pbstrnaoffset 10 20 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     grep(last_stderr, /option "-pbstrnaoffset" requires option "-trnas"/)
-    run_test "#{$bin}gt ltrdigest -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
+    run_test "#{$bin}gt ltrdigest -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3"
   end
 
@@ -548,8 +558,9 @@ if $gttestdata then
     Name "gt ltrdigest use of deprecated '-threads' switch (legacy syntax)"
     Keywords "gt_ltrdigest"
     Test do
+      FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
       run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
-      run_test "#{$bin}gt ltrdigest -threads 2 -outfileprefix result4 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0, :maxtime => 12000
+      run_test "#{$bin}gt ltrdigest -threads 2 -outfileprefix result4 -trnas Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0, :maxtime => 12000
       grep(last_stderr, /option is deprecated. Please use/)
     end
   end
@@ -557,6 +568,7 @@ if $gttestdata then
   Name "gt ltrdigest PPT HMM parameters (background distribution, legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
+    FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
     run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     # probabilities do not add up to 1, sum > 0
     run_test "#{$bin}gt ltrdigest -ppttprob 0.3 -pptaprob 0.3 -pptgprob 0.9 -pptcprob 0.2 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
@@ -567,29 +579,31 @@ if $gttestdata then
     # probabilities do not add up to 1, sum < 0
     run_test "#{$bin}gt ltrdigest -ppttprob 0.1 -pptaprob 0.1 -pptgprob 0.2 -pptcprob 0.2 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     # positive test
-    run_test "#{$bin}gt ltrdigest -ppttprob 0.25 -pptaprob 0.25 -pptgprob 0.25 -pptcprob 0.25 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
+    run_test "#{$bin}gt ltrdigest -ppttprob 0.25 -pptaprob 0.25 -pptgprob 0.25 -pptcprob 0.25 -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3"
   end
 
   Name "gt ltrdigest PPT HMM parameters (U-box U frequency, legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
+    FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
     run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -pptuprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     run_test "#{$bin}gt ltrdigest -pptuprob 0.0 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
-    run_test "#{$bin}gt ltrdigest -pptuprob 0.91 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
+    run_test "#{$bin}gt ltrdigest -pptuprob 0.91 -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3"
   end
 
   Name "gt ltrdigest PPT HMM parameters (PPT R/Y frequencies, legacy syntax)"
   Keywords "gt_ltrdigest"
   Test do
+    FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
     run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -pptrprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     run_test "#{$bin}gt ltrdigest -pptyprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     run_test "#{$bin}gt ltrdigest -pptrprob 0.97 -pptyprob 0.03 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3"
-    run_test "#{$bin}gt ltrdigest -pptrprob 0.6 -pptyprob 0.4 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
+    run_test "#{$bin}gt ltrdigest -pptrprob 0.6 -pptyprob 0.4 -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3", :retval => 1
   end
 
@@ -608,8 +622,9 @@ if $gttestdata then
       Name "gt ltrdigest D. mel. #{chr} basic test w/ RT (legacy syntax)"
       Keywords "gt_ltrdigest"
       Test do
+        FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
         run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
-        run_test "#{$bin}gt ltrdigest -outfileprefix result#{chr} -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_test_Run9_#{chr}.gff3.sorted #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0, :maxtime => 12000
+        run_test "#{$bin}gt ltrdigest -outfileprefix result#{chr} -trnas Dm-tRNAs-uniq.fa -hmms #{$gttestdata}ltrdigest/hmms/RVT_1.hmm --  #{$gttestdata}ltrdigest/dmel_test_Run9_#{chr}.gff3.sorted #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0, :maxtime => 12000
         check_ppt_pbs(last_stdout, chr)
         #run "diff #{last_stdout} #{$gttestdata}ltrdigest/#{chr}_ref.gff3"
       end
@@ -617,8 +632,9 @@ if $gttestdata then
       Name "gt ltrdigest D. mel. #{chr} basic test, no HMM (legacy syntax)"
       Keywords "gt_ltrdigest"
       Test do
+        FileUtils.copy "#{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa", "."
         run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/#{chr}_genomic_dmel_RELEASE3-1.FASTA.gz", :maxtime => 600
-        run_test "#{$bin}gt -j 2 ltrdigest -outfileprefix result#{chr} -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_#{chr}.gff3.sorted #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz",\
+        run_test "#{$bin}gt -j 2 ltrdigest -outfileprefix result#{chr} -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_#{chr}.gff3.sorted #{chr}_genomic_dmel_RELEASE3-1.FASTA.gz",\
        :retval => 0, :maxtime => 700
         check_ppt_pbs(last_stdout, chr)
         #run "diff #{last_stdout} #{$gttestdata}ltrdigest/#{chr}_ref_noHMM.gff3"

--- a/testsuite/gt_ltrdigest_include.rb
+++ b/testsuite/gt_ltrdigest_include.rb
@@ -601,7 +601,7 @@ if $gttestdata then
     run_test "#{$bin}gt suffixerator -dna -des -ssp -tis -v -db #{$gttestdata}ltrharvest/d_mel/4_genomic_dmel_RELEASE3-1.FASTA.gz"
     run_test "#{$bin}gt ltrdigest -pptrprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
     run_test "#{$bin}gt ltrdigest -pptyprob 1.3 #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 1
-    run_test "#{$bin}gt ltrdigest -pptrprob 0.97 -pptyprob 0.03 -trnas #{$gttestdata}ltrdigest/Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
+    run_test "#{$bin}gt ltrdigest -pptrprob 0.97 -pptyprob 0.03 -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3"
     run_test "#{$bin}gt ltrdigest -pptrprob 0.6 -pptyprob 0.4 -trnas Dm-tRNAs-uniq.fa #{$gttestdata}ltrdigest/dmel_test_Run9_4.gff3.sorted 4_genomic_dmel_RELEASE3-1.FASTA.gz", :retval => 0
     #run "diff #{last_stdout} #{$gttestdata}ltrdigest/4_ref_noHMM.gff3", :retval => 1

--- a/testsuite/gt_md5_to_id_include.rb
+++ b/testsuite/gt_md5_to_id_include.rb
@@ -1,8 +1,12 @@
+require 'fileutils'
+
 Name "gt md5_to_id (U89959_sas.gff3, old)"
 Keywords "gt_md5_to_id"
 Test do
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
+  FileUtils.copy "#{$testdata}U89959_genomic.fas", "."
   run_test "#{$bin}gt md5_to_id -seqfiles " +
-           "#{$testdata}U89959_genomic.fas #{$testdata}U89959_ests.fas -- " +
+           "U89959_genomic.fas U89959_ests.fas -- " +
            "#{$testdata}U89959_sas.gff3md5old"
   run "diff #{last_stdout} #{$testdata}U89959_sas.gff3"
 end
@@ -17,8 +21,10 @@ end
 Name "gt md5_to_id (U89959_csas.gff3, old)"
 Keywords "gt_md5_to_id"
 Test do
+  FileUtils.copy "#{$testdata}U89959_ests.fas", "."
+  FileUtils.copy "#{$testdata}U89959_genomic.fas", "."
   run_test "#{$bin}gt md5_to_id -seqfiles " +
-           "#{$testdata}U89959_genomic.fas #{$testdata}U89959_ests.fas -- " +
+           "U89959_genomic.fas U89959_ests.fas -- " +
            "#{$testdata}U89959_csas.gff3md5old"
   run "diff #{last_stdout} #{$testdata}U89959_csas.gff3"
 end

--- a/testsuite/gt_mgth_include.rb
+++ b/testsuite/gt_mgth_include.rb
@@ -2,35 +2,45 @@ if $gttestdata then
   Name "gt mgth testdata mixed options 1"
   Keywords "gt_mgth"
   Test do
-    run_test "#{$bin}gt mgth -o Pyrococcus_NTo1_horikoshii -g yes -r 3 -e 3 -x yes -t yes #{$gttestdata}mgth/Pyrococcus_NTo1_horikoshii.xml.gz #{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz #{$gttestdata}mgth/Hits_NTo1_Pyrococcus_horikoshii.txt.gz", :maxtime => 200
+    FileUtils.copy "#{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz", "."
+    FileUtils.copy "#{$gttestdata}mgth/Hits_NTo1_Pyrococcus_horikoshii.txt.gz", "."
+    run_test "#{$bin}gt mgth -o Pyrococcus_NTo1_horikoshii -g yes -r 3 -e 3 -x yes -t yes #{$gttestdata}mgth/Pyrococcus_NTo1_horikoshii.xml.gz Pyrococcus_horikoshii.txt.gz Hits_NTo1_Pyrococcus_horikoshii.txt.gz", :maxtime => 200
     run "diff Pyrococcus_NTo1_horikoshii.xml #{$gttestdata}mgth/Pyrococcus_NTo1_horikoshii_ori_1.xml"
   end
 
   Name "gt mgth testdata mixed options 2"
   Keywords "gt_mgth"
   Test do
-    run_test "#{$bin}gt mgth -o Pyrococcus_NTo1_horikoshii -s 1.17 -n 3 -b -9.10 -q -3.0 -h -3.98 -l -1.3 -p 368 -f 217.0 -t yes -g yes -m yes -x yes -r 2 -e 3 -d 0.73 #{$gttestdata}mgth/Pyrococcus_NTo1_horikoshii.xml.gz #{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz #{$gttestdata}mgth/Hits_NTo1_Pyrococcus_horikoshii.txt.gz", :maxtime => 200
+    FileUtils.copy "#{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz", "."
+    FileUtils.copy "#{$gttestdata}mgth/Hits_NTo1_Pyrococcus_horikoshii.txt.gz", "."
+    run_test "#{$bin}gt mgth -o Pyrococcus_NTo1_horikoshii -s 1.17 -n 3 -b -9.10 -q -3.0 -h -3.98 -l -1.3 -p 368 -f 217.0 -t yes -g yes -m yes -x yes -r 2 -e 3 -d 0.73 #{$gttestdata}mgth/Pyrococcus_NTo1_horikoshii.xml.gz Pyrococcus_horikoshii.txt.gz Hits_NTo1_Pyrococcus_horikoshii.txt.gz", :maxtime => 200
     run "diff Pyrococcus_NTo1_horikoshii.html #{$gttestdata}mgth/Pyrococcus_NTo1_horikoshii_ori_2.html"
   end
 
   Name "gt mgth testdata mixed options 3"
   Keywords "gt_mgth"
   Test do
-    run_test "#{$bin}gt mgth -o Pyrococcus_NTo1_horikoshii -s 5 -n 3.5 -b -14.23 -q -2.88 -h -5 -l -0.75 -p 295.75 -f 300.20 -t yes -g yes -m no -x no -r 3 -e 2 -a 25 -d 0.2 #{$gttestdata}mgth/Pyrococcus_NTo1_horikoshii.xml.gz #{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz #{$gttestdata}mgth/Hits_NTo1_Pyrococcus_horikoshii.txt.gz", :maxtime => 200
+    FileUtils.copy "#{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz", "."
+    FileUtils.copy "#{$gttestdata}mgth/Hits_NTo1_Pyrococcus_horikoshii.txt.gz", "."
+    run_test "#{$bin}gt mgth -o Pyrococcus_NTo1_horikoshii -s 5 -n 3.5 -b -14.23 -q -2.88 -h -5 -l -0.75 -p 295.75 -f 300.20 -t yes -g yes -m no -x no -r 3 -e 2 -a 25 -d 0.2 #{$gttestdata}mgth/Pyrococcus_NTo1_horikoshii.xml.gz Pyrococcus_horikoshii.txt.gz Hits_NTo1_Pyrococcus_horikoshii.txt.gz", :maxtime => 200
     run "diff Pyrococcus_NTo1_horikoshii.xml #{$gttestdata}mgth/Pyrococcus_NTo1_horikoshii_ori_3.xml"
   end
 
   Name "gt mgth testdata mixed options 4"
   Keywords "gt_mgth"
   Test do
-    run_test "#{$bin}gt mgth -o Pyrococcus_horikoshii -s 3.17 -n 2.32 -b -13.64 -q -3.45 -h -4.77 -l -1.5 -p 325.50 -f 225.25 -t yes -g yes -m no -x yes -r 1 -e 1 -d 0.21  #{$gttestdata}mgth/Pyrococcus_horikoshii.xml.gz #{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz #{$gttestdata}mgth/Hits_Pyrococcus_horikoshii.txt.gz", :maxtime => 200
+    FileUtils.copy "#{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz", "."
+    FileUtils.copy "#{$gttestdata}mgth/Hits_Pyrococcus_horikoshii.txt.gz", "."
+    run_test "#{$bin}gt mgth -o Pyrococcus_horikoshii -s 3.17 -n 2.32 -b -13.64 -q -3.45 -h -4.77 -l -1.5 -p 325.50 -f 225.25 -t yes -g yes -m no -x yes -r 1 -e 1 -d 0.21  #{$gttestdata}mgth/Pyrococcus_horikoshii.xml.gz Pyrococcus_horikoshii.txt.gz Hits_Pyrococcus_horikoshii.txt.gz", :maxtime => 200
     run "diff Pyrococcus_horikoshii.txt #{$gttestdata}mgth/Pyrococcus_horikoshii_ori_4.txt"
   end
 
   Name "gt mgth testdata mixed options 5"
   Keywords "gt_mgth"
   Test do
-    run_test "#{$bin}gt mgth -o Pyrococcus_horikoshii -s 2.55 -n 4.77 -b -15 -q -3 -h -3.27 -l -1.2 -p 177.13 -f 123 -t yes -g yes -m no -x yes -r 2 -e 2 -d 0.05 #{$gttestdata}mgth/Pyrococcus_horikoshii.xml.gz #{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz #{$gttestdata}mgth/Hits_Pyrococcus_horikoshii.txt.gz", :maxtime => 200
+    FileUtils.copy "#{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz", "."
+    FileUtils.copy "#{$gttestdata}mgth/Hits_Pyrococcus_horikoshii.txt.gz", "."
+    run_test "#{$bin}gt mgth -o Pyrococcus_horikoshii -s 2.55 -n 4.77 -b -15 -q -3 -h -3.27 -l -1.2 -p 177.13 -f 123 -t yes -g yes -m no -x yes -r 2 -e 2 -d 0.05 #{$gttestdata}mgth/Pyrococcus_horikoshii.xml.gz Pyrococcus_horikoshii.txt.gz Hits_Pyrococcus_horikoshii.txt.gz", :maxtime => 200
     run "diff Pyrococcus_horikoshii.html #{$gttestdata}mgth/Pyrococcus_horikoshii_ori_5.html"
   end
 
@@ -38,38 +48,45 @@ if $gttestdata then
   Name "gt mgth testdata mixed options 6"
   Keywords "gt_mgth"
   Test do
-    run_test "#{$bin}gt mgth -o Pyrococcus_horikoshii -s 4.12 -n 2.9 -b -10 -q -7.5 -h -2 -l -0.5 -p 300 -f 211 -t yes -g yes -m no -x no -r 1 -e 3 -a 17 -d 0.13 #{$gttestdata}mgth/Pyrococcus_horikoshii.xml.gz #{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz #{$gttestdata}mgth/Hits_Pyrococcus_horikoshii.txt.gz", :maxtime => 100
+    FileUtils.copy "#{$gttestdata}mgth/Pyrococcus_horikoshii.txt.gz", "."
+    FileUtils.copy "#{$gttestdata}mgth/Hits_Pyrococcus_horikoshii.txt.gz", "."
+    run_test "#{$bin}gt mgth -o Pyrococcus_horikoshii -s 4.12 -n 2.9 -b -10 -q -7.5 -h -2 -l -0.5 -p 300 -f 211 -t yes -g yes -m no -x no -r 1 -e 3 -a 17 -d 0.13 #{$gttestdata}mgth/Pyrococcus_horikoshii.xml.gz Pyrococcus_horikoshii.txt.gz Hits_Pyrococcus_horikoshii.txt.gz", :maxtime => 100
     run "diff Pyrococcus_horikoshii.txt #{$gttestdata}mgth/Pyrococcus_horikoshii_ori_6.txt"
   end
 
   Name "gt mgth testdata mixed options 7"
   Keywords "gt_mgth"
   Test do
-    run_test "#{$bin}gt mgth -o Metagenome -s 3.17 -n 2.32 -b -13.64 -q -3.45 -h -4.77 -l -1.5 -p 325.50 -f 225.25 -t yes -g yes -m no -x yes -r 1 -e 1 -d 0.01 #{$gttestdata}mgth/Metagenome_NT.xml.gz #{$gttestdata}mgth/Metagenome.txt.gz #{$gttestdata}mgth/Hits_NT_Metagenome.txt.gz", :maxtime => 3200
+    FileUtils.copy "#{$gttestdata}mgth/Metagenome.txt.gz", "."
+    FileUtils.copy "#{$gttestdata}mgth/Hits_NT_Metagenome.txt.gz", "."
+    run_test "#{$bin}gt mgth -o Metagenome -s 3.17 -n 2.32 -b -13.64 -q -3.45 -h -4.77 -l -1.5 -p 325.50 -f 225.25 -t yes -g yes -m no -x yes -r 1 -e 1 -d 0.01 #{$gttestdata}mgth/Metagenome_NT.xml.gz Metagenome.txt.gz Hits_NT_Metagenome.txt.gz", :maxtime => 3200
     run "diff Metagenome.txt #{$gttestdata}mgth/Metagenome_ori_1.txt"
   end
 
   Name "gt mgth testdata mixed options 8"
   Keywords "gt_mgth"
   Test do
-    run_test "#{$bin}gt mgth -o Metagenome -s 1.17 -n 3 -b -9.10 -q -3.0 -h -3.98 -l -1.3 -p 368 -f 217.0 -t yes -g yes -m no -x yes -r 2 -e 3 -d 0.05  #{$gttestdata}mgth/Metagenome_NTo1.xml.gz #{$gttestdata}mgth/Metagenome.txt.gz #{$gttestdata}mgth/Hits_NTo1_Metagenome.txt.gz", :maxtime => 3200
+    FileUtils.copy "#{$gttestdata}mgth/Metagenome.txt.gz", "."
+    FileUtils.copy "#{$gttestdata}mgth/Hits_NTo1_Metagenome.txt.gz", "."
+    run_test "#{$bin}gt mgth -o Metagenome -s 1.17 -n 3 -b -9.10 -q -3.0 -h -3.98 -l -1.3 -p 368 -f 217.0 -t yes -g yes -m no -x yes -r 2 -e 3 -d 0.05  #{$gttestdata}mgth/Metagenome_NTo1.xml.gz Metagenome.txt.gz Hits_NTo1_Metagenome.txt.gz", :maxtime => 3200
     run "diff Metagenome.html #{$gttestdata}mgth/Metagenome_ori_2.html"
   end
 
   Name "gt mgth testdata mixed options 9"
   Keywords "gt_mgth"
   Test do
-    run_test "#{$bin}gt mgth -o Metagenome_454 -s 3.17 -n 2.32 -b -13.64 -q -3.45 -h -4.77 -l -1.5 -p 325.50 -f 225.25 -t yes -g yes -m no -x yes -r 1 -e 1 -d 0.01  #{$gttestdata}mgth/Metagenome_NT_454.xml.gz #{$gttestdata}mgth/Metagenome_454.txt.gz #{$gttestdata}mgth/Hits_NT_Metagenome_454.txt.gz", :maxtime => 3200
+    FileUtils.copy "#{$gttestdata}mgth/Metagenome_454.txt.gz", "."
+    FileUtils.copy "#{$gttestdata}mgth/Hits_NT_Metagenome_454.txt.gz", "."
+    run_test "#{$bin}gt mgth -o Metagenome_454 -s 3.17 -n 2.32 -b -13.64 -q -3.45 -h -4.77 -l -1.5 -p 325.50 -f 225.25 -t yes -g yes -m no -x yes -r 1 -e 1 -d 0.01  #{$gttestdata}mgth/Metagenome_NT_454.xml.gz Metagenome_454.txt.gz Hits_NT_Metagenome_454.txt.gz", :maxtime => 3200
     run "diff Metagenome_454.txt #{$gttestdata}mgth/Metagenome_454_ori_3.txt"
   end
 
   Name "gt mgth testdata mixed options 10"
   Keywords "gt_mgth"
   Test do
-    run_test "#{$bin}gt mgth -o Metagenome_454 -s 1.17 -n 3 -b -9.10 -q -3.0 -h -3.98 -l -1.3 -p 368 -f 217.0 -t yes -g yes -m no -x yes -r 2 -e 3 -d 0.05  #{$gttestdata}mgth/Metagenome_NTo1_454.xml.gz #{$gttestdata}mgth/Metagenome_454.txt.gz #{$gttestdata}mgth/Hits_NTo1_Metagenome_454.txt.gz", :maxtime => 3200
+    FileUtils.copy "#{$gttestdata}mgth/Metagenome_454.txt.gz", "."
+    FileUtils.copy "#{$gttestdata}mgth/Hits_NTo1_Metagenome_454.txt.gz", "."
+    run_test "#{$bin}gt mgth -o Metagenome_454 -s 1.17 -n 3 -b -9.10 -q -3.0 -h -3.98 -l -1.3 -p 368 -f 217.0 -t yes -g yes -m no -x yes -r 2 -e 3 -d 0.05  #{$gttestdata}mgth/Metagenome_NTo1_454.xml.gz Metagenome_454.txt.gz Hits_NTo1_Metagenome_454.txt.gz", :maxtime => 3200
     run "diff Metagenome_454.html #{$gttestdata}mgth/Metagenome_454_ori_4.html"
-    run "rm -f #{$gttestdata}mgth/*.des #{$gttestdata}mgth/*.esq " + \
-        "#{$gttestdata}mgth/*.md5 #{$gttestdata}mgth/*.ois " + \
-        "#{$gttestdata}mgth/*.sds #{$gttestdata}mgth/*.ssp"
   end
 end

--- a/testsuite/gt_scripts_include.rb
+++ b/testsuite/gt_scripts_include.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 Name "arg passing test 1"
 Keywords "gt_scripts"
 Test do
@@ -33,8 +35,9 @@ end
   Name "cds_stream bindings #{i}"
   Keywords "gt_scripts"
   Test do
+    FileUtils.copy "#{$testdata}gt_cds_test_#{i}.fas", "."
     run_test "#{$bin}gt  #{$testdata}gtscripts/cds_stream.lua " +
-             "#{$testdata}gt_cds_test_#{i}.fas " +
+             "gt_cds_test_#{i}.fas " +
              "#{$testdata}gt_cds_test_#{i}.in"
     run "sed 's/gtscript/gt cds/' #{last_stdout}"
     run "diff #{last_stdout} #{$testdata}gt_cds_test_#{i}.out"

--- a/testsuite/gt_seq_include.rb
+++ b/testsuite/gt_seq_include.rb
@@ -10,7 +10,8 @@ end
   Name "gt seq fail #{i}"
   Keywords "gt_seq"
   Test do
-    run_test("#{$bin}gt seq -recreate #{$testdata}gt_bioseq_fail_#{i}.fas",
+    FileUtils.copy "#{$testdata}gt_bioseq_fail_#{i}.fas", "."
+    run_test("#{$bin}gt seq -recreate gt_bioseq_fail_#{i}.fas",
              :retval => 1)
   end
 end
@@ -26,8 +27,9 @@ end
 Name "gt seq (DOS line breaks)"
 Keywords "gt_seq"
 Test do
+  FileUtils.copy "#{$testdata}tRNA.dos.fas", "."
   run "#{$scriptsdir}dos2unix #{$testdata}tRNA.dos.fas > ./tRNA.unix.fas"
-  run_test "#{$bin}gt seq -showfasta -width 60 #{$testdata}tRNA.dos.fas"
+  run_test "#{$bin}gt seq -showfasta -width 60 tRNA.dos.fas"
   run "diff #{last_stdout} tRNA.unix.fas"
   run "diff #{last_stdout} #{$testdata}tRNA.dos.fas", :retval => 1
 end
@@ -93,7 +95,8 @@ end
 Name "gt seq test 3"
 Keywords "gt_seq"
 Test do
-  run_test "#{$bin}gt seq -recreate -showfasta -width 70 #{$testdata}gt_bioseq_succ_3.fas"
+  FileUtils.copy("#{$testdata}gt_bioseq_succ_3.fas", ".")
+  run_test "#{$bin}gt seq -recreate -showfasta -width 70 gt_bioseq_succ_3.fas"
   run "diff #{last_stdout} #{$testdata}gt_bioseq_succ_3.fas"
 end
 
@@ -126,7 +129,8 @@ end
 Name "gt seq test 3 out 4 fail"
 Keywords "gt_seq"
 Test do
-  run_test("#{$bin}gt seq -showseqnum 4 #{$testdata}gt_bioseq_succ_3.fas",
+  FileUtils.copy("#{$testdata}gt_bioseq_succ_3.fas", ".")
+  run_test("#{$bin}gt seq -showseqnum 4 gt_bioseq_succ_3.fas",
            :retval => 1)
 end
 
@@ -154,7 +158,8 @@ end
 Name "gt seq test multiple sequence files (incl. stdin)"
 Keywords "gt_seq"
 Test do
-  run "cat #{$testdata}gt_bioseq_succ_2.fas | #{$memcheck} #{$bin}gt seq -recreate #{$testdata}gt_bioseq_succ_1.fas -"
+  FileUtils.copy("#{$testdata}gt_bioseq_succ_1.fas", ".")
+  run "cat #{$testdata}gt_bioseq_succ_2.fas | #{$memcheck} #{$bin}gt seq -recreate gt_bioseq_succ_1.fas -"
 end
 
 Name "gt seq -gc-content"
@@ -167,7 +172,8 @@ end
 Name "gt seq -seqlengthdistri"
 Keywords "gt_seq"
 Test do
-  run_test "#{$bin}gt seq -seqlengthdistri #{$testdata}sw100K1.fsa"
+  FileUtils.copy("#{$testdata}sw100K1.fsa", ".")
+  run_test "#{$bin}gt seq -seqlengthdistri sw100K1.fsa"
   run "diff #{last_stdout} #{$testdata}gt_bioseq_seqlengthdistri.out"
 end
 

--- a/testsuite/gt_splicesiteinfo_include.rb
+++ b/testsuite/gt_splicesiteinfo_include.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 Name "gt splicesiteinfo -help"
 Keywords "gt_splicesiteinfo"
 Test do
@@ -22,35 +24,40 @@ end
 Name "gt splicesiteinfo test 1"
 Keywords "gt_splicesiteinfo"
 Test do
-  run_test "#{$bin}gt splicesiteinfo -seqfile #{$testdata}gt_splicesiteinfo_test_1.fas -matchdesc #{$testdata}gt_splicesiteinfo_test_1.gff3"
+  FileUtils.copy "#{$testdata}gt_splicesiteinfo_test_1.fas", "."
+  run_test "#{$bin}gt splicesiteinfo -seqfile gt_splicesiteinfo_test_1.fas -matchdesc #{$testdata}gt_splicesiteinfo_test_1.gff3"
   run "diff #{last_stdout} #{$testdata}gt_splicesiteinfo_test_1.out"
 end
 
 Name "gt splicesiteinfo test 2"
 Keywords "gt_splicesiteinfo"
 Test do
-  run_test "#{$bin}gt splicesiteinfo -seqfile #{$testdata}gt_splicesiteinfo_test_2.fas -matchdesc #{$testdata}gt_splicesiteinfo_test_2.gff3"
+  FileUtils.copy "#{$testdata}gt_splicesiteinfo_test_2.fas", "."
+  run_test "#{$bin}gt splicesiteinfo -seqfile gt_splicesiteinfo_test_2.fas -matchdesc #{$testdata}gt_splicesiteinfo_test_2.gff3"
   run "diff #{last_stdout} #{$testdata}gt_splicesiteinfo_test_2.out"
 end
 
 Name "gt splicesiteinfo test 3"
 Keywords "gt_splicesiteinfo"
 Test do
-  run_test "#{$bin}gt splicesiteinfo -seqfile #{$testdata}gt_splicesiteinfo_test_1.fas -matchdesc #{$testdata}gt_splicesiteinfo_test_3.gff3"
+  FileUtils.copy "#{$testdata}gt_splicesiteinfo_test_1.fas", "."
+  run_test "#{$bin}gt splicesiteinfo -seqfile gt_splicesiteinfo_test_1.fas -matchdesc #{$testdata}gt_splicesiteinfo_test_3.gff3"
   grep last_stderr, "unknown orientation"
 end
 
 Name "gt splicesiteinfo test 4"
 Keywords "gt_splicesiteinfo"
 Test do
-  run_test "#{$bin}gt splicesiteinfo -seqfile #{$testdata}gt_splicesiteinfo_test_4.fas -matchdesc #{$testdata}gt_splicesiteinfo_test_4.gff3"
+  FileUtils.copy "#{$testdata}gt_splicesiteinfo_test_4.fas", "."
+  run_test "#{$bin}gt splicesiteinfo -seqfile gt_splicesiteinfo_test_4.fas -matchdesc #{$testdata}gt_splicesiteinfo_test_4.gff3"
   run "diff #{last_stdout} #{$testdata}gt_splicesiteinfo_test_4.out"
 end
 
 Name "gt splicesiteinfo test 5 (-addintrons)"
 Keywords "gt_splicesiteinfo"
 Test do
-  run_test "#{$bin}gt splicesiteinfo -addintrons -seqfile #{$testdata}gt_splicesiteinfo_test_5.fas -matchdesc #{$testdata}gt_splicesiteinfo_test_5.gff3"
+  FileUtils.copy "#{$testdata}gt_splicesiteinfo_test_5.fas", "."
+  run_test "#{$bin}gt splicesiteinfo -addintrons -seqfile gt_splicesiteinfo_test_5.fas -matchdesc #{$testdata}gt_splicesiteinfo_test_5.gff3"
   run "diff #{last_stdout} #{$testdata}gt_splicesiteinfo_test_5.out"
 end
 
@@ -76,8 +83,9 @@ end
 Name "gt splicesiteinfo error message"
 Keywords "gt_splicesiteinfo"
 Test do
+  FileUtils.copy "#{$testdata}gt_splicesiteinfo_test_1.fas", "."
   run "#{$bin}gt gff3 -offset 1000 #{$testdata}gt_splicesiteinfo_test_1.gff3 " +
       "| #{$bin}gt splicesiteinfo -seqfile " +
-      "#{$testdata}gt_splicesiteinfo_test_1.fas -matchdesc ", :retval => 1
+      "gt_splicesiteinfo_test_1.fas -matchdesc ", :retval => 1
   grep last_stderr, "Has the sequence-region to sequence mapping been defined correctly"
 end

--- a/testsuite/gt_splitfasta_include.rb
+++ b/testsuite/gt_splitfasta_include.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 Name "gt splitfasta (default)"
 Keywords "gt_splitfasta"
 Test do
@@ -92,7 +94,8 @@ end
 Name "gt splitfasta (-splitdesc)"
 Keywords "gt_splitfasta"
 Test do
-  run_test "#{$bin}gt splitfasta -splitdesc . #{$testdata}foobar.fas"
+  FileUtils.copy "#{$testdata}foobar.fas", "."
+  run_test "#{$bin}gt splitfasta -splitdesc . foobar.fas"
   if not File.exists?("foo.fas") then
     raise TestFailed, "file 'foo.fas' does not exist"
   end
@@ -104,8 +107,9 @@ end
 Name "gt splitfasta (-splitdesc, file exists)"
 Keywords "gt_splitfasta"
 Test do
+  FileUtils.copy "#{$testdata}foobar.fas", "."
   run "touch foo.fas"
-  run_test("#{$bin}gt splitfasta -splitdesc . #{$testdata}foobar.fas",
+  run_test("#{$bin}gt splitfasta -splitdesc . foobar.fas",
            :retval => 1)
   grep last_stderr, /exists already/
 end
@@ -113,8 +117,9 @@ end
 Name "gt splitfasta (-splitdesc -force)"
 Keywords "gt_splitfasta"
 Test do
+  FileUtils.copy "#{$testdata}foobar.fas", "."
   run "touch foo.fas"
-  run_test "#{$bin}gt splitfasta -force -splitdesc . #{$testdata}foobar.fas"
+  run_test "#{$bin}gt splitfasta -force -splitdesc . foobar.fas"
   if not File.exists?("foo.fas") then
     raise TestFailed, "file 'foo.fas' does not exist"
   end


### PR DESCRIPTION
**Issue**: *make test* produces several index files in testdata and gttestdata (sub-)directories. 
When threaded tests produce the same files simultaneously, there can occur write conflicts. 
[testdata_modifications.txt](https://github.com/genometools/genometools/files/5113/testdata_modifications.txt)
**Solution**: Intermediate files are created only in the test's working directory. 