### PR TITLE
initialize variables

### DIFF
--- a/src/extended/diagonalbandalign_affinegapcost.c
+++ b/src/extended/diagonalbandalign_affinegapcost.c
@@ -758,7 +758,7 @@ static Rnode evaluateallaffineDBcolumns(LinspaceManagement *spacemanager,
   AffinealignDPentry *Atabcolumn, northwestAffinealignDPentry,
   westAffinealignDPentry = (AffinealignDPentry)
                            {GT_WORD_MAX, GT_WORD_MAX, GT_WORD_MAX};;
-  Rtabentry *Rtabcolumn, northwestRtabentry, westRtabentry;
+  Rtabentry *Rtabcolumn, northwestRtabentry, westRtabentry = {{0}} ;
   Rnode lastcpoint = {GT_UWORD_MAX, Affine_X};
 
   if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||

--- a/src/extended/linearalign_affinegapcost.c
+++ b/src/extended/linearalign_affinegapcost.c
@@ -818,7 +818,7 @@ static void nextAStabcolumn(AffinealignDPentry *Atabcolumn,
   Starttabentry Snw, Swe;
   GtUword rowindex;
   GtWord gap_extension, gap_opening, replacement, temp, val1, val2;
-  GtUwordPair start;
+  GtUwordPair start = {0};
 
   gap_opening = gt_scorehandler_get_gap_opening(scorehandler);
   gap_extension = gt_scorehandler_get_gapscore(scorehandler);


### PR DESCRIPTION
fix warning from i686-apple-darwin10-gcc-4.2.1