### PR TITLE
introduce dates for manuals

### DIFF
--- a/doc/manuals/annotationsketch.tex
+++ b/doc/manuals/annotationsketch.tex
@@ -50,6 +50,7 @@
 \subject{Supplementary Information}
 \author{Sascha Steinbiss, Gordon Gremme, Christin Sch\"arfer, Malte Mader\\ and Stefan Kurtz}
 
+\date{11/07/2012}
 \begin{document}
 
 \maketitle

--- a/doc/manuals/genomediff.tex
+++ b/doc/manuals/genomediff.tex
@@ -59,6 +59,7 @@ comment=[l]{--}%
   \url{willrodt@zbh.uni-hamburg.de}\\
 \end{tabular}}
 
+\date{02/10/2012}
 \begin{document}
 %\tsuhhfamily
 \maketitle

--- a/doc/manuals/hop.tex
+++ b/doc/manuals/hop.tex
@@ -32,6 +32,7 @@
          \url{kurtz@zbh.uni-hamburg.de}\\[1cm]
         \end{tabular}}
 
+\date{15/05/2014}
 \begin{document}
 \maketitle
 

--- a/doc/manuals/ltrdigest.tex
+++ b/doc/manuals/ltrdigest.tex
@@ -41,6 +41,7 @@
         \end{tabular}
         \end{tabular}}
 
+\date{26/08/2013}
 \begin{document}
 \maketitle
 

--- a/doc/manuals/ltrharvest.tex
+++ b/doc/manuals/ltrharvest.tex
@@ -41,6 +41,7 @@ a manual}
         \url{http://www.biomedcentral.com/1471-2105/9/18}
         \end{tabular}
         \end{tabular}}
+\date{26/08/2013}
 \begin{document}
 \maketitle
 

--- a/doc/manuals/mgth.tex
+++ b/doc/manuals/mgth.tex
@@ -37,6 +37,7 @@ a manual}
          20146 Hamburg\\
          Germany\\[1cm]
         \end{tabular}}
+\date{26/08/2013}
 \begin{document}
 \maketitle
 

--- a/doc/manuals/packedindex.tex
+++ b/doc/manuals/packedindex.tex
@@ -38,6 +38,7 @@
 %        BMC Bioinformatics 2008, 9:18
         \end{tabular}
         \end{tabular}}
+\date{26/08/2013}
 \begin{document}
 \maketitle
 

--- a/doc/manuals/readjoiner.tex
+++ b/doc/manuals/readjoiner.tex
@@ -45,6 +45,7 @@
          \url{kurtz@zbh.uni-hamburg.de}\\[1cm]
         \end{tabular}}
 
+\date{18/02/2014}
 \begin{document}
 \maketitle
 

--- a/doc/manuals/repfind.tex
+++ b/doc/manuals/repfind.tex
@@ -28,6 +28,7 @@
          University of Hamburg
         \end{tabular}}
 
+\date{26/08/2013}
 \begin{document}
 \maketitle
 This manual describes the options of the program \Repfind. It also gives

--- a/doc/manuals/tagerator.tex
+++ b/doc/manuals/tagerator.tex
@@ -22,6 +22,7 @@
          University of Hamburg
         \end{tabular}}
 
+\date{26/08/2013}
 \begin{document}
 \maketitle
 

--- a/doc/manuals/tallymer.tex
+++ b/doc/manuals/tallymer.tex
@@ -95,6 +95,7 @@ a manual}
          University of Hamburg
         \end{tabular}}
 
+\date{26/08/2013}
 \begin{document}
 \maketitle
 This manual describes the \textit{Tallymer}-software, a collection of programs

--- a/doc/manuals/uniquesub.tex
+++ b/doc/manuals/uniquesub.tex
@@ -47,6 +47,7 @@
          University of Hamburg
         \end{tabular}}
 
+\date{26/08/2013}
 \begin{document}
 \maketitle
 


### PR DESCRIPTION
IMHO manuals should have a specific date, and the date they were built should not be meaningful there. This commit initialises the date fields in the manuals by setting the date to the last modification date of the file in git, as given by:
```
for f in doc/manuals/*.tex; do
  export OUT=`TZ=UTC LC_ALL=C date -d "$(git log -1 --format='%aD' -- $f )" +'%d\/%m\/%Y'`;
  sed -ri "s/.begin.document./\\\date{$OUT}\n\\\begin{document}/g" $f;
  unset OUT;
done
```
OK with everyone?