### PR TITLE
skip assertion if had_err is set

### DIFF
--- a/src/tools/gt_readjoiner_assembly.c
+++ b/src/tools/gt_readjoiner_assembly.c
@@ -469,7 +469,7 @@ static int gt_readjoiner_assembly_build_contained_reads_list(
     gt_str_append_cstr(filename, GT_READJOINER_SUFFIX_CNTLIST);
     had_err = gt_cntlist_parse(gt_str_get(filename), false, contained,
         &nofreads_i, err);
-    gt_assert(nofreads == nofreads_i);
+    gt_assert(had_err || nofreads == nofreads_i);
   }
   gt_str_delete(filename);
   return had_err;


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - check for errors in assertion -- this might fix a case where the error code in a function that can fail at runtime is not checked before checking an invariant on the results 

## Related issues

Adresses #806.

