### PR TITLE
travis: do not run brew as root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,5 +57,5 @@ matrix:
     - compiler: x86_64-w64-mingw32-gcc
       env: SYSTEM=Windows MACHINE=i686 GT_BITS=64 AR=x86_64-w64-mingw32-ar fpic=no cairo=no sharedlib=no CFLAGS='-Wno-error=attributes -Wno-error=unused-parameter -DSQLITE_MALLOCSIZE=_msize'
 before_install:
-  - sudo ./scripts/travis_installdeps.sh
+  - ./scripts/travis_installdeps.sh
 script: ./scripts/travis_test.rb

--- a/scripts/travis_installdeps.sh
+++ b/scripts/travis_installdeps.sh
@@ -2,10 +2,10 @@
 
 echo $TRAVIS_OS_NAME
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  apt-get update -q
-  apt-get install ncbi-blast+ gcc-multilib -y
-  apt-get install binutils-mingw-w64-i686 gcc-mingw-w64-i686 -y
-  apt-get install binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64 -y
+  sudo apt-get update -q
+  sudo apt-get install ncbi-blast+ gcc-multilib -y
+  sudo apt-get install binutils-mingw-w64-i686 gcc-mingw-w64-i686 -y
+  sudo apt-get install binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64 -y
 else
   brew update
   brew install pango cairo


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Do not run Homebrew's `brew` as root as it breaks Travis runs. 
