### PR TITLE
make unit tests compatible with Python 2.6

### DIFF
--- a/gtpython/tests/test_version.py
+++ b/gtpython/tests/test_version.py
@@ -22,7 +22,7 @@ import unittest
 class VersionTest(unittest.TestCase):
 
     def test_has_version(self):
-        self.assertIsNotNone(gt.__version__)
+        self.assertNotEqual(gt.__version__, None)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This removes the dependency on `assertIsNotNone()` which was only added in Python 2.7 and causes tests to fail on Python 2.6. Closes #795.