### PR TITLE
allow compiling with GCC 6

### DIFF
--- a/src/core/encseq.c
+++ b/src/core/encseq.c
@@ -3298,7 +3298,7 @@ void gt_specialrangeiterator_reinit_with_startpos(GtSpecialrangeiterator *sri,
   sri->lengthofspecialrange = 0;
   if (sri->esr != NULL)
     gt_encseq_reader_delete(sri->esr);
-    sri->esr = gt_encseq_create_reader_with_readmode(encseq,
+  sri->esr = gt_encseq_create_reader_with_readmode(encseq,
                                                    moveforward
                                                      ? GT_READMODE_FORWARD
                                                      : GT_READMODE_REVERSE,

--- a/src/external/lua-5.1.5/src/ltablib.c
+++ b/src/external/lua-5.1.5/src/ltablib.c
@@ -137,7 +137,7 @@ static void addfield (lua_State *L, luaL_Buffer *b, int i) {
   if (!lua_isstring(L, -1))
     luaL_error(L, "invalid value (%s) at index %d in table for "
                   LUA_QL("concat"), luaL_typename(L, -1), i);
-    luaL_addvalue(b);
+  luaL_addvalue(b);
 }
 
 

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -152,11 +152,12 @@ static void dotty(lua_State *L) {
     if (status == 0 && lua_gettop(L) > 0) {  /* any result to print? */
       lua_getglobal(L, "print");
       lua_insert(L, 1);
-      if (lua_pcall(L, lua_gettop(L)-1, 0, 0) != 0)
+      if (lua_pcall(L, lua_gettop(L)-1, 0, 0) != 0) {
         fprintf(stderr, "%s\n", lua_pushfstring(L,
                                "error calling " LUA_QL("print") " (%s)",
                                lua_tostring(L, -1)));
         fflush(stderr);
+      }
     }
   }
   lua_settop(L, 0);  /* clear stack */


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Address warnings introduced by some new static checks in GCC 6 that cause builds to fail due to
`-Werror`. In this case, the warnings are complaining about potentially misleading indentation.
  
GCC6 is expected to be the default compiler in Debian stretch and also other Debian-derived distros so we better fix this asap.