### PR TITLE
Parse ID/LOCUS lines in EMBL/GenBank sequence input

### DIFF
--- a/testdata/embl_test5.fas
+++ b/testdata/embl_test5.fas
@@ -1,4 +1,4 @@
->Trifolium repens mRNA for non-cyanogenic beta-glucosidase
+>X56734 Trifolium repens mRNA for non-cyanogenic beta-glucosidase
 aaacaaaccaaatatggattttattgtagccatatttgctctgtttgttattagctcatt
 cacaattacttccacaaatgcagttgaagcttctactcttcttgacataggtaacctgag
 tcggagcagttttcctcgtggcttcatctttggtgctggatcttcagcataccaatttga

--- a/testdata/genbank_test2.fas
+++ b/testdata/genbank_test2.fas
@@ -1,4 +1,4 @@
->AF078689 Arabidopsis thaliana library (Tan K) Arabidopsis thaliana cDNA clone IFA2, mRNA sequence.
+>AF078689 AF078689 Arabidopsis thaliana library (Tan K) Arabidopsis thaliana cDNA clone IFA2, mRNA sequence.
 antnnctacnncnncnntnncnncnatnnaantanacnnatnntnntannaatnaaannc
 tanaancnncnnanaantatntnnataanaaataacaaaaactnannnnatcatnaantt
 cttcnttatattatanttttcaatctnaatttcaattccnccnctcncctttttcctctc

--- a/testdata/shorten_desc.clipped.fas
+++ b/testdata/shorten_desc.clipped.fas
@@ -1,10 +1,10 @@
->test1
+>sequence0
 aaaaaaaaaaaaaaaaaaaaaaaaa
->test2
+>sequence1
 cccccccccccccc
->test3
+>sequence2
 ggggggggggggggggggggggg
->test4
+>sequence3
 cgcgcg
->
+>sequence4
 atattttttt

--- a/testdata/shorten_desc.embl
+++ b/testdata/shorten_desc.embl
@@ -1,4 +1,4 @@
-ID   sequence0
+ID   sequence0;;;;;; 25 BP.
 XX
 DE   test1 foo bar
 XX
@@ -6,7 +6,7 @@ SQ
      AAAAAAAAAA AAAAAAAAAA AAAAA                                              25
 //
 
-ID   sequence1
+ID   sequence1;;;;;; 14 BP.
 XX
 DE   test2 bar baz
 XX
@@ -14,7 +14,7 @@ SQ
      CCCCCCCCCC CCCC                                                          14
 //
 
-ID   sequence2
+ID   sequence2;;;;;; 23 BP.
 XX
 DE   test3 baz quux
 XX
@@ -22,7 +22,7 @@ SQ
      GGGGGGGGGG GGGGGGGGGG GGG                                                23
 //
 
-ID   sequence3
+ID   sequence3;;;;;; 6 BP.
 XX
 DE   test4
 XX
@@ -30,7 +30,7 @@ SQ
      CGCGCG                                                                    6
 //
 
-ID   sequence4
+ID   sequence4;;;;;; 10 BP.
 XX
 DE   
 XX

--- a/testdata/shorten_desc.fas
+++ b/testdata/shorten_desc.fas
@@ -1,10 +1,10 @@
->test1 foo bar
+>sequence0 test1 foo bar
 AAAAAAAAAAAAAAAAAAAAAAAAA
->test2 bar baz
+>sequence1 test2 bar baz
 CCCCCCCCCCCCCC
->test3 baz quux
+>sequence2 test3 baz quux
 GGGGGGGGGGGGGGGGGGGGGGG
->test4
+>sequence3 test4
 CGCGCG
-> 
+>sequence4
 ATATTTTTTT


### PR DESCRIPTION
This PR makes the EMBL and GenBank parsers recognize `ID` and `LOCUS` lines,  like they would be needed if there is no `DE`scription. The IDs will be the first part of the parsed header, and the description will be concatenated to it, with a space in between.