### PR TITLE
return non-zero status code on error or failure

### DIFF
--- a/src/extended/spec_results.h
+++ b/src/extended/spec_results.h
@@ -18,6 +18,7 @@
 #ifndef SPEC_RESULTS_H
 #define SPEC_RESULTS_H
 
+#include <stdbool.h>
 #include "core/error_api.h"
 #include "core/file_api.h"
 #include "extended/genome_node_api.h"
@@ -39,6 +40,8 @@ void           gt_spec_results_add_result(GtSpecResults *sr,
 void           gt_spec_results_add_cc(GtSpecResults *sr);
 void           gt_spec_results_record_warning(GtSpecResults *sr, const char *w);
 void           gt_spec_results_record_per_node(GtSpecResults *sr);
+bool           gt_spec_results_has_failures(GtSpecResults *sr);
+bool           gt_spec_results_has_runtime_errors(GtSpecResults *sr);
 
 void           gt_spec_results_report(GtSpecResults *sr, GtFile *outfile,
                                       const char *specfile, bool details,

--- a/src/tools/gt_speck.c
+++ b/src/tools/gt_speck.c
@@ -303,8 +303,8 @@ static int gt_speck_runner(int argc, const char **argv, int parsed_args,
       gt_str_delete(runtime);
     }
 
-    if (gt_spec_results_has_runtime_errors(res)
-          || gt_spec_results_has_failures(res)) {
+    if (!had_err && (gt_spec_results_has_runtime_errors(res)
+          || gt_spec_results_has_failures(res))) {
       had_err = -2;
     }
   }

--- a/src/tools/gt_speck.c
+++ b/src/tools/gt_speck.c
@@ -1,6 +1,6 @@
 /*
-  Copyright (c) 2014-2015 Sascha Steinbiss <ss34@sanger.ac.uk>
-  Copyright (c) 2014-2015 Genome Research Ltd.
+  Copyright (c) 2014-2016 Sascha Steinbiss <ss34@sanger.ac.uk>
+  Copyright (c) 2014-2016 Genome Research Ltd.
 
   Permission to use, copy, modify, and distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -301,6 +301,11 @@ static int gt_speck_runner(int argc, const char **argv, int parsed_args,
                                                 arguments->colored,
                                                 gt_str_get(runtime), err);
       gt_str_delete(runtime);
+    }
+
+    if (gt_spec_results_has_runtime_errors(res)
+          || gt_spec_results_has_failures(res)) {
+      had_err = -2;
     }
   }
 


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - return non-zero status code when a run resulted in a runtime error or failed check 

## Related issues

Closes #811.
