### PR TITLE
add tabular speck output template

### DIFF
--- a/gtdata/spec/output_drivers/tabular
+++ b/gtdata/spec/output_drivers/tabular
@@ -1,0 +1,72 @@
+--[[
+  This is an output template for tabular text output format.
+]]
+
+function tablelength(T)
+  local count = 0
+  for _ in pairs(T) do count = count + 1 end
+  return count
+end
+
+function print_aspects(aspects, feature)
+  for aspect, aspect_details in pairs(aspects) do
+    for n, node in ipairs(aspect_details.nodes) do
+      local id = ""
+      local seqid = ''
+      local rng_start = ''
+      local rng_end = ''
+      if node.ID then
+        id = node.ID
+      end
+      -- meta and comment nodes don't have seqids
+      if feature ~= 'meta' and feature ~= 'comment' then
+        seqid = node.node:get_seqid()
+      end
+      -- sequence and comment nodes don't have ranges
+      if feature ~= 'sequence' and feature ~= 'comment' then
+        rng_start = node.node:get_range():get_start()
+        rng_end = node.node:get_range():get_end()
+      end
+      for _, msg in ipairs(node.failure_messages) do
+        template_print(feature .. "\t"
+                         .. aspect .. "\t"
+                         .. id .. "\t"
+                         .. seqid .. "\t"
+                         .. rng_start .. "\t"
+                         .. rng_end .. "\t"
+                         .. "'" .. msg .. "'\n")
+      end
+      for _, msg in ipairs(node.runtime_error_messages) do
+        template_print(feature .. "\t"
+                         .. aspect .. "\t"
+                         .. id .. "\t"
+                         .. seqid .. "\t"
+                         .. rng_start .. "\t"
+                         .. rng_end .. "\t"
+                         .. "'" .. msg .. "'\n")
+      end
+    end
+  end
+end
+
+if tablelength(features) > 0 then
+  for feature, aspects in pairs(features) do
+    print_aspects(aspects, feature)
+  end
+end
+
+if tablelength(metas) > 0 then
+  print_aspects(metas, "meta")
+end
+
+if tablelength(regions) > 0 then
+  print_aspects(regions, "region")
+end
+
+if tablelength(comments) > 0 then
+  print_aspects(comments, "comment")
+end
+
+if tablelength(sequences) > 0 then
+  print_aspects(sequences, "sequence")
+end

--- a/src/tools/gt_speck.c
+++ b/src/tools/gt_speck.c
@@ -114,7 +114,8 @@ static GtOptionParser* gt_speck_option_parser_new(void *tool_arguments)
 
   /* -format */
   option = gt_option_new_string("output", "output format\n"
-                                "choose from: json, text, html, statsonly",
+                                "choose from: [json, text, html, statsonly, "
+                                "tabular] or give path to output driver",
                                 arguments->format, "text");
   gt_option_parser_add_option(op, option);
 


### PR DESCRIPTION
This PR adds a new output format to `gt speck`: a simple tab-separated text format suitable for loading into Excel and friends, making it easier to prepare lists of issues without having to parse them manually from one of the other, more structured formats.