### PR TITLE
Revert "Remove assertion. Bugfix."

### DIFF
--- a/src/extended/condenseq.c
+++ b/src/extended/condenseq.c
@@ -462,6 +462,7 @@ static int condenseq_io(GtCondenseq *condenseq,
   if (!had_err)
     had_err = gt_condenseq_io_one(condenseq->ldb_nelems);
   if (!had_err) {
+    gt_assert(condenseq->ldb_nelems > 0);
     if (condenseq->links == NULL) {
       condenseq->links = gt_calloc((size_t) condenseq->ldb_nelems,
                                    sizeof (*condenseq->links));


### PR DESCRIPTION
This reverts commit 045d6f204465dc16dee1c8a71650deab9bcdcf33.

This commit was done without a pull request and should be discussed as the
assumption to remove the assertion without replacing it by a warning or an
GtError is simply wrong.