### PR TITLE
install gtdata into $PREFIX/share/genometools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -975,9 +975,8 @@ else
 	cp bin/gt $(prefix)/bin
 	$(STRIP) $(prefix)/bin/gt
 endif
-	test -d $(prefix)/share/genometools \
-	  || mkdir -p $(prefix)/share/genometools
-	cp -r gtdata $(prefix)/share/genometools
+	mkdir -p $(prefix)/share/genometools
+	cp -a gtdata $(prefix)/share/genometools/
 	test -d $(prefix)/include/genometools/core \
 	  || mkdir -p $(prefix)/include/genometools/core
 	cp src/core/*_api.h $(prefix)/include/genometools/core

--- a/Makefile
+++ b/Makefile
@@ -975,7 +975,9 @@ else
 	cp bin/gt $(prefix)/bin
 	$(STRIP) $(prefix)/bin/gt
 endif
-	cp -r gtdata $(prefix)/bin
+	test -d $(prefix)/share/genometools \
+	  || mkdir -p $(prefix)/share/genometools
+	cp -r gtdata $(prefix)/share/genometools
 	test -d $(prefix)/include/genometools/core \
 	  || mkdir -p $(prefix)/include/genometools/core
 	cp src/core/*_api.h $(prefix)/include/genometools/core

--- a/src/core/gtdatapath.c
+++ b/src/core/gtdatapath.c
@@ -60,16 +60,17 @@ GtStr* gt_get_gtdata_path(const char *prog, GtError *err)
       if (gt_file_exists_and_is_dir(gt_str_get(path)))
         return path;
     }
+    for (spath = GTDATA_RELATIVE_SEARCH_PATHS; *spath; spath++) {
+      had_err = gt_file_find_exec_in_path(path, prog, err);
+      if (!had_err) {
+        gt_str_append_cstr(path, *spath);
+        if (gt_file_exists_and_is_dir(gt_str_get(path)))
+          return path;
+      }
+    }
     for (defaultpath = GTDATA_DEFAULT_PATHS; *defaultpath; defaultpath++) {
       gt_str_reset(path);
       gt_str_append_cstr(path, *defaultpath);
-      if (gt_file_exists_and_is_dir(gt_str_get(path)))
-        return path;
-    }
-    for (spath = GTDATA_RELATIVE_SEARCH_PATHS; *spath; spath++) {
-      had_err = gt_file_find_exec_in_path(path, prog, err);
-      if (had_err) break;
-      gt_str_append_cstr(path, *spath);
       if (gt_file_exists_and_is_dir(gt_str_get(path)))
         return path;
     }

--- a/src/core/gtdatapath.c
+++ b/src/core/gtdatapath.c
@@ -20,6 +20,7 @@
 #include "core/compat.h"
 #include "core/fileutils.h"
 #include "core/gtdatapath.h"
+#include "core/log_api.h"
 
 #ifndef _WIN32
 #define GTDATADIR "/gtdata"
@@ -35,10 +36,14 @@ static const char* GTDATA_DEFAULT_PATHS[]
       "/usr/local/share/genometools" GTDATADIR,
       NULL };
 
+static const char* GTDATA_RELATIVE_SEARCH_PATHS[]
+  = { UPDIR "/share/genometools" GTDATADIR,
+      NULL };
+
 GtStr* gt_get_gtdata_path(const char *prog, GtError *err)
 {
   GtStr *path;
-  const char **defaultpath;
+  const char **defaultpath, **spath;
   int had_err = 0;
   gt_error_check(err);
   gt_assert(prog);
@@ -58,6 +63,13 @@ GtStr* gt_get_gtdata_path(const char *prog, GtError *err)
     for (defaultpath = GTDATA_DEFAULT_PATHS; *defaultpath; defaultpath++) {
       gt_str_reset(path);
       gt_str_append_cstr(path, *defaultpath);
+      if (gt_file_exists_and_is_dir(gt_str_get(path)))
+        return path;
+    }
+    for (spath = GTDATA_RELATIVE_SEARCH_PATHS; *spath; spath++) {
+      had_err = gt_file_find_exec_in_path(path, prog, err);
+      if (had_err) break;
+      gt_str_append_cstr(path, *spath);
       if (gt_file_exists_and_is_dir(gt_str_get(path)))
         return path;
     }


### PR DESCRIPTION
## Brief summary

- Install gtdata in `$PREFIX/share/genometools` by default.
- Extend search paths to account for relative gtdata location.

## Related issues

This addresses #618 which encourages the installation of gtdata outside `$PREFIX/bin` by default, which would also take some work away from packagers. There are also some adjustments to the relative search paths when trying to resolve the gtdata path to allow for arbitrary prefixes without having to compile them in.

