### PR TITLE
adjust spacecalc macros

### DIFF
--- a/src/core/spacecalc.h
+++ b/src/core/spacecalc.h
@@ -19,12 +19,12 @@
 #define SPACECALC_H
 
 #define GT_KILOBYTES(V) \
-        ((double) (V)/((1UL << 10) - 1))
+        ((double) (V)/(1UL << 10))
 
 #define GT_MEGABYTES(V) \
-        ((double) (V)/((1UL << 20) - 1))
+        ((double) (V)/(1UL << 20))
 
 #define GT_GIGABYTES(V) \
-        ((double) (V)/((1UL << 30) - 1))
+        ((double) (V)/(1UL << 30))
 
 #endif


### PR DESCRIPTION
As @stefan-kurtz pointed out, I can't recollect why the strange divisors (minus one) were used to convert space values to KB/MB/GB. Making these more straightforward.