### PR TITLE
Update gt_convertseq.c

### DIFF
--- a/src/tools/gt_convertseq.c
+++ b/src/tools/gt_convertseq.c
@@ -228,12 +228,13 @@ static int gt_convertseq_runner(int argc, const char **argv, int parsed_args,
             gt_file_xfputc((int) seq[i], arguments->outfp);
             j++;
           }
-          if ((j % arguments->fastawidth) == 0) {
+          if (arguments->fastawidth > 0 && j % arguments->fastawidth == 0) {
             j = 0;
             gt_file_xprintf(arguments->outfp, "\n");
           }
         }
-        gt_file_xprintf(arguments->outfp, "\n");
+        if (arguments->fastawidth == 0 || len % arguments->fastawidth != 0)
+            gt_file_xprintf(arguments->outfp, "\n");
       }
       if (arguments->revcomp) {
         gt_free(seq);


### PR DESCRIPTION
'Breaks' for fastawidth = 0 ("x % 0") or 60 (prints an extra newline). Candidate fixes to get around this.