### PR TITLE
add GtRegionMapping to Lua bindings

### DIFF
--- a/src/gtlua/region_mapping_lua.c
+++ b/src/gtlua/region_mapping_lua.c
@@ -179,8 +179,8 @@ static int region_mapping_lua_get_md5_fingerprint(lua_State *L)
     rng = check_range(L, 3);
   seqidstr = gt_str_new_cstr(seqid);
   err = gt_error_new();
-  md5   = gt_region_mapping_get_md5_fingerprint(*region_mapping, seqidstr,
-                                                rng, &offset, err);
+  md5 = gt_region_mapping_get_md5_fingerprint(*region_mapping, seqidstr,
+                                              rng, &offset, err);
   gt_str_delete(seqidstr);
   if (!md5)
     return gt_lua_error(L, err);

--- a/src/gtlua/region_mapping_lua.c
+++ b/src/gtlua/region_mapping_lua.c
@@ -1,5 +1,6 @@
 /*
   Copyright (c) 2008 Gordon Gremme <gordon@gremme.org>
+  Copyright (c) 2016 Sascha Steinbiss <sascha@steinbiss.name>
   Copyright (c) 2008 Center for Bioinformatics, University of Hamburg
 
   Permission to use, copy, modify, and distribute this software for any

--- a/src/gtlua/region_mapping_lua.c
+++ b/src/gtlua/region_mapping_lua.c
@@ -108,6 +108,32 @@ static int region_mapping_lua_get_sequence_length(lua_State *L)
   return 1;
 }
 
+static int region_mapping_lua_get_sequence(lua_State *L)
+{
+  GtRegionMapping **region_mapping;
+  GtError *err;
+  GtStr *seqidstr;
+  char *result;
+  GtUword start, end;
+  const char *seqid;
+  int had_err = 0;
+  gt_assert(L);
+  region_mapping = check_region_mapping(L, 1);
+  err = gt_error_new();
+  seqid = luaL_checkstring(L, 2);
+  start = luaL_checknumber(L, 3);
+  end = luaL_checknumber(L, 4);
+  seqidstr = gt_str_new_cstr(seqid);
+  had_err = gt_region_mapping_get_sequence(*region_mapping, &result, seqidstr,
+                                           start, end, err);
+  gt_str_delete(seqidstr);
+  if (had_err)
+    return gt_lua_error(L, err);
+  gt_error_delete(err);
+  lua_pushstring(L, result);
+  return 1;
+}
+
 static int region_mapping_lua_delete(lua_State *L)
 {
   GtRegionMapping **region_mapping;
@@ -139,6 +165,7 @@ static const struct luaL_Reg region_mapping_lib_f [] = {
 
 static const struct luaL_Reg region_mapping_lib_m [] = {
   { "get_sequence_length", region_mapping_lua_get_sequence_length },
+  { "get_sequence", region_mapping_lua_get_sequence },
   { NULL, NULL }
 };
 

--- a/src/gtlua/region_mapping_lua.c
+++ b/src/gtlua/region_mapping_lua.c
@@ -17,9 +17,11 @@
 */
 
 #include "lauxlib.h"
+#include "core/ma_api.h"
 #include "extended/luahelper.h"
 #include "extended/region_mapping.h"
 #include "gtlua/region_mapping_lua.h"
+#include "gtlua/range_lua.h"
 #include "gtlua/gtcore_lua.h"
 
 static int region_mapping_lua_new_seqfile_matchdesc(lua_State *L)
@@ -95,9 +97,9 @@ static int region_mapping_lua_get_sequence_length(lua_State *L)
   int had_err = 0;
   gt_assert(L);
   region_mapping = check_region_mapping(L, 1);
-  err = gt_error_new();
   seqid = luaL_checkstring(L, 2);
   seqidstr = gt_str_new_cstr(seqid);
+  err = gt_error_new();
   had_err = gt_region_mapping_get_sequence_length(*region_mapping, &length,
                                                   seqidstr, err);
   gt_str_delete(seqidstr);
@@ -119,11 +121,14 @@ static int region_mapping_lua_get_sequence(lua_State *L)
   int had_err = 0;
   gt_assert(L);
   region_mapping = check_region_mapping(L, 1);
-  err = gt_error_new();
   seqid = luaL_checkstring(L, 2);
   start = luaL_checknumber(L, 3);
   end = luaL_checknumber(L, 4);
+  luaL_argcheck(L, start > 0, 3, "must be > 0");
+  luaL_argcheck(L, end > 0, 4, "must be > 0");
+  luaL_argcheck(L, start <= end, 3, "must be <= endpos");
   seqidstr = gt_str_new_cstr(seqid);
+  err = gt_error_new();
   had_err = gt_region_mapping_get_sequence(*region_mapping, &result, seqidstr,
                                            start, end, err);
   gt_str_delete(seqidstr);
@@ -131,7 +136,58 @@ static int region_mapping_lua_get_sequence(lua_State *L)
     return gt_lua_error(L, err);
   gt_error_delete(err);
   lua_pushstring(L, result);
+  gt_free(result);
   return 1;
+}
+
+static int region_mapping_lua_get_description(lua_State *L)
+{
+  GtRegionMapping **region_mapping;
+  GtError *err;
+  GtStr *seqidstr, *descstr = NULL;
+  const char *seqid;
+  int had_err = 0;
+  gt_assert(L);
+  region_mapping = check_region_mapping(L, 1);
+  seqid = luaL_checkstring(L, 2);
+  seqidstr = gt_str_new_cstr(seqid);
+  descstr = gt_str_new();
+  err = gt_error_new();
+  had_err = gt_region_mapping_get_description(*region_mapping, descstr,
+                                              seqidstr, err);
+  gt_str_delete(seqidstr);
+  if (had_err)
+    return gt_lua_error(L, err);
+  gt_error_delete(err);
+  lua_pushstring(L, gt_str_get(descstr));
+  gt_str_delete(descstr);
+  return 1;
+}
+
+static int region_mapping_lua_get_md5_fingerprint(lua_State *L)
+{
+  GtRegionMapping **region_mapping;
+  GtError *err;
+  GtStr *seqidstr;
+  GtRange *rng = NULL;
+  GtUword offset;
+  const char *md5 = NULL, *seqid;
+  gt_assert(L);
+  region_mapping = check_region_mapping(L, 1);
+  seqid = luaL_checkstring(L, 2);
+  if (lua_gettop(L) == 3)
+    rng = check_range(L, 3);
+  seqidstr = gt_str_new_cstr(seqid);
+  err = gt_error_new();
+  md5   = gt_region_mapping_get_md5_fingerprint(*region_mapping, seqidstr,
+                                                rng, &offset, err);
+  gt_str_delete(seqidstr);
+  if (!md5)
+    return gt_lua_error(L, err);
+  gt_error_delete(err);
+  lua_pushstring(L, md5);
+  lua_pushnumber(L, offset);
+  return 2;
 }
 
 static int region_mapping_lua_delete(lua_State *L)
@@ -166,6 +222,8 @@ static const struct luaL_Reg region_mapping_lib_f [] = {
 static const struct luaL_Reg region_mapping_lib_m [] = {
   { "get_sequence_length", region_mapping_lua_get_sequence_length },
   { "get_sequence", region_mapping_lua_get_sequence },
+  { "get_description", region_mapping_lua_get_description },
+  { "get_md5_fingerprint", region_mapping_lua_get_md5_fingerprint },
   { NULL, NULL }
 };
 

--- a/src/gtlua/region_mapping_lua.h
+++ b/src/gtlua/region_mapping_lua.h
@@ -1,5 +1,6 @@
 /*
   Copyright (c) 2008 Gordon Gremme <gordon@gremme.org>
+  Copyright (c) 2016 Sascha Steinbiss <sascha@steinbiss.name>
   Copyright (c) 2008 Center for Bioinformatics, University of Hamburg
 
   Permission to use, copy, modify, and distribute this software for any
@@ -26,6 +27,23 @@
    -- Returns a new region mapping which maps everything onto sequence file
    -- <seqfile>.
    function region_mapping_new_seqfile(seqfile)
+
+   -- Use <region_mapping> to extract the sequence from <start> to <end> of the
+   -- given sequence ID <seqid>.
+   function region_mapping:get_sequence(seqid, start, end)
+
+   -- Use <region_mapping> to retrieve the sequence length of the given
+   sequence ID <seqid>.
+   function region_mapping:get_sequence_length(seqid)
+
+   -- Use <region_mapping> to get the description of the MD5 sequence ID
+   -- <seqid>.
+   function region_mapping:get_description(seqid)
+
+   -- Use <region_mapping> to return the MD5 fingerprint of the sequence with
+   -- the sequence ID <seqid> and its corresponding <range> (optional).
+   -- Returns both the MD5 fingerprint as a string and the offset.
+   function region_mapping:get_md5_fingerprint(seqid, range)
 */
 int gt_lua_open_region_mapping(lua_State*);
 


### PR DESCRIPTION
This PR addresses #804 by implementing the GtRegionMapping API, allowing to access sequences by their seqid to pull out sequences as strings, sequence lengths, descriptions (headers) and fingerprints.