### PR TITLE
Fix documentation building

### DIFF
--- a/gtdata/modules/gtdoclib/docvisitorlatex.lua
+++ b/gtdata/modules/gtdoclib/docvisitorlatex.lua
@@ -131,7 +131,10 @@ function DocVisitorLaTeX:visit_method(desc)
   else
     name = trim(desc.name)
   end
-  local aligncol = string.find(name, '_') - 1
+  local aligncol = string.len(name) + 1
+  if string.find(name, '_') then
+    aligncol = string.find(name, '_') - 1
+  end
   if desc.args then
     args = align(trim(desc.args),aligncol)
   else

--- a/www/genometools.org/htdocs/docs.html
+++ b/www/genometools.org/htdocs/docs.html
@@ -143,41 +143,6 @@ Returns a random number between 0 and <code>val</code>.
 Reload <code>gt</code> module.
 </p>
 <hr>
-<a name="export"></a>
-
-<code> export()</code>
-<p>
-Export the content of <code>gt</code> table to the global environment.
-</p>
-<hr>
-<a name="display"></a>
-
-<code> display(filename)</code>
-<p>
-Call external 'display' program for file <code>filename</code>.
-</p>
-<hr>
-<a name="show_table"></a>
-
-<code> show_table(tbl)</code>
-<p>
-Show all keys and values of table <code>tbl</code>.
-</p>
-<hr>
-<a name="show"></a>
-
-<code> show(all)</code>
-<p>
-Show content of the <code>gt</code> table.
-</p>
-<hr>
-<a name="re"></a>
-
-<code> re()</code>
-<p>
-Reload the <code>gt</code> module and export its content to the global environment.
-</p>
-<hr>
 <a name="features_contain_marked"></a>
 
 <code> features_contain_marked(features)</code>
@@ -218,6 +183,41 @@ Return an array of genome features which contains a separate gene feature for ea
 <code> features_extract_sequences(features, type, join, region_mapping)</code>
 <p>
 Return an array with the sequences of the given features.
+</p>
+<hr>
+<a name="export"></a>
+
+<code> export()</code>
+<p>
+Export the content of <code>gt</code> table to the global environment.
+</p>
+<hr>
+<a name="display"></a>
+
+<code> display(filename)</code>
+<p>
+Call external 'display' program for file <code>filename</code>.
+</p>
+<hr>
+<a name="show_table"></a>
+
+<code> show_table(tbl)</code>
+<p>
+Show all keys and values of table <code>tbl</code>.
+</p>
+<hr>
+<a name="show"></a>
+
+<code> show(all)</code>
+<p>
+Show content of the <code>gt</code> table.
+</p>
+<hr>
+<a name="re"></a>
+
+<code> re()</code>
+<p>
+Reload the <code>gt</code> module and export its content to the global environment.
 </p>
 <hr>
 <a name="Alphabet"></a>
@@ -1000,6 +1000,13 @@ Show range on stdout.
 Returns a new region mapping which maps everything onto sequence file <code>seqfile</code>.
 </p>
 <hr>
+<a name="region_mapping:get_sequence"></a>
+
+<code> region_mapping:get_sequence(seqid, start, end)</code>
+<p>
+Use <code>region_mapping</code> to extract the sequence from <code>start</code> to <code>end</code> of the given sequence ID <code>seqid</code>.
+</p>
+<hr>
 <a name="RegionNode"></a>
 <h2>Class RegionNode</h2>
 <a name="region_node_new"></a>
@@ -1339,6 +1346,8 @@ Returns translated <code>dna</code>.
 
   <a href="#re"><code>re</code></a><br>
 
+  <a href="#region_mapping:get_sequence"><code>region_mapping:get_sequence</code></a><br>
+
   <a href="#region_mapping_new_seqfile"><code>region_mapping_new_seqfile</code></a><br>
 
   <a href="#region_node_new"><code>region_node_new</code></a><br>
@@ -1378,7 +1387,7 @@ Returns translated <code>dna</code>.
 <div id="footer">
 Copyright &copy; 2008-2016
 The <i>GenomeTools</i> authors.
-Last update: 2016-04-12
+Last update: 2016-07-21
 </div>
 </div>
 <!-- Piwik -->

--- a/www/genometools.org/htdocs/libgenometools.html
+++ b/www/genometools.org/htdocs/libgenometools.html
@@ -371,6 +371,15 @@ Duplicate internal feature nodes of type <code>source_type</code> as features wi
    <code>dest_type</code>. The duplicated features does not inherit the children.
 </p>
 <hr>
+<a name="GtTrackSelectorFunc"></a>
+
+<code>void  GtTrackSelectorFunc(GtBlock*, GtStr*, void*)</code>
+<p>
+A <code>GtTrackSelectorFunc</code> is a callback function which sets a <code>GtStr</code> to a
+   string to be used as a track identifier for assignment of a <code>GtBlock</code>
+   to a given track.
+</p>
+<hr>
 <a name="GtTrackOrderingFunc"></a>
 
 <code>int  GtTrackOrderingFunc(const char *s1, const char *s2, void *data)</code>
@@ -380,15 +389,6 @@ A function describing the order of tracks based on their track identifier
    should appear before the track with ID <code>s2</code> and a positive value if <code>s1</code>
    should appear after <code>s2</code>. Returning a value of 0 will result in an undefined
    ordering of <code>s1</code> and <code>s2</code>.
-</p>
-<hr>
-<a name="GtTrackSelectorFunc"></a>
-
-<code>void  GtTrackSelectorFunc(GtBlock*, GtStr*, void*)</code>
-<p>
-A <code>GtTrackSelectorFunc</code> is a callback function which sets a <code>GtStr</code> to a
-   string to be used as a track identifier for assignment of a <code>GtBlock</code>
-   to a given track.
 </p>
 <hr>
 <a name="GtAddIntronsStream"></a>
@@ -12076,7 +12076,7 @@ Similar to <code>vsnprintf(3)</code>, terminates on error.
 <div id="footer">
 Copyright &copy; 2008-2016
 The <i>GenomeTools</i> authors.
-Last update: 2016-04-12
+Last update: 2016-07-21
 </div>
 </div>
 <!-- Piwik -->

--- a/www/genometools.org/htdocs/tools/gt_seed_extend.html
+++ b/www/genometools.org/htdocs/tools/gt_seed_extend.html
@@ -177,6 +177,14 @@ Divide data into specified number of parts (default: 1)
 </p>
 </dd>
 <dt class="hdlist1">
+<strong>-kmerfile</strong> [<em>yes|no</em>]
+</dt>
+<dd>
+<p>
+Use pre-calculated k-mers from file (if exist) (default: yes)
+</p>
+</dd>
+<dt class="hdlist1">
 <strong>-v</strong> [<em>yes|no</em>]
 </dt>
 <dd>


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Only use the location of `_` in a function name to align parameters if it exists. Currently this would break for `GtTrackSelectorFunc` which is handled like a function name while it is a function pointer type. 
  - Update documentation prior to release

## Related issues

Fixes #821.
