### PR TITLE
implement seqstat for arbitrary N values

### DIFF
--- a/src/extended/assembly_stats_calculator.c
+++ b/src/extended/assembly_stats_calculator.c
@@ -15,6 +15,7 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
+#include "core/array_api.h"
 #include "core/compat.h"
 #include "core/disc_distri_api.h"
 #include "core/format64.h"
@@ -29,6 +30,7 @@ struct GtAssemblyStatsCalculator
   GtUword maxlength;
   GtUword genome_length;
   GtDiscDistri *lengths;
+  GtArray *nstats;
 };
 
 GtAssemblyStatsCalculator *gt_assembly_stats_calculator_new(void)
@@ -42,6 +44,7 @@ GtAssemblyStatsCalculator *gt_assembly_stats_calculator_new(void)
   asc->minlength = 0;
   asc->maxlength = 0;
   asc->genome_length = 0;
+  asc->nstats = gt_array_new(sizeof (GtUword));
   return asc;
 }
 
@@ -50,6 +53,7 @@ void gt_assembly_stats_calculator_delete(GtAssemblyStatsCalculator *asc)
   if (asc != NULL)
   {
     gt_disc_distri_delete(asc->lengths);
+    gt_array_delete(asc->nstats);
     gt_free(asc);
   }
 }
@@ -77,7 +81,7 @@ void gt_assembly_stats_calculator_set_genome_length(
 
 #define NOF_LIMITS 5
 
-#define MAX_NOF_NSTATS 4
+#define MAX_NOF_NSTATS 10
 typedef struct
 {
   char         *name[MAX_NOF_NSTATS];
@@ -94,7 +98,8 @@ typedef struct
                third_quartile,
                three_fourth_num;
   GtUword      nvalue[MAX_NOF_NSTATS],
-               lvalue[MAX_NOF_NSTATS];
+               lvalue[MAX_NOF_NSTATS],
+               val[MAX_NOF_NSTATS];
   unsigned int nofstats;
 } Nstats;
 
@@ -134,8 +139,9 @@ static void calcNstats(GtUword key, GtUint64 value,
   }
 }
 
-#define initNstat(INDEX, NAME, LENGTH)\
+#define initNstat(INDEX, NAME, VAL, LENGTH)\
   nstats.name[INDEX] = (NAME);\
+  nstats.val[INDEX] = VAL;\
   nstats.min[INDEX] = (GtUint64) (LENGTH);\
   nstats.nvalue[INDEX] = 0;\
   nstats.lvalue[INDEX] = 0;\
@@ -169,6 +175,47 @@ GtUword gt_assembly_stats_calculator_nstat(GtAssemblyStatsCalculator *asc,
   return nstats.nvalue[0];
 }
 
+int gt_assembly_stats_calculator_register_nstat(GtAssemblyStatsCalculator *asc,
+                                                GtUword n, GtError *err)
+{
+  GtUword i;
+  bool present;
+  gt_assert(asc != NULL && n > 0);
+
+  if (n > 100) {
+    gt_error_set(err, "invalid N value " GT_WU ", must be <= 100", n);
+    return -1;
+  }
+
+  if (gt_array_size(asc->nstats) == MAX_NOF_NSTATS) {
+    gt_error_set(err, "Limit of N statistics reached (%d)", MAX_NOF_NSTATS);
+    return -1;
+  }
+
+  present = false;
+  for (i = 0; i < gt_array_size(asc->nstats); i++) {
+    if ((*(GtUword*) gt_array_get(asc->nstats, i)) == n) {
+      present = true;
+      break;
+    }
+  }
+  if (!present) {
+    gt_array_add(asc->nstats, n);
+  }
+
+  return 0;
+}
+
+int gt_assembly_stats_calculator_cmp_nstat(const void *v1, const void *v2) {
+  GtUword u1 = *(GtUword*) v1;
+  GtUword u2 = *(GtUword*) v2;
+  if (u1 < u2)
+    return -1;
+  if (u1 == u2)
+    return 0;
+  return 1;
+}
+
 void gt_assembly_stats_calculator_show(GtAssemblyStatsCalculator *asc,
     GtLogger *logger)
 {
@@ -176,13 +223,26 @@ void gt_assembly_stats_calculator_show(GtAssemblyStatsCalculator *asc,
   unsigned int i;
 
   gt_assert(asc != NULL);
+
+  /* defaults are N50/N80 */
+  if (gt_array_size(asc->nstats) == 0) {
+    gt_assembly_stats_calculator_register_nstat(asc, 50, NULL);
+    gt_assembly_stats_calculator_register_nstat(asc, 80, NULL);
+  }
+
   nstats.nofstats = 0;
-  initNstat(0, "50: ", asc->sumlength * 0.5);
-  initNstat(1, "80: ", asc->sumlength * 0.8);
-  if (asc->genome_length > 0)
-  {
-    initNstat(2, "G50:", asc->genome_length * 0.5);
-    initNstat(3, "G80:", asc->genome_length * 0.8);
+  gt_array_sort_stable(asc->nstats, gt_assembly_stats_calculator_cmp_nstat);
+  for (i = 0; i < gt_array_size(asc->nstats); i++) {
+    GtUword v = *(GtUword*) gt_array_get(asc->nstats, i);
+    initNstat(i, "", v, (GtUint64) (asc->sumlength * ((float) v / 100U)));
+  }
+  if (asc->genome_length > 0) {
+    GtUword j;
+    for (j = 0; j < gt_array_size(asc->nstats); j++) {
+      GtUword v = *(GtUword*) gt_array_get(asc->nstats, j);
+      initNstat(i + j, "G", v,
+                (GtUint64) (asc->genome_length * ((float) v / 100U)));
+    }
   }
 
   initLimit(0, 500ULL);
@@ -242,17 +302,17 @@ void gt_assembly_stats_calculator_show(GtAssemblyStatsCalculator *asc,
   {
     if (nstats.nvalue[i] > 0)
     {
-      gt_logger_log(logger, "N%s                  "GT_WU"", nstats.name[i],
-          nstats.nvalue[i]);
-      gt_logger_log(logger, "L%s                  "GT_WU"", nstats.name[i],
-          nstats.lvalue[i]);
+      gt_logger_log(logger, "N%s%02d                "GT_WU"", nstats.name[i],
+          (int) nstats.val[i], nstats.nvalue[i]);
+      gt_logger_log(logger, "L%s%02d                "GT_WU"", nstats.name[i],
+          (int) nstats.val[i], nstats.lvalue[i]);
     }
     else
     {
-      gt_logger_log(logger, "N%s                  n.a.",
-          nstats.name[i]);
-      gt_logger_log(logger, "L%s                  n.a.",
-          nstats.name[i]);
+      gt_logger_log(logger, "N%s%02d                n.a.",
+          nstats.name[i], (int) nstats.val[i]);
+      gt_logger_log(logger, "L%s%02d                n.a.",
+          nstats.name[i], (int) nstats.val[i]);
     }
   }
 }

--- a/src/extended/assembly_stats_calculator.c
+++ b/src/extended/assembly_stats_calculator.c
@@ -206,7 +206,8 @@ int gt_assembly_stats_calculator_register_nstat(GtAssemblyStatsCalculator *asc,
   return 0;
 }
 
-int gt_assembly_stats_calculator_cmp_nstat(const void *v1, const void *v2) {
+static int gt_assembly_stats_calculator_cmp_nstat(const void *v1,
+                                                  const void *v2) {
   GtUword u1 = *(GtUword*) v1;
   GtUword u2 = *(GtUword*) v2;
   if (u1 < u2)

--- a/src/extended/assembly_stats_calculator.h
+++ b/src/extended/assembly_stats_calculator.h
@@ -18,6 +18,7 @@
 #ifndef ASSEMBLY_STATS_CALCULATOR_H
 #define ASSEMBLY_STATS_CALCULATOR_H
 
+#include "core/error_api.h"
 #include "core/logger.h"
 #include "core/types_api.h"
 
@@ -45,6 +46,10 @@ void                       gt_assembly_stats_calculator_add(
 GtUword                    gt_assembly_stats_calculator_nstat(
                                                  GtAssemblyStatsCalculator *asc,
                                                  GtUword n);
+
+int                        gt_assembly_stats_calculator_register_nstat(
+                                                 GtAssemblyStatsCalculator *asc,
+                                                 GtUword n, GtError *err);
 
 /* Set the genome length for the GtAssemblyStatsCalculator <asc>;
    this is not necessary, but if the genome length is set;


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Add new option `-nstats` to `gt seqstat`. This options allows to specify a set of up to 10 N values between 0 and 100, which will then be calculated and output instead of just N50 and N80. These two are still the defaults though.

Please review carefully as I am not the main author of the modified code. Otherwise feel free to fix and contribute.

Example:
```
$ ./bin/gt seqstat -contigs -nstats 20 25 70 -- ./testdata/U89959_ests.fas
# number of contigs:     200
# total contigs length:  86350
# mean contig size:      431.75
# contig size first quartile: 369
# median contig size:         423
# contig size third quartile: 506
# longest contig:             749
# shortest contig:            93
# contigs > 500 nt:           51 (25.50 %)
# contigs > 1K nt:            0 (0.00 %)
# contigs > 10K nt:           0 (0.00 %)
# contigs > 100K nt:          0 (0.00 %)
# contigs > 1M nt:            0 (0.00 %)
# N20                566
# L20                28
# N25                535
# L25                36
# N70                408
# L70                121
```

## Related issues

Adresses #850 by allowing arbitrary N values.
