### PR TITLE
Fix writing of LTRdigest output files

### DIFF
--- a/src/ltr/ltrdigest_file_out_stream.c
+++ b/src/ltr/ltrdigest_file_out_stream.c
@@ -257,14 +257,14 @@ static int write_pdom(GtLTRdigestFileOutStream *ls, GtArray *pdoms,
 
   (void) snprintf(buffer, (size_t) (GT_MAXFILENAMELEN-1), "%s_pdom_%s.fas",
                   ls->fileprefix, pdomname);
-  seqfile = gt_file_xopen(buffer, "w+");
+  seqfile = gt_file_xopen(buffer, "a+");
 
   /* get protein alignment output file */
   if (ls->write_pdom_alignments)
   {
     (void) snprintf(buffer, (size_t) (GT_MAXFILENAMELEN-1), "%s_pdom_%s.ali",
                     ls->fileprefix, pdomname);
-    alifile = gt_file_xopen(buffer, "w+");
+    alifile = gt_file_xopen(buffer, "a+");
   }
 
   /* get amino acid sequence output file */
@@ -273,7 +273,7 @@ static int write_pdom(GtLTRdigestFileOutStream *ls, GtArray *pdoms,
     (void) snprintf(buffer, (size_t) (GT_MAXFILENAMELEN-1),
                     "%s_pdom_%s_aa.fas",
                     ls->fileprefix, pdomname);
-    aafile = gt_file_xopen(buffer, "w+");
+    aafile = gt_file_xopen(buffer, "a+");
   }
 
   if (gt_array_size(pdoms) > 1UL)

--- a/testsuite/gt_ltrdigest_include.rb
+++ b/testsuite/gt_ltrdigest_include.rb
@@ -459,6 +459,9 @@ if $gttestdata then
       if !File.exists?("result4_pdom_RVT_1_aa.fas") then
         raise TestFailed, "file \"result4_pdom_RVT_1_aa.fas\" does not exist"
       end
+      if !(`grep ">" result4_pdom_RVT_1_aa.fas | wc -l`.to_i > 1) then
+        raise TestFailed, "file \"result4_pdom_RVT_1_aa.fas\" only contains one sequence"
+      end
     end
   end
 


### PR DESCRIPTION
This PR fixes a bug in LTRdigest where not all feature sequences would be included in the per-domain output files. Addresses second issue reported in #662.