### PR TITLE
extend wording options for speck matchers

### DIFF
--- a/gtdata/spec/speclib.lua
+++ b/gtdata/spec/speclib.lua
@@ -211,3 +211,17 @@ matchers = {
   end;
 }
 matchers.should_equal = matchers.should_be
+
+-- also make matchers available as expect(foo).to_X() instead of
+-- expect(foo).should_X() to make them more similar to natural language
+_matchers = {}
+for m, f in pairs(matchers) do
+  if m:match('^should_') then
+    if m:match('^should_not_') then
+      _matchers[m:gsub('should_not_', 'not_to_')] = f
+    end
+    _matchers[m:gsub('should_', 'to_')] = f
+  end
+  _matchers[m] = f
+end
+matchers = _matchers


### PR DESCRIPTION
This PR introduces more natural sounding wording for the speck matchers. That is, instead of
```
expect(foo).should_be(bar);
```
you can now additionally use

```
expect(foo).to_be(bar);
```

For negative assertions, multiple variants are recognized, i.e.:

```
expect(foo).should_not_contain(bar);
```
can also be written as:
```
expect(foo).to_not_contain(bar);
```
or even
```
expect(foo).not_to_contain(bar);
```