### PR TITLE
Fix building on GCC7

### DIFF
--- a/src/extended/gff3_escaping.c
+++ b/src/extended/gff3_escaping.c
@@ -178,23 +178,23 @@ int gt_gff3_escaping_unit_test(GtError *err)
 
   /* test allowed chars, need not be escaped but should be unescaped */
   for (i = ' '; !had_err && i < 0x7F; i++) {
-    char code[4];
-    snprintf(code, 4, "%%%02X", i);
+    char code[10];
+    snprintf(code, 10, "%%%02X", i);
     had_err = test_single_escaping((char) i, code, false, true, err);
   }
 
   /* control characters, must be escaped and unescaped */
   for (i = 1; !had_err && i < ' '; i++) {
-    char code[4];
-    snprintf(code, 4, "%%%02X", i);
+    char code[10];
+    snprintf(code, 10, "%%%02X", i);
     had_err = test_single_escaping((char) i, code, true, true, err);
   }
 
   /* non-hex codes (e.g. '%ZS') should be ignored altogether */
   for (i = 0x7F; !had_err && i <= 0xFF; i++) {
-    char code[10];
-    snprintf(code, 10, "foo%%%Xbar", i);
-    had_err = gt_gff3_unescape(unescaped, code, 10, err);
+    char code[16];
+    snprintf(code, 16, "foo%%%Xbar", i);
+    had_err = gt_gff3_unescape(unescaped, code, 16, err);
     gt_ensure(!strcmp(gt_str_get(unescaped), code));
     gt_str_reset(unescaped);
   }

--- a/src/match/eis-bwtseq-context.c
+++ b/src/match/eis-bwtseq-context.c
@@ -287,7 +287,7 @@ BWTSeqCRMapOpen(unsigned short mapIntervalLog2,
                             seqLen, mapIntervalLog2));
     mapName = gt_str_new_cstr(projectName);
     {
-      char buf[1 + 4 + 3];
+      char buf[1 + 4 + 3 + 2];
       snprintf(buf, sizeof (buf), ".%ucxm", (unsigned)mapIntervalLog2);
       gt_str_append_cstr(mapName, buf);
       if (createMapFile)

--- a/src/match/gfa_writer.c
+++ b/src/match/gfa_writer.c
@@ -48,6 +48,7 @@ static inline const char *gt_gfa_writer_versionstr(GtGfaVersion version)
     default:
       gt_assert(false);
   }
+  return "UNKNOWN";
 }
 
 int gt_gfa_writer_show_header(GtGfaWriter *gw,


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes to allow proper building on GCC7 with `-Werror`:

  - Adjust buffer sizes to allow for variable length `sprintf` output.
  - Address compiler complaints regarding functions not returning a value.

Error message from before (example):
```
src/match/eis-bwtseq-context.c: In function ‘gt_BWTSCRFGet’:
src/match/eis-bwtseq-context.c:291:35: error: ‘cxm’ directive output may be truncated writing 3 bytes into a region of size between 2 and 6 [-Werror=format-truncation=]
       snprintf(buf, sizeof (buf), ".%ucxm", (unsigned)mapIntervalLog2);
                                   ^~~~~~~~
In file included from /usr/include/stdio.h:938:0,
                 from src/match/eis-bwtseq-context.c:19:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:10: note: ‘__builtin___snprintf_chk’ output between 6 and 10 bytes into a destination of size 8
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Related issues

This fixes compilation except #856 which should be looked at by someone in detail.
