### PR TITLE
spelling: positon -> position

### DIFF
--- a/src/extended/condenseq_creator.c
+++ b/src/extended/condenseq_creator.c
@@ -1723,7 +1723,7 @@ int gt_condenseq_creator_create(GtCondenseqCreator *condenseq_creator,
   if (!had_err) {
     if (gt_showtime_enabled())
       gt_timer_show_progress(timer, "write data, alphabet", stderr);
-    gt_log_log(GT_WU " kmer positons in final kmer_db",
+    gt_log_log(GT_WU " kmer positions in final kmer_db",
                gt_kmer_database_get_kmer_count(condenseq_creator->kmer_db));
     gt_log_log(GT_WU " xdrop calls.", ces_c_xdrops);
     gt_log_log(GT_WU " uniques", condenseq_creator->ces->udb_nelems);

--- a/src/extended/wtree_encseq.c
+++ b/src/extended/wtree_encseq.c
@@ -84,7 +84,7 @@ static GtWtreeSymbol gt_wtree_encseq_access_rec(GtWtreeEncseq *we,
 
     if (bit == 0) {
       pos = gt_compressed_bitsequence_rank_0(we->c_bits, node_start + pos) -
-        zero_rank_prefix - 1; /*convert count (rank) to positon */
+        zero_rank_prefix - 1; /*convert count (rank) to position */
       alpha_end = middle;
       node_start += we->parent_instance.members->length;
       node_size = left_child_size;
@@ -96,7 +96,7 @@ static GtWtreeSymbol gt_wtree_encseq_access_rec(GtWtreeEncseq *we,
         one_rank_prefix =
           gt_compressed_bitsequence_rank_1(we->c_bits, node_start - 1);
       pos = gt_compressed_bitsequence_rank_1(we->c_bits, node_start + pos) -
-        one_rank_prefix - 1; /*convert count (rank) to positon */
+        one_rank_prefix - 1; /*convert count (rank) to position */
       alpha_start = middle + 1;
       node_size =
         gt_compressed_bitsequence_rank_1(we->c_bits,

--- a/src/match/seqabstract.h
+++ b/src/match/seqabstract.h
@@ -71,7 +71,7 @@ void           gt_seqabstract_reinit_encseq(bool rightextension,
 /* return the length of <sa> */
 GtUword        gt_seqabstract_length(const GtSeqabstract *sa);
 
-/* return character at positon <idx> (relative to <startpos>) of <sa> */
+/* return character at position <idx> (relative to <startpos>) of <sa> */
 GtUchar        gt_seqabstract_encoded_char(const GtSeqabstract *sa,
                                            GtUword idx);
 

--- a/src/match/sfx-diffcov.c
+++ b/src/match/sfx-diffcov.c
@@ -491,7 +491,7 @@ static GtUword dc_derivespecialcodesonthefly(GtDifferencecover *dcov,
   return countderived;
 }
 
-static int dc_compareCodeatpositon(const void *vala,const void *valb)
+static int dc_compareCodeatposition(const void *vala,const void *valb)
 {
   const Codeatposition *a = (const Codeatposition *) vala;
   const Codeatposition *b = (const Codeatposition *) valb;
@@ -516,7 +516,7 @@ static int dc_compareCodeatpositon(const void *vala,const void *valb)
   return 0;
 }
 
-static void dc_validate_samplepositons(const GtDifferencecover *dcov)
+static void dc_validate_samplepositions(const GtDifferencecover *dcov)
 {
   GtUword pos;
   unsigned int modvalue;
@@ -1268,7 +1268,7 @@ static void dc_differencecover_sortsample(GtDifferencecover *dcov,
     gt_assert(codelist.spaceCodeatposition != NULL);
     qsort(codelist.spaceCodeatposition,
           (size_t) codelist.nextfreeCodeatposition,
-          sizeof (*codelist.spaceCodeatposition),dc_compareCodeatpositon);
+          sizeof (*codelist.spaceCodeatposition),dc_compareCodeatposition);
   }
   if (dcov->effectivesamplesize > 0)
   {
@@ -1690,7 +1690,7 @@ void gt_differencecover_check(const GtEncseq *encseq,GtReadmode readmode)
     printf("v=%u (size=%u)\n",dcov->vparam,dcov->size);
     if (withcheck)
     {
-      dc_validate_samplepositons(dcov);
+      dc_validate_samplepositions(dcov);
     }
     dc_differencecover_sortsample(dcov,NULL,NULL,NULL,withcheck);
     gt_differencecover_delete(dcov);

--- a/src/tools/gt_show_seedext.c
+++ b/src/tools/gt_show_seedext.c
@@ -119,7 +119,7 @@ static GtOptionParser* gt_show_seedext_option_parser_new(void *tool_arguments)
 
   /* -sort */
   op_sortmatches = gt_option_new_bool("sort","sort matches in ascending order "
-                                             "of their end positon on the "
+                                             "of their end position on the "
                                              "query",
                                       &arguments->sortmatches,false);
   gt_option_parser_add_option(op, op_sortmatches);


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Fix spelling of 'position' in various non-API function names and comments.
