### PR TITLE
Sk Add sorting option for gt dev show_seedext

### DIFF
--- a/scripts/all-vs-all.sh
+++ b/scripts/all-vs-all.sh
@@ -13,7 +13,10 @@ do
     for mode in "" -seed-display
     do
       bin/gt seed_extend $mode -v -ii ref-index -maxfreq 20 -qii query-index > tmp.matches
+      bin/gt dev show_seedext -a -f tmp.matches
+      bin/gt dev show_seedext -e -f tmp.matches
       bin/gt dev show_seedext -a -f tmp.matches -sort
+      bin/gt dev show_seedext -e -f tmp.matches -sort
       bin/gt dev show_seedext -f tmp.matches -sort | ascQorder.rb -c
     done
   done

--- a/scripts/all-vs-all.sh
+++ b/scripts/all-vs-all.sh
@@ -13,7 +13,7 @@ do
     for mode in "" -seed-display
     do
       bin/gt seed_extend $mode -v -ii ref-index -maxfreq 20 -qii query-index > tmp.matches
-      bin/gt dev show_seedext -f tmp.matches -sort | ascQorder.rb -c
+      bin/gt dev show_seedext -a -f tmp.matches -sort
     done
   done
 done

--- a/scripts/all-vs-all.sh
+++ b/scripts/all-vs-all.sh
@@ -14,6 +14,7 @@ do
     do
       bin/gt seed_extend $mode -v -ii ref-index -maxfreq 20 -qii query-index > tmp.matches
       bin/gt dev show_seedext -a -f tmp.matches -sort
+      bin/gt dev show_seedext -f tmp.matches -sort | ascQorder.rb -c
     done
   done
 done

--- a/scripts/all-vs-all.sh
+++ b/scripts/all-vs-all.sh
@@ -10,7 +10,10 @@ do
   for query in `${GTDIR}/scripts/findfasta.rb -n -e ${excludelist}`
   do
     bin/gt encseq encode -indexname query-index ${query}
-    bin/gt seed_extend -v -ii ref-index -seed-display -maxfreq 20 -qii query-index > tmp.matches
-    bin/gt dev show_seedext -f tmp.matches -sort | ascQorder.rb -c
+    for mode in "" -seed-display
+    do
+      bin/gt seed_extend $mode -v -ii ref-index -maxfreq 20 -qii query-index > tmp.matches
+      bin/gt dev show_seedext -f tmp.matches -sort | ascQorder.rb -c
+    done
   done
 done

--- a/scripts/all-vs-all.sh
+++ b/scripts/all-vs-all.sh
@@ -10,7 +10,7 @@ do
   for query in `${GTDIR}/scripts/findfasta.rb -n -e ${excludelist}`
   do
     bin/gt encseq encode -indexname query-index ${query}
-    bin/gt seed_extend -v -ii ref-index -maxfreq 20 -qii query-index > tmp.matches
-    scripts/ascQorder.rb tmp.matches | scripts/ascQorder.rb -c
+    bin/gt seed_extend -v -ii ref-index -seed-display -maxfreq 20 -qii query-index > tmp.matches
+    bin/gt dev show_seedext -f tmp.matches -sort | ascQorder.rb -c
   done
 done

--- a/src/core/mathsupport.c
+++ b/src/core/mathsupport.c
@@ -127,7 +127,7 @@ unsigned int gt_determinebitspervalue(GtUword maxvalue)
 {
   unsigned int bits = 0;
 #ifndef USEbuiltin_clzl
-  GtUword value, mask = (~0) << CHAR_BIT;
+  GtUword value, mask = (~((GtUword) 0)) << CHAR_BIT;
 
   for (value = maxvalue; (value & mask) != 0; value >>= CHAR_BIT) {
     bits += CHAR_BIT;

--- a/src/extended/multieoplist.c
+++ b/src/extended/multieoplist.c
@@ -290,6 +290,11 @@ void gt_multieoplist_show(GtMultieoplist *multieops, FILE *fp)
           num = multieops->meoplist.nextfreeEop;
   Eop *space, *last, *next;
 
+  if (num == 0)
+  {
+    gt_xfputs("[]\n", fp);
+    return;
+  }
   gt_assert(multieops != NULL);
   space = multieops->meoplist.spaceEop;
 
@@ -324,8 +329,9 @@ void gt_multieoplist_show(GtMultieoplist *multieops, FILE *fp)
       stepssum = (GtUword) (*last & GT_MEOPS_STEPS_MASK);
       next = last - 1;
     }
+    gt_assert(next + 1 == last);
   }
-  gt_assert(last == space);
+  gt_assert(num == 0 || last == space);
   switch (*last >> GT_MEOPS_STEPS_BITS) {
     case GT_MEOPS_MATCH:
       gt_xfputc('M', fp);

--- a/src/external/zlib-1.2.8/inflate.c
+++ b/src/external/zlib-1.2.8/inflate.c
@@ -1504,7 +1504,7 @@ z_streamp strm;
 {
     struct inflate_state FAR *state;
 
-    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
+    if (strm == Z_NULL || strm->state == Z_NULL) return -(1L << 16);
     state = (struct inflate_state FAR *)strm->state;
     return ((long)(state->back) << 16) +
         (state->mode == COPY ? state->length :

--- a/src/match/querymatch-align.c
+++ b/src/match/querymatch-align.c
@@ -106,7 +106,7 @@ void gt_querymatch_showeoplist(const GtArrayuint8_t *eoplist)
 struct GtQuerymatchoutoptions
 {
   GtUword totallength,
-          alignmentwidth, /* if > 0, then with alignment of this width */
+          alignmentwidth,
           useqbuffer_size,
           vseqbuffer_size;
   GtArrayuint8_t eoplist;
@@ -120,15 +120,22 @@ struct GtQuerymatchoutoptions
   GtSeqpaircoordinates correction_info;
   GtLinspaceManagement *linspace_spacemanager;
   GtScoreHandler *linspace_scorehandler;
-  bool always_polished_ends;
+  bool always_polished_ends,
+       generatealignment,
+       showeoplist;
   Polishing_info *pol_info;
 };
 
-GtQuerymatchoutoptions *gt_querymatchoutoptions_new(GtUword alignmentwidth)
+GtQuerymatchoutoptions *gt_querymatchoutoptions_new(bool generatealignment,
+                                                    bool showeoplist,
+                                                    GtUword alignmentwidth)
 {
   GtQuerymatchoutoptions *querymatchoutoptions
     = gt_malloc(sizeof *querymatchoutoptions);
 
+  querymatchoutoptions->generatealignment
+    = generatealignment || alignmentwidth > 0 || showeoplist;
+  querymatchoutoptions->showeoplist = showeoplist;
   querymatchoutoptions->alignmentwidth = alignmentwidth;
   querymatchoutoptions->front_trace = NULL;
   querymatchoutoptions->ggemi = NULL;
@@ -144,16 +151,17 @@ GtQuerymatchoutoptions *gt_querymatchoutoptions_new(GtUword alignmentwidth)
   querymatchoutoptions->linspace_spacemanager = NULL;
   querymatchoutoptions->linspace_scorehandler = NULL;
   querymatchoutoptions->always_polished_ends = true;
+  querymatchoutoptions->alignment_show_buffer = NULL;
+  if (generatealignment)
+  {
+    querymatchoutoptions->alignment = gt_alignment_new();
+  }
   if (alignmentwidth > 0)
   {
     querymatchoutoptions->alignment_show_buffer
       = gt_alignment_buffer_new(alignmentwidth);
-    querymatchoutoptions->alignment = gt_alignment_new();
     querymatchoutoptions->linspace_spacemanager = gt_linspaceManagement_new();
     querymatchoutoptions->linspace_scorehandler = gt_scorehandler_new(0,1,0,1);
-  } else
-  {
-    querymatchoutoptions->alignment_show_buffer = NULL;
   }
   return querymatchoutoptions;
 }
@@ -174,7 +182,7 @@ void gt_querymatchoutoptions_extend(
   if (errorpercentage > 0)
   {
     gt_assert(querymatchoutoptions != NULL);
-    if (querymatchoutoptions->alignmentwidth > 0)
+    if (querymatchoutoptions->generatealignment)
     {
       querymatchoutoptions->front_trace = front_trace_new();
     }
@@ -326,13 +334,13 @@ static bool seededmatch2eoplist(GtQuerymatchoutoptions *querymatchoutoptions,
     }
     if (querymatchoutoptions->front_trace != NULL)
     {
-      gt_assert(querymatchoutoptions->alignmentwidth > 0);
+      gt_assert(querymatchoutoptions->generatealignment);
       front_trace_reset(querymatchoutoptions->front_trace,ulen+vlen);
     }
   }
   if (alignment_succeeded)
   {
-    if (querymatchoutoptions->alignmentwidth > 0)
+    if (querymatchoutoptions->generatealignment)
     {
       front_trace_multireplacement(&querymatchoutoptions->eoplist,seedlen);
     }
@@ -530,9 +538,14 @@ bool gt_querymatchoutoptions_alignment_prepare(GtQuerymatchoutoptions
                             seedlen,
                             greedyextension))
     {
-      if (querymatchoutoptions->alignmentwidth > 0)
+      if (querymatchoutoptions->generatealignment)
       {
         gt_alignment_reset(querymatchoutoptions->alignment);
+        converteoplist2alignment(querymatchoutoptions->alignment,
+                                 &querymatchoutoptions->eoplist);
+      }
+      if (querymatchoutoptions->alignmentwidth > 0)
+      {
         gt_assert(dbstart <= seedpos1);
         gt_alignment_set_seedoffset(querymatchoutoptions->alignment,
                                     seedpos1 - dbstart,
@@ -544,13 +557,11 @@ bool gt_querymatchoutoptions_alignment_prepare(GtQuerymatchoutoptions
                               querymatchoutoptions->vseqbuffer +
                                   querymatchoutoptions->correction_info.voffset,
                               querymatchoutoptions->correction_info.vlen);
-        converteoplist2alignment(querymatchoutoptions->alignment,
-                                 &querymatchoutoptions->eoplist);
       }
       seededalignment = true;
     } else
     {
-      if (querymatchoutoptions->alignmentwidth > 0)
+      if (querymatchoutoptions->generatealignment)
       {
 #ifndef NDEBUG
         GtUword linedist;
@@ -577,7 +588,6 @@ bool gt_querymatchoutoptions_alignment_prepare(GtQuerymatchoutoptions
                               0,
                               querylen);
         gt_assert(linedist <= edist);
-        /*printf("linedist = " GT_WU " <= " GT_WU "= edist\n",linedist,edist);*/
       }
     }
   } else
@@ -599,32 +609,50 @@ void gt_querymatchoutoptions_alignment_show(const GtQuerymatchoutoptions
                                             GtUword distance,
                                             GT_UNUSED bool verify_alignment)
 {
-  if (querymatchoutoptions != NULL && querymatchoutoptions->alignmentwidth > 0)
+  if (querymatchoutoptions != NULL)
   {
-    if (distance > 0)
+    if (querymatchoutoptions->alignmentwidth > 0)
     {
-      gt_alignment_show_generic(querymatchoutoptions->alignment_show_buffer,
-                                false,
+      if (distance > 0)
+      {
+        gt_alignment_show_generic(querymatchoutoptions->alignment_show_buffer,
+                                  false,
+                                  querymatchoutoptions->alignment,
+                                  stdout,
+                                  (unsigned int)
+                                  querymatchoutoptions->alignmentwidth,
+                                  querymatchoutoptions->characters,
+                                  querymatchoutoptions->wildcardshow);
+      } else
+      {
+        gt_alignment_exact_show(querymatchoutoptions->alignment_show_buffer,
                                 querymatchoutoptions->alignment,
                                 stdout,
-                                (unsigned int)
                                 querymatchoutoptions->alignmentwidth,
-                                querymatchoutoptions->characters,
-                                querymatchoutoptions->wildcardshow);
-    } else
-    {
-      gt_alignment_exact_show(querymatchoutoptions->alignment_show_buffer,
-                              querymatchoutoptions->alignment,
-                              stdout,
-                              querymatchoutoptions->alignmentwidth,
-                              querymatchoutoptions->characters);
+                                querymatchoutoptions->characters);
+      }
+      if (verify_alignment)
+      {
+        (void) gt_alignment_check_edist(querymatchoutoptions->alignment,
+                                        distance,NULL);
+      }
     }
-    if (verify_alignment)
+    if (querymatchoutoptions->showeoplist)
     {
-      (void) gt_alignment_check_edist(querymatchoutoptions->alignment,distance,
-                                      NULL);
+      if (distance > 0)
+      {
+        gt_alignment_show_multieop_list(querymatchoutoptions->alignment,
+                                        stdout);
+      } else
+      {
+        printf("[]\n");
+      }
     }
-    gt_alignment_reset(querymatchoutoptions->alignment);
+    if (querymatchoutoptions->alignmentwidth > 0 ||
+        querymatchoutoptions->showeoplist)
+    {
+      gt_alignment_reset(querymatchoutoptions->alignment);
+    }
   }
 }
 

--- a/src/match/querymatch-align.c
+++ b/src/match/querymatch-align.c
@@ -634,3 +634,10 @@ const GtSeqpaircoordinates *gt_querymatchoutoptions_correction_get(
   gt_assert(querymatchoutoptions != NULL);
   return &querymatchoutoptions->correction_info;
 }
+
+const GtAlignment *gt_querymatchoutoptions_alignment_get(
+              const GtQuerymatchoutoptions *querymatchoutoptions)
+{
+  gt_assert(querymatchoutoptions != NULL);
+  return querymatchoutoptions->alignment;
+}

--- a/src/match/querymatch-align.h
+++ b/src/match/querymatch-align.h
@@ -25,8 +25,9 @@
 
 typedef struct GtQuerymatchoutoptions GtQuerymatchoutoptions;
 
-GtQuerymatchoutoptions *gt_querymatchoutoptions_new(
-                                GtUword alignmentwidth);
+GtQuerymatchoutoptions *gt_querymatchoutoptions_new(bool generatealignment,
+                                                    bool showeoplist,
+                                                    GtUword alignmentwidth);
 
 void gt_querymatchoutoptions_extend(
                   GtQuerymatchoutoptions *querymatchoutoptions,

--- a/src/match/querymatch-align.h
+++ b/src/match/querymatch-align.h
@@ -21,6 +21,7 @@
 #include "core/types_api.h"
 #include "match/ft-front-prune.h"
 #include "match/seq_or_encseq.h"
+#include "extended/alignment.h"
 
 typedef struct GtQuerymatchoutoptions GtQuerymatchoutoptions;
 
@@ -81,6 +82,9 @@ typedef struct
 } GtSeqpaircoordinates;
 
 const GtSeqpaircoordinates *gt_querymatchoutoptions_correction_get(
+              const GtQuerymatchoutoptions *querymatchoutoptions);
+
+const GtAlignment *gt_querymatchoutoptions_alignment_get(
               const GtQuerymatchoutoptions *querymatchoutoptions);
 
 #endif

--- a/src/match/querymatch.c
+++ b/src/match/querymatch.c
@@ -68,6 +68,15 @@ GtQuerymatch *gt_querymatch_dup(const GtQuerymatch *querymatch_src)
   return querymatch_dest;
 }
 
+void gt_querymatch_table_add(GtArrayGtQuerymatch *querymatch_table,
+                             const GtQuerymatch *querymatch)
+{
+  GT_STOREINARRAY(querymatch_table,
+                  GtQuerymatch,
+                  querymatch_table->allocatedGtQuerymatch * 0.2 + 256,
+                  *querymatch);
+}
+
 void gt_querymatch_outoptions_set(GtQuerymatch *querymatch,
                 GtQuerymatchoutoptions *querymatchoutoptions)
 {
@@ -526,8 +535,39 @@ int gt_querymatch_compare(const void *va,const void *vb)
   return 1;
 }
 
+static int gt_querymatch_compare2(const void *va,const void *vb)
+{
+  const GtQuerymatch *a = (const GtQuerymatch *) va;
+  const GtQuerymatch *b = (const GtQuerymatch *) vb;
+
+  gt_assert(a != NULL && b != NULL);
+  if (a->queryseqnum < b->queryseqnum ||
+       (a->queryseqnum == b->queryseqnum &&
+        a->querystart_fwdstrand + a->querylen <=
+        b->querystart_fwdstrand + b->querylen))
+  {
+    return -1;
+  }
+  return 1;
+}
+
+void gt_querymatch_table_sort(GtArrayGtQuerymatch *querymatch_table)
+{
+  qsort(querymatch_table->spaceGtQuerymatch,
+        querymatch_table->nextfreeGtQuerymatch,
+        sizeof *querymatch_table->spaceGtQuerymatch,
+        gt_querymatch_compare2);
+}
+
 bool gt_querymatch_has_seed(const GtQuerymatch *querymatch)
 {
   gt_assert(querymatch != NULL);
   return querymatch->seedpos1 != GT_UWORD_MAX ? true : false;
+}
+
+GtQuerymatch *gt_querymatch_table_get(const GtArrayGtQuerymatch
+                                        *querymatch_table,GtUword idx)
+{
+  gt_assert(querymatch_table != NULL);
+  return querymatch_table->spaceGtQuerymatch + idx;
 }

--- a/src/match/querymatch.c
+++ b/src/match/querymatch.c
@@ -448,6 +448,12 @@ GtUword gt_querymatch_querystart(const GtQuerymatch *querymatch)
   return querymatch->querystart;
 }
 
+GtUword gt_querymatch_querystart_fwdstrand(const GtQuerymatch *querymatch)
+{
+  gt_assert(querymatch != NULL);
+  return querymatch->querystart_fwdstrand;
+}
+
 uint64_t gt_querymatch_queryseqnum(const GtQuerymatch *querymatch)
 {
   gt_assert(querymatch != NULL);

--- a/src/match/querymatch.c
+++ b/src/match/querymatch.c
@@ -509,6 +509,7 @@ int gt_querymatch_compare(const void *va,const void *vb)
   const GtQuerymatch *a = *((const GtQuerymatch **) va);
   const GtQuerymatch *b = *((const GtQuerymatch **) vb);
 
+  gt_assert(a != NULL && b != NULL);
   if (a->queryseqnum < b->queryseqnum ||
        (a->queryseqnum == b->queryseqnum &&
         a->querystart_fwdstrand + a->querylen <=
@@ -517,4 +518,10 @@ int gt_querymatch_compare(const void *va,const void *vb)
     return -1;
   }
   return 1;
+}
+
+bool gt_querymatch_has_seed(const GtQuerymatch *querymatch)
+{
+  gt_assert(querymatch != NULL);
+  return querymatch->seedpos1 != GT_UWORD_MAX ? true : false;
 }

--- a/src/match/querymatch.c
+++ b/src/match/querymatch.c
@@ -568,3 +568,10 @@ GtQuerymatch *gt_querymatch_table_get(const GtArrayGtQuerymatch
   gt_assert(querymatch_table != NULL);
   return querymatch_table->spaceGtQuerymatch + idx;
 }
+
+const GtAlignment *gt_querymatch_alignment_get(const GtQuerymatch *querymatch)
+{
+  gt_assert(querymatch != NULL);
+  return gt_querymatchoutoptions_alignment_get(
+                  querymatch->ref_querymatchoutoptions);
+}

--- a/src/match/querymatch.h
+++ b/src/match/querymatch.h
@@ -132,4 +132,6 @@ bool gt_querymatch_overlap(const GtQuerymatch *querymatch,
                            GtUword start_relative);
 
 int gt_querymatch_compare(const void *va,const void *vb);
+
+bool gt_querymatch_has_seed(const GtQuerymatch *querymatch);
 #endif

--- a/src/match/querymatch.h
+++ b/src/match/querymatch.h
@@ -33,8 +33,6 @@ GT_DECLAREARRAYSTRUCT(GtQuerymatch);
 
 GtQuerymatch *gt_querymatch_new(void);
 
-GtQuerymatch *gt_querymatch_dup(const GtQuerymatch *querymatch_src);
-
 void gt_querymatch_seed_display_set(GtQuerymatch *querymatch);
 
 void gt_querymatch_outoptions_set(GtQuerymatch *querymatch,
@@ -134,8 +132,6 @@ GtWord gt_querymatch_distance2score(GtUword distance,GtUword alignedlen);
 bool gt_querymatch_overlap(const GtQuerymatch *querymatch,
                            GtUword start_relative);
 
-int gt_querymatch_compare(const void *va,const void *vb);
-
 bool gt_querymatch_has_seed(const GtQuerymatch *querymatch);
 
 GtUword gt_querymatch_querystart_fwdstrand(const GtQuerymatch *querymatch);
@@ -143,7 +139,8 @@ GtUword gt_querymatch_querystart_fwdstrand(const GtQuerymatch *querymatch);
 void gt_querymatch_table_add(GtArrayGtQuerymatch *querymatch_table,
                              const GtQuerymatch *querymatch);
 
-void gt_querymatch_table_sort(GtArrayGtQuerymatch *querymatch_table);
+void gt_querymatch_table_sort(GtArrayGtQuerymatch *querymatch_table,
+                              bool ascending);
 
 GtQuerymatch *gt_querymatch_table_get(const GtArrayGtQuerymatch
                                         *querymatch_table,GtUword idx);

--- a/src/match/querymatch.h
+++ b/src/match/querymatch.h
@@ -144,4 +144,6 @@ void gt_querymatch_table_sort(GtArrayGtQuerymatch *querymatch_table,
 
 GtQuerymatch *gt_querymatch_table_get(const GtArrayGtQuerymatch
                                         *querymatch_table,GtUword idx);
+
+const GtAlignment *gt_querymatch_alignment_get(const GtQuerymatch *querymatch);
 #endif

--- a/src/match/querymatch.h
+++ b/src/match/querymatch.h
@@ -134,4 +134,6 @@ bool gt_querymatch_overlap(const GtQuerymatch *querymatch,
 int gt_querymatch_compare(const void *va,const void *vb);
 
 bool gt_querymatch_has_seed(const GtQuerymatch *querymatch);
+
+GtUword gt_querymatch_querystart_fwdstrand(const GtQuerymatch *querymatch);
 #endif

--- a/src/match/querymatch.h
+++ b/src/match/querymatch.h
@@ -30,6 +30,8 @@ typedef struct GtQuerymatch GtQuerymatch;
 
 GtQuerymatch *gt_querymatch_new(void);
 
+GtQuerymatch *gt_querymatch_dup(const GtQuerymatch *querymatch_src);
+
 void gt_querymatch_seed_display_set(GtQuerymatch *querymatch);
 
 void gt_querymatch_outoptions_set(GtQuerymatch *querymatch,
@@ -51,13 +53,13 @@ void gt_querymatch_init(GtQuerymatch *querymatch,
 bool gt_querymatch_read_line(GtQuerymatch *querymatchptr,
                              const char *line_ptr,
                              bool selfmatch,
+                             GtUword seedpos1,
+                             GtUword seedpos2,
+                             GtUword seedlen,
                              const GtEncseq *dbencseq,
                              const GtEncseq *queryencseq);
 
 bool gt_querymatch_process(GtQuerymatch *querymatchptr,
-                           GtUword seedpos1,
-                           GtUword seedpos2,
-                           GtUword seedlen,
                            const GtEncseq *encseq,
                            const GtSeqorEncseq *query,
                            GtUword query_totallength,
@@ -128,4 +130,6 @@ GtWord gt_querymatch_distance2score(GtUword distance,GtUword alignedlen);
 /* Returns true, iff the given seed start position is below the querymatch. */
 bool gt_querymatch_overlap(const GtQuerymatch *querymatch,
                            GtUword start_relative);
+
+int gt_querymatch_compare(const void *va,const void *vb);
 #endif

--- a/src/match/querymatch.h
+++ b/src/match/querymatch.h
@@ -23,10 +23,13 @@
 #include "core/readmode.h"
 #include "core/encseq.h"
 #include "core/unused_api.h"
+#include "core/arraydef.h"
 #include "querymatch-align.h"
 #include "seq_or_encseq.h"
 
 typedef struct GtQuerymatch GtQuerymatch;
+
+GT_DECLAREARRAYSTRUCT(GtQuerymatch);
 
 GtQuerymatch *gt_querymatch_new(void);
 
@@ -136,4 +139,12 @@ int gt_querymatch_compare(const void *va,const void *vb);
 bool gt_querymatch_has_seed(const GtQuerymatch *querymatch);
 
 GtUword gt_querymatch_querystart_fwdstrand(const GtQuerymatch *querymatch);
+
+void gt_querymatch_table_add(GtArrayGtQuerymatch *querymatch_table,
+                             const GtQuerymatch *querymatch);
+
+void gt_querymatch_table_sort(GtArrayGtQuerymatch *querymatch_table);
+
+GtQuerymatch *gt_querymatch_table_get(const GtArrayGtQuerymatch
+                                        *querymatch_table,GtUword idx);
 #endif

--- a/src/match/seed-extend-iter.c
+++ b/src/match/seed-extend-iter.c
@@ -98,7 +98,7 @@ GtSeedextendMatchIterator *gt_seedextend_match_iterator_new(
   semi->line_buffer = NULL;
   semi->inputfileptr = NULL;
   semi->querymatchptr = gt_querymatch_new();
-  semi->seedpos1 = semi->seedpos2 = semi->seedlen = 0;
+  semi->seedpos1 = semi->seedpos2 = semi->seedlen = GT_UWORD_MAX;
   options_line_inputfileptr = fopen(semi->matchfilename, "r");
   if (options_line_inputfileptr == NULL)
   {

--- a/src/match/seed-extend-iter.c
+++ b/src/match/seed-extend-iter.c
@@ -26,7 +26,7 @@ struct GtSeedextendMatchIterator
   GtStr *ii, *qii;
   bool mirror, bias_parameters;
   GtEncseq *aencseq, *bencseq;
-  GtUword errorpercentage, history_size, query_totallength;
+  GtUword errorpercentage, history_size;
   const char *matchfilename;
   GtStr *line_buffer;
   uint64_t linenum;
@@ -93,7 +93,6 @@ GtSeedextendMatchIterator *gt_seedextend_match_iterator_new(
   semi->mirror = false;
   semi->bias_parameters = false;
   semi->aencseq = semi->bencseq = NULL;
-  semi->query_totallength = 0;
   semi->errorpercentage = 0;
   semi->history_size = 0;
   semi->matchfilename = gt_str_get(matchfilename);
@@ -248,7 +247,6 @@ GtSeedextendMatchIterator *gt_seedextend_match_iterator_new(
   if (!had_err)
   {
     gt_assert(semi->bencseq != NULL);
-    semi->query_totallength = gt_encseq_total_length(semi->bencseq);
     semi->line_buffer = gt_str_new();
     semi->linenum = 0;
     semi->inputfileptr = fopen(semi->matchfilename, "rb");

--- a/src/match/seed-extend-iter.c
+++ b/src/match/seed-extend-iter.c
@@ -98,6 +98,7 @@ GtSeedextendMatchIterator *gt_seedextend_match_iterator_new(
   semi->line_buffer = NULL;
   semi->inputfileptr = NULL;
   semi->querymatchptr = gt_querymatch_new();
+  semi->seedpos1 = semi->seedpos2 = semi->seedlen = 0;
   options_line_inputfileptr = fopen(semi->matchfilename, "r");
   if (options_line_inputfileptr == NULL)
   {
@@ -297,6 +298,9 @@ GtQuerymatch *gt_seedextend_match_iterator_next(GtSeedextendMatchIterator *semi)
         if (gt_querymatch_read_line(semi->querymatchptr,
                                     line_ptr,
                                     selfmatch,
+                                    semi->seedpos1,
+                                    semi->seedpos2,
+                                    semi->seedlen,
                                     semi->aencseq,
                                     semi->bencseq))
         {

--- a/src/match/seed-extend-iter.h
+++ b/src/match/seed-extend-iter.h
@@ -55,6 +55,8 @@ GtQuerymatch *gt_seedextend_match_iterator_next(
     had_err = -1;
   } else
   {
+    const bool ascending = false;
+    (void) gt_seedextend_match_iterator_all_sorted(semi,ascending);
     while (true)
     {
       uint64_t queryseqnum;
@@ -86,6 +88,23 @@ void gt_seedextend_match_iterator_outoptions_set(
                         GtSeedextendMatchIterator *semi,
                         GtQuerymatchoutoptions *querymatchoutoptions);
 
+/* The following function reads all matches into an arrays and sorts the,. If
+   <ascending is true, then all matches are sorted in ascending order of
+   the query position they occur at. Otherwise, all matches are sorted in
+   descending order of the query position they occur at. */
+
+GtUword gt_seedextend_match_iterator_all_sorted(
+                                         GtSeedextendMatchIterator *semi,
+                                         bool ascending);
+
+/* If the previous function has been called, the matches are stored in a table
+   (in sorted order) and the following function allows to obtain the
+   <querymatch> stored at a given index in this table */
+
+GtQuerymatch *gt_seedextend_match_iterator_get(
+                            const GtSeedextendMatchIterator *semi,
+                            GtUword idx);
+
 /* The following function return different component of the iterator
    object. */
 
@@ -116,10 +135,4 @@ GtUword gt_seedextend_match_iterator_seedpos1(
 GtUword gt_seedextend_match_iterator_seedpos2(
                             const GtSeedextendMatchIterator *semi);
 
-GtUword gt_seedextend_match_iterator_all_sorted(
-                                         GtSeedextendMatchIterator *semi);
-
-GtQuerymatch *gt_seedextend_match_iterator_get(
-                            const GtSeedextendMatchIterator *semi,
-                            GtUword idx);
 #endif

--- a/src/match/seed-extend-iter.h
+++ b/src/match/seed-extend-iter.h
@@ -149,4 +149,28 @@ GtUword gt_seedextend_match_iterator_seedpos2(
          start and endpositions querystart and queryend */
     }
   }
+
+  /* When processing the chain first declare the following: */
+
+  GtSeqorEncseq bseqorencseq;
+
+  bseqorencseq.seq = NULL;
+  bseqorencseq.encseq = bencseq;
+
+  /* for each match in the chain */
+
+  idx = chainelem->indexintableofallmatches;
+  querymatchptr = gt_seedextend_match_iterator_get(semi,idx);
+
+  if (gt_querymatch_process(querymatchptr,
+                            aencseq,
+                            &bseqorencseq,
+                            query_totallength,
+                            false) != 0)
+  {
+    GtAlignment *alignment = gt_querymatch_alignment_get(querymatchptr);
+
+    /* now use feed the eoplist of the alignment with the required
+       coordinates into the condenser */
+  }
 #endif

--- a/src/match/seed-extend-iter.h
+++ b/src/match/seed-extend-iter.h
@@ -116,4 +116,10 @@ GtUword gt_seedextend_match_iterator_seedpos1(
 GtUword gt_seedextend_match_iterator_seedpos2(
                             const GtSeedextendMatchIterator *semi);
 
+GtUword gt_seedextend_match_iterator_all_sorted(
+                                         GtSeedextendMatchIterator *semi);
+
+GtQuerymatch *gt_seedextend_match_iterator_get(
+                            const GtSeedextendMatchIterator *semi,
+                            GtUword idx);
 #endif

--- a/src/match/seed-extend-iter.h
+++ b/src/match/seed-extend-iter.h
@@ -45,48 +45,11 @@ void gt_seedextend_match_iterator_delete(GtSeedextendMatchIterator *semi);
 GtQuerymatch *gt_seedextend_match_iterator_next(
                              GtSeedextendMatchIterator *semi);
 
-/* Here is a typical use of the iterator: */
-#ifdef SOBANSKI_KEIL
-  GtSeedextendMatchIterator *semi
-    = gt_seedextend_match_iterator_new(matchfile,err);
-
-  if (semi == NULL)
-  {
-    had_err = -1;
-  } else
-  {
-    const bool ascending = false;
-    (void) gt_seedextend_match_iterator_all_sorted(semi,ascending);
-    while (true)
-    {
-      uint64_t queryseqnum;
-      GtUword querystart, queryend;
-      GtQuerymatch *querymatchptr = gt_seedextend_match_iterator_next(semi);
-      if (querymatchptr == NULL)
-      {
-        break;
-      }
-      queryseqnum = gt_querymatch_queryseqnum(querymatchptr);
-      querystart = gt_querymatch_querystart(querymatchptr);
-      querend = querystart + gt_querymatch_querylen(querymatchptr) - 1;
-      /* now process match in sequence queryseqnum with relativ
-         start and endpositions querystart and queryend */
-    }
-  }
-#endif
-
 /* The following functions set the seed_display flag of the iterators
    querymatch-object. */
 
 void gt_seedextend_match_iterator_seed_display_set(
                         GtSeedextendMatchIterator *semi);
-
-/* The following functions sets the <GtQuerymatchoutoptions> of the
-   iterator. */
-
-void gt_seedextend_match_iterator_outoptions_set(
-                        GtSeedextendMatchIterator *semi,
-                        GtQuerymatchoutoptions *querymatchoutoptions);
 
 /* The following function reads all matches into an arrays and sorts the,. If
    <ascending is true, then all matches are sorted in ascending order of
@@ -105,7 +68,20 @@ GtQuerymatch *gt_seedextend_match_iterator_get(
                             const GtSeedextendMatchIterator *semi,
                             GtUword idx);
 
-/* The following function return different component of the iterator
+/* The following function sets some option related to the output of
+   the matches and the corresponding alignments. If only the edit operation
+   list is required, then set <generatealignment> to <true>,
+   <alignmentwidth> to 0 and the other three boolean parameters to <false>. */
+
+void gt_seedextend_match_iterator_querymatchoutoptions_set(
+                    GtSeedextendMatchIterator *semi,
+                    bool generatealignment,
+                    bool showeoplist,
+                    GtUword alignmentwidth,
+                    bool always_polished_ends,
+                    bool seed_display);
+
+/* The following function return different components of the iterator
    object. */
 
 const GtEncseq *gt_seedextend_match_iterator_aencseq(
@@ -135,4 +111,42 @@ GtUword gt_seedextend_match_iterator_seedpos1(
 GtUword gt_seedextend_match_iterator_seedpos2(
                             const GtSeedextendMatchIterator *semi);
 
+#endif
+
+/* Here is a typical use of the iterator: */
+#ifdef SOBANSKI_KEIL
+  GtSeedextendMatchIterator *semi
+    = gt_seedextend_match_iterator_new(matchfile,err);
+
+  if (semi == NULL)
+  {
+    had_err = -1;
+  } else
+  {
+    const bool ascending = false;
+
+    gt_seedextend_match_iterator_querymatchoutoptions_set(
+                    semi,
+                    true,
+                    false,
+                    0,
+                    false,
+                    false);
+    (void) gt_seedextend_match_iterator_all_sorted(semi,ascending);
+    while (true)
+    {
+      uint64_t queryseqnum;
+      GtUword querystart, queryend;
+      GtQuerymatch *querymatchptr = gt_seedextend_match_iterator_next(semi);
+      if (querymatchptr == NULL)
+      {
+        break;
+      }
+      queryseqnum = gt_querymatch_queryseqnum(querymatchptr);
+      querystart = gt_querymatch_querystart(querymatchptr);
+      querend = querystart + gt_querymatch_querylen(querymatchptr) - 1;
+      /* now process match in sequence queryseqnum with relativ
+         start and endpositions querystart and queryend */
+    }
+  }
 #endif

--- a/src/tools/gt_repfind.c
+++ b/src/tools/gt_repfind.c
@@ -828,7 +828,7 @@ static int gt_repfind_runner(int argc,
          !arguments->noxpolish))
     {
       querymatchoutoptions
-        = gt_querymatchoutoptions_new(arguments->alignmentwidth);
+        = gt_querymatchoutoptions_new(true, false,arguments->alignmentwidth);
 
       if (gt_option_is_set(arguments->refextendxdropoption) ||
           gt_option_is_set(arguments->refextendgreedyoption))

--- a/src/tools/gt_seed_extend.c
+++ b/src/tools/gt_seed_extend.c
@@ -655,7 +655,7 @@ static int gt_seed_extend_runner(GT_UNUSED int argc,
                    gt_option_is_set(arguments->se_option_xdrop)))
   {
     querymatchoutopt
-      = gt_querymatchoutoptions_new(arguments->se_alignmentwidth);
+      = gt_querymatchoutoptions_new(true,false,arguments->se_alignmentwidth);
 
     if (!arguments->onlyseeds)
     {

--- a/src/tools/gt_show_seedext.c
+++ b/src/tools/gt_show_seedext.c
@@ -286,8 +286,6 @@ static int gt_show_seedext_runner(GT_UNUSED int argc,
     GtAlignment *alignment = gt_alignment_new();
     Polishing_info *pol_info = NULL;
     GtSequencepairbuffer seqpairbuf = {NULL,NULL,0,0};
-    double matchscore_bias = GT_DEFAULT_MATCHSCORE_BIAS;
-    GtQuerymatchoutoptions *querymatchoutoptions = NULL;
 
     /* the following are used if seed_extend is set */
     GtGreedyextendmatchinfo *greedyextendmatchinfo = NULL;
@@ -302,6 +300,7 @@ static int gt_show_seedext_runner(GT_UNUSED int argc,
 
     if (!arguments->relax_polish)
     {
+      double matchscore_bias = GT_DEFAULT_MATCHSCORE_BIAS;
       if (gt_seedextend_match_iterator_bias_parameters(semi))
       {
         matchscore_bias = gt_greedy_dna_sequence_bias_get(aencseq);
@@ -317,16 +316,12 @@ static int gt_show_seedext_runner(GT_UNUSED int argc,
     }
     if (arguments->show_alignment || arguments->showeoplist)
     {
-      querymatchoutoptions = gt_querymatchoutoptions_new(true,
-                                                         arguments->showeoplist,
-                                                         alignmentwidth);
-      gt_querymatchoutoptions_for_align_only(querymatchoutoptions,
-                            gt_seedextend_match_iterator_errorpercentage(semi),
-                            matchscore_bias,
-                            gt_seedextend_match_iterator_history_size(semi),
-                            !arguments->relax_polish,
-                            arguments->seed_display);
-      gt_seedextend_match_iterator_outoptions_set(semi,querymatchoutoptions);
+      gt_seedextend_match_iterator_querymatchoutoptions_set(semi,
+                                                       true,
+                                                       arguments->showeoplist,
+                                                       alignmentwidth,
+                                                       !arguments->relax_polish,
+                                                       arguments->seed_display);
     }
     if (arguments->seed_extend)
     {
@@ -413,7 +408,6 @@ static int gt_show_seedext_runner(GT_UNUSED int argc,
     }
     polishing_info_delete(pol_info);
     gt_greedy_extend_matchinfo_delete(greedyextendmatchinfo);
-    gt_querymatchoutoptions_delete(querymatchoutoptions);
     gt_free(alignment_show_buffer);
     gt_scorehandler_delete(linspace_scorehandler);
     gt_linspaceManagement_delete(linspace_spacemanager);

--- a/src/tools/gt_show_seedext.c
+++ b/src/tools/gt_show_seedext.c
@@ -166,12 +166,13 @@ static void gt_show_seed_extend_plain(GtSequencepairbuffer *seqpairbuf,
   const GtUword distance = gt_querymatch_distance(querymatchptr),
                 dblen = gt_querymatch_dblen(querymatchptr),
                 queryseqnum = gt_querymatch_queryseqnum(querymatchptr),
-                querystart = gt_querymatch_querystart(querymatchptr),
+                querystart_fwdstrand
+                  = gt_querymatch_querystart_fwdstrand(querymatchptr),
                 querylen = gt_querymatch_querylen(querymatchptr);
 
   const GtUword apos_ab = gt_querymatch_dbstart(querymatchptr);
   const GtUword bpos_ab = gt_encseq_seqstartpos(bencseq, queryseqnum) +
-                          querystart;
+                          querystart_fwdstrand;
 
   gt_querymatch_coordinates_out(querymatchptr);
   if (dblen >= seqpairbuf->a_allocated)

--- a/src/tools/gt_show_seedext.c
+++ b/src/tools/gt_show_seedext.c
@@ -327,95 +327,67 @@ static int gt_show_seedext_runner(GT_UNUSED int argc,
     processinfo_and_querymatchspaceptr.processinfo = greedyextendmatchinfo;
     if (arguments->sortmatches)
     {
-      GtUword idx,
-              numberofmatches = gt_seedextend_match_iterator_all_sorted(semi);
-
-      for (idx = 0; idx < numberofmatches; idx++)
-      {
-        GtQuerymatch *qptr = gt_seedextend_match_iterator_get(semi,idx);
-        if (gt_querymatch_has_seed(qptr))
-        {
-          const GtUword query_totallength
-
-           = gt_encseq_seqlength(bencseq,gt_querymatch_queryseqnum(qptr));
-          gt_show_seed_extend_encseq(qptr, aencseq, bencseq, query_totallength);
-        } else
-        {
-          gt_show_seed_extend_plain(&seqpairbuf,
-                                    linspace_spacemanager,
-                                    linspace_scorehandler,
-                                    alignment,
-                                    alignment_show_buffer,
-                                    alignmentwidth,
-                                    characters,
-                                    wildcardshow,
-                                    aencseq,
-                                    bencseq,
-                                    qptr);
-        }
-      }
-    } else
+      (void) gt_seedextend_match_iterator_all_sorted(semi,true);
+    }
+    while (true)
     {
-      while (true)
+      GtQuerymatch *querymatchptr = gt_seedextend_match_iterator_next(semi);
+
+      if (querymatchptr == NULL)
       {
-        GtQuerymatch *querymatchptr = gt_seedextend_match_iterator_next(semi);
-
-        if (querymatchptr == NULL)
+        break;
+      }
+      if (gt_seedextend_match_iterator_has_seedline(semi))
+      {
+        if (arguments->seed_extend)
         {
-          break;
-        }
-        if (gt_seedextend_match_iterator_has_seedline(semi))
-        {
-          if (arguments->seed_extend)
+          if (aencseq == bencseq)
           {
-            if (aencseq == bencseq)
-            {
-              const GtUword
-                seedlen = gt_seedextend_match_iterator_seedlen(semi),
-                seedpos1 = gt_seedextend_match_iterator_seedpos1(semi),
-                seedpos2 = gt_seedextend_match_iterator_seedpos2(semi);
+            const GtUword
+              seedlen = gt_seedextend_match_iterator_seedlen(semi),
+              seedpos1 = gt_seedextend_match_iterator_seedpos1(semi),
+              seedpos2 = gt_seedextend_match_iterator_seedpos2(semi);
 
-              processinfo_and_querymatchspaceptr.querymatchspaceptr
-                = querymatchptr;
-              had_err = gt_greedy_extend_selfmatch_with_output(
-                                    &processinfo_and_querymatchspaceptr,
-                                    aencseq,
-                                    seedlen,
-                                    seedpos1,
-                                    seedpos2,
-                                    err);
-              if (had_err)
-              {
-                break;
-              }
-            } else
+            processinfo_and_querymatchspaceptr.querymatchspaceptr
+              = querymatchptr;
+            had_err = gt_greedy_extend_selfmatch_with_output(
+                                  &processinfo_and_querymatchspaceptr,
+                                  aencseq,
+                                  seedlen,
+                                  seedpos1,
+                                  seedpos2,
+                                  err);
+            if (had_err)
             {
-              gt_assert(false);
+              break;
             }
           } else
           {
-            const GtUword query_totallength
-              = gt_encseq_seqlength(bencseq,
-                                    gt_querymatch_queryseqnum(querymatchptr));
-            gt_show_seed_extend_encseq(querymatchptr,
-                                       aencseq,
-                                       bencseq,
-                                       query_totallength);
+            gt_assert(false);
           }
         } else
         {
-          gt_show_seed_extend_plain(&seqpairbuf,
-                                    linspace_spacemanager,
-                                    linspace_scorehandler,
-                                    alignment,
-                                    alignment_show_buffer,
-                                    alignmentwidth,
-                                    characters,
-                                    wildcardshow,
-                                    aencseq,
-                                    bencseq,
-                                    querymatchptr);
+          const GtUword query_totallength
+            = gt_encseq_seqlength(bencseq,
+                                  gt_querymatch_queryseqnum(querymatchptr));
+          gt_show_seed_extend_encseq(querymatchptr,
+                                     aencseq,
+                                     bencseq,
+                                     query_totallength);
         }
+      } else
+      {
+        gt_show_seed_extend_plain(&seqpairbuf,
+                                  linspace_spacemanager,
+                                  linspace_scorehandler,
+                                  alignment,
+                                  alignment_show_buffer,
+                                  alignmentwidth,
+                                  characters,
+                                  wildcardshow,
+                                  aencseq,
+                                  bencseq,
+                                  querymatchptr);
       }
     }
     polishing_info_delete(pol_info);


### PR DESCRIPTION
- show_seedext can store the matches internally to sort them. After the sorting the  _next method
can be used as before, but enumerating the matches in sorted order.

- the last commit concerns some fixed to allow compilation with clang 3.7.0 on Linux.
  Please check the applied modification in the zlib.