### PR TITLE
Revert "use basename as indexname for encoded seq in bioseq"

### DIFF
--- a/src/core/bioseq.c
+++ b/src/core/bioseq.c
@@ -40,7 +40,6 @@
 #include "core/undef_api.h"
 #include "core/unused_api.h"
 #include "core/xansi_api.h"
-#include "core/basename_api.h"
 #include "core/xposix.h"
 
 struct GtBioseq {
@@ -163,11 +162,7 @@ static int bioseq_fill(GtBioseq *bs, bool recreate, GtError *err)
     /* assign a unique name */
     gt_str_append_uword(bioseq_basename, (GtUword) bs);
   } else
-  {
-    char *basename = gt_basename(gt_str_get(bs->sequence_file));
-    bioseq_basename = gt_str_new_cstr(basename);
-    gt_free(basename);
-  }
+    bioseq_basename = bs->sequence_file;
 
   /* construct file names */
   bioseq_index_file = gt_str_clone(bioseq_basename);
@@ -212,7 +207,8 @@ static int bioseq_fill(GtBioseq *bs, bool recreate, GtError *err)
   }
 
   /* free */
-  gt_str_delete(bioseq_basename);
+  if (bs->use_stdin)
+    gt_str_delete(bioseq_basename);
   gt_str_delete(bioseq_index_file);
   gt_str_delete(bioseq_ois_file);
   gt_str_delete(bioseq_md5_file);


### PR DESCRIPTION
This reverts commit c4b5870965270ac3ffb12379c19c2b8bdce54935.

See #791