### PR TITLE
fix Clang's compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ EXP_CXXFLAGS:=$(CXXFLAGS)
 EXP_CPPFLAGS:=$(CPPFLAGS)
 EXP_LDLIBS:=$(LIBS) -lm
 # ...while those starting with GT_ are for internal purposes only
-GT_CFLAGS:=-g -Wall -Wunused-parameter -pipe $(FPIC) -Wpointer-arith
+GT_CFLAGS:=-g -Wall -Wunused-parameter -pipe $(FPIC) -Wpointer-arith -Wno-unknown-pragmas
 # expat needs -DHAVE_MEMMOVE
 # zlib needs -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN
 EXT_FLAGS:= -DHAVE_MEMMOVE -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN

--- a/src/external/lpeg-0.10.2/lpeg.c
+++ b/src/external/lpeg-0.10.2/lpeg.c
@@ -1841,13 +1841,13 @@ typedef struct CapState {
 } CapState;
 
 
-#define captype(cap)	(cap)->kind
+#define captype(cap)	((cap)->kind)
 
-#define isclosecap(cap)	captype(cap) == Cclose
+#define isclosecap(cap)	(captype(cap) == Cclose)
 
 #define closeaddr(c)	((c)->s + (c)->siz - 1)
 
-#define isfullcap(cap)	(cap)->siz != 0
+#define isfullcap(cap)	((cap)->siz != 0)
 
 #define getfromenv(cs,v)	lua_rawgeti((cs)->L, penvidx((cs)->ptop), v)
 #define pushluaval(cs)		getfromenv(cs, (cs)->cap->idx)

--- a/src/external/lua-5.1.5/src/lobject.h
+++ b/src/external/lua-5.1.5/src/lobject.h
@@ -76,15 +76,15 @@ typedef struct lua_TValue {
 
 
 /* Macros to test type */
-#define ttisnil(o)	ttype(o) == LUA_TNIL
-#define ttisnumber(o)	ttype(o) == LUA_TNUMBER
-#define ttisstring(o)	ttype(o) == LUA_TSTRING
-#define ttistable(o)	ttype(o) == LUA_TTABLE
-#define ttisfunction(o)	ttype(o) == LUA_TFUNCTION
-#define ttisboolean(o)	ttype(o) == LUA_TBOOLEAN
-#define ttisuserdata(o)	ttype(o) == LUA_TUSERDATA
-#define ttisthread(o)	ttype(o) == LUA_TTHREAD
-#define ttislightuserdata(o)	ttype(o) == LUA_TLIGHTUSERDATA
+#define ttisnil(o)	(ttype(o) == LUA_TNIL)
+#define ttisnumber(o)	(ttype(o) == LUA_TNUMBER)
+#define ttisstring(o)	(ttype(o) == LUA_TSTRING)
+#define ttistable(o)	(ttype(o) == LUA_TTABLE)
+#define ttisfunction(o)	(ttype(o) == LUA_TFUNCTION)
+#define ttisboolean(o)	(ttype(o) == LUA_TBOOLEAN)
+#define ttisuserdata(o)	(ttype(o) == LUA_TUSERDATA)
+#define ttisthread(o)	(ttype(o) == LUA_TTHREAD)
+#define ttislightuserdata(o)	(ttype(o) == LUA_TLIGHTUSERDATA)
 
 /* Macros to access values */
 #define ttype(o)	((o)->tt)

--- a/src/external/lua-5.1.5/src/lua.h
+++ b/src/external/lua-5.1.5/src/lua.h
@@ -5,6 +5,7 @@
 ** See Copyright Notice at the end of this file
 */
 
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 
 #ifndef lua_h
 #define lua_h


### PR DESCRIPTION
This fixes/silences a couple of compiler warnings in the Lua 5.1 source, appearing in Apple's latest shipped clang. These broke the build with `-Werror` on latest OS X.
Not sure how `-Wno-parentheses-equality` behaves in other or older compilers.  According to https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html this should at least not concern GCC.
If merged this closes #776.