### PR TITLE
spelling fix: occurence -> occurrence

### DIFF
--- a/src/core/cstr_api.h
+++ b/src/core/cstr_api.h
@@ -39,7 +39,7 @@ char**  gt_cstr_split(const char *cstr, char sep);
    be given. */
 char*   gt_cstr_dup_nt(const char *cstr, GtUword length);
 
-/* Replace each occurence of <f> in <cstr> to <t>. */
+/* Replace each occurrence of <f> in <cstr> to <t>. */
 void    gt_cstr_rep(char *cstr, char f, char t);
 
 /* Outputs the first <length> characters of the string <cstr> to file pointer

--- a/src/core/radix_sort.c
+++ b/src/core/radix_sort.c
@@ -84,7 +84,7 @@ static void gt_radixsort_lsb_linear_phase(GtUword *count,
 {
   GtUword idx, *cptr, *countptr, *sptr;
 
-  /* count occurences of every byte value */
+  /* count occurrences of every byte value */
   countptr = count;
   for (cptr = countptr; cptr <= countptr + UINT8_MAX; cptr++)
   {

--- a/src/match/eis-bwtseq.h
+++ b/src/match/eis-bwtseq.h
@@ -158,7 +158,7 @@ static inline GtUword
 BWTSeqTerminatorPos(const BWTSeq *bwtSeq);
 
 /**
- * \brief Query BWT sequence for the number of occurences of a symbol in a
+ * \brief Query BWT sequence for the number of occurrences of a symbol in a
  * given prefix.
  * @param bwtSeq reference of object to query
  * @param tSym transformed symbol (as obtained by
@@ -170,7 +170,7 @@ static inline GtUword
 BWTSeqTransformedOcc(const BWTSeq *bwtSeq, Symbol tSym, GtUword pos);
 
 /**
- * \brief Query BWT sequence for the number of occurences of a symbol in a
+ * \brief Query BWT sequence for the number of occurrences of a symbol in a
  * given prefix.
  * @param bwtSeq reference of object to query
  * @param sym symbol (from original alphabet)
@@ -181,7 +181,7 @@ static inline GtUword
 BWTSeqOcc(const BWTSeq *bwtSeq, Symbol sym, GtUword pos);
 
 /**
- * \brief Query BWT sequence for the number of occurences of a symbol
+ * \brief Query BWT sequence for the number of occurrences of a symbol
  * in two given prefixes.
  * @param bwtSeq reference of object to query
  * @param tSym transformed symbol (as obtained by
@@ -196,7 +196,7 @@ BWTSeqTransformedPosPairOcc(const BWTSeq *bwtSeq, Symbol tSym,
                             GtUword posA, GtUword posB);
 
 /**
- * \brief Query BWT sequence for the number of occurences of a symbol
+ * \brief Query BWT sequence for the number of occurrences of a symbol
  * in two given prefixes.
  * @param bwtSeq reference of object to query
  * @param sym symbol (from original alphabet)
@@ -210,7 +210,7 @@ BWTSeqPosPairOcc(const BWTSeq *bwtSeq, Symbol sym,
                  GtUword posA, GtUword posB);
 
 /**
- * \brief Query BWT sequence for the number of occurences of all symbols in a
+ * \brief Query BWT sequence for the number of occurrences of all symbols in a
  * given alphabet range and BWT sequence prefix.
  * @param bwtSeq reference of object to query
  * @param range range of symbols in alphabet to query
@@ -229,7 +229,7 @@ BWTSeqRangeOcc(const BWTSeq *bwtSeq, AlphabetRangeID range, GtUword pos,
    GtUword rangeOcc[4]; */
 
 /**
- * \brief Query BWT sequence for the number of occurences of all symbols in a
+ * \brief Query BWT sequence for the number of occurrences of all symbols in a
  * given alphabet range and two BWT sequence prefixes.
  * @param bwtSeq reference of object to query
  * @param range range of symbols in alphabet to query

--- a/src/match/eis-encidxseq.h
+++ b/src/match/eis-encidxseq.h
@@ -165,7 +165,7 @@ EISGetAlphabet(const EISeq *seq);
  * but not including given position.
  * @param seq sequence index object to query
  * @param sym original alphabet symbol to query occurrences of
- * @param pos occurences are counted up to this position
+ * @param pos occurrences are counted up to this position
  * @param hint provides cache and direction information for queries
  * based on previous queries
  */
@@ -178,7 +178,7 @@ EISRank(EISeq *seq, Symbol sym, GtUword pos, union EISHint *hint);
  * @param seq sequence index object to query
  * @param tSym symbol to query occurrences of, but already transformed
  * by input alphabet
- * @param pos occurences are counted up to this position
+ * @param pos occurrences are counted up to this position
  * @param hint provides cache and direction information for queries
  * based on previous queries
  */
@@ -193,8 +193,8 @@ EISSymTransformedRank(EISeq *seq, Symbol tSym, GtUword pos,
  * precondition: posA <= posB
  * @param seq sequence index object to query
  * @param sym original alphabet symbol to query occurrences of
- * @param posA occurences are counted up to this position
- * @param posB as for posA occurences are counted up to this position
+ * @param posA occurrences are counted up to this position
+ * @param posB as for posA occurrences are counted up to this position
  * @param hint provides cache and direction information for queries
  * based on previous queries
  * @return members a and b of returned struct contain Occ results for
@@ -212,8 +212,8 @@ EISPosPairRank(EISeq *seq, Symbol sym, GtUword posA, GtUword posB,
  * @param seq sequence index object to query
  * @param tSym symbol to query occurrences of, but already transformed
  * by input alphabet
- * @param posA occurences are counted up to this position
- * @param posB as for posA occurences are counted up to this position
+ * @param posA occurrences are counted up to this position
+ * @param posB as for posA occurrences are counted up to this position
  * @param hint provides cache and direction information for queries
  * based on previous queries
  * @return members a and b of returned struct contain Occ results for
@@ -229,7 +229,7 @@ EISSymTransformedPosPairRank(EISeq *seq, Symbol tSym, GtUword posA,
  *
  * @param seq sequence index object to query
  * @param range compute rank counts for all symbols in this range
- * @param pos occurences are counted up to (but not including) this position
+ * @param pos occurrences are counted up to (but not including) this position
  * @param rankCounts ranks for all symbols in range are written to this
  * array. The referenced memory must be sized appropriately to
  * accomodate as many symbols as are in range (MRAEncGetRangeSize if
@@ -248,8 +248,8 @@ EISRangeRank(EISeq *seq, AlphabetRangeID range, GtUword pos,
  *
  * @param seq sequence index object to query
  * @param range compute rank counts for all symbols in this range
- * @param posA occurences are counted up to (but not including) this position
- * @param posB occurences are counted up to (but not including) this position
+ * @param posA occurrences are counted up to (but not including) this position
+ * @param posB occurrences are counted up to (but not including) this position
  * @param rankCounts ranks for all symbols in range are written to this
  * array. The referenced memory must be sized appropriately to
  * accomodate two-times as many positions symbols as are in range

--- a/src/match/eis-voiditf.h
+++ b/src/match/eis-voiditf.h
@@ -168,7 +168,7 @@ GtUword gt_pck_get_nonspecial_count(const FMindex *index);
  * that is the number of rows that would be extended with a special. */
 GtUword gt_pck_special_occ_in_nonspecial_intervals(const FMindex *index);
 
-/* counts the exact occurences of pattern in index returns 0 if pattern is not
+/* counts the exact occurrences of pattern in index returns 0 if pattern is not
  found */
 GtUword gt_pck_exact_pattern_count(const FMindex *index,
                                          const GtUchar *pattern,

--- a/src/tools/gt_condenseq_compress.c
+++ b/src/tools/gt_condenseq_compress.c
@@ -126,7 +126,7 @@ gt_condenseq_compress_option_parser_new(void *tool_arguments)
                                "it will be ignored for alignment searches. "
                                "Setting this to 0 will disable cutoffs, "
                                "leaving it undefined will use a cutoff based "
-                               "on the mean number of occurences of a k-word.",
+                               "on the mean number of occurrences of a k-word.",
                                &arguments->cutoff_value, GT_UNDEF_UWORD);
   gt_option_is_extended_option(option);
   gt_option_parser_add_option(op, option);

--- a/www/genometools.org/htdocs/libgenometools.html
+++ b/www/genometools.org/htdocs/libgenometools.html
@@ -9199,7 +9199,7 @@ Creates a duplicate of string <code>cstr</code> using the <em>GenomeTools</em> m
 
 <code>void     gt_cstr_rep(char *cstr, char f, char t)</code>
 <p>
-Replace each occurence of <code>f</code> in <code>cstr</code> to <code>t</code>.
+Replace each occurrence of <code>f</code> in <code>cstr</code> to <code>t</code>.
 </p>
 <hr>
 <a name="gt_cstr_show"></a>


### PR DESCRIPTION
This PR changes the misspelled word 'occurence' to 'occurrence'. Debian's lintian complains about this. 