### PR TITLE
remove mailing list from website

### DIFF
--- a/gtdata/modules/gtdoclib/gtscript_header.lp
+++ b/gtdata/modules/gtdoclib/gtscript_header.lp
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/gtdata/modules/gtdoclib/libgenometools_header.lp
+++ b/gtdata/modules/gtdoclib/libgenometools_header.lp
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/annotationsketch.html
+++ b/www/genometools.org/htdocs/annotationsketch.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
 <li><a id="current" href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/cgi-bin/annotationsketch_demo.cgi
+++ b/www/genometools.org/htdocs/cgi-bin/annotationsketch_demo.cgi
@@ -79,7 +79,6 @@ HTML_HEADER = <<END
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/cgi-bin/gff3validator.cgi
+++ b/www/genometools.org/htdocs/cgi-bin/gff3validator.cgi
@@ -63,7 +63,6 @@ table.padded-table td {
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
 <li><a href="../annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/contract.html
+++ b/www/genometools.org/htdocs/contract.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/contribute.html
+++ b/www/genometools.org/htdocs/contribute.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/customtracks.html
+++ b/www/genometools.org/htdocs/customtracks.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/design.html
+++ b/www/genometools.org/htdocs/design.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a id="current" href="design.html">Design</a></li>
 <li><a href="tools.html">Tools</a></li>

--- a/www/genometools.org/htdocs/docs.html
+++ b/www/genometools.org/htdocs/docs.html
@@ -143,6 +143,41 @@ Returns a random number between 0 and <code>val</code>.
 Reload <code>gt</code> module.
 </p>
 <hr>
+<a name="export"></a>
+
+<code> export()</code>
+<p>
+Export the content of <code>gt</code> table to the global environment.
+</p>
+<hr>
+<a name="display"></a>
+
+<code> display(filename)</code>
+<p>
+Call external 'display' program for file <code>filename</code>.
+</p>
+<hr>
+<a name="show_table"></a>
+
+<code> show_table(tbl)</code>
+<p>
+Show all keys and values of table <code>tbl</code>.
+</p>
+<hr>
+<a name="show"></a>
+
+<code> show(all)</code>
+<p>
+Show content of the <code>gt</code> table.
+</p>
+<hr>
+<a name="re"></a>
+
+<code> re()</code>
+<p>
+Reload the <code>gt</code> module and export its content to the global environment.
+</p>
+<hr>
 <a name="features_contain_marked"></a>
 
 <code> features_contain_marked(features)</code>
@@ -183,41 +218,6 @@ Return an array of genome features which contains a separate gene feature for ea
 <code> features_extract_sequences(features, type, join, region_mapping)</code>
 <p>
 Return an array with the sequences of the given features.
-</p>
-<hr>
-<a name="export"></a>
-
-<code> export()</code>
-<p>
-Export the content of <code>gt</code> table to the global environment.
-</p>
-<hr>
-<a name="display"></a>
-
-<code> display(filename)</code>
-<p>
-Call external 'display' program for file <code>filename</code>.
-</p>
-<hr>
-<a name="show_table"></a>
-
-<code> show_table(tbl)</code>
-<p>
-Show all keys and values of table <code>tbl</code>.
-</p>
-<hr>
-<a name="show"></a>
-
-<code> show(all)</code>
-<p>
-Show content of the <code>gt</code> table.
-</p>
-<hr>
-<a name="re"></a>
-
-<code> re()</code>
-<p>
-Reload the <code>gt</code> module and export its content to the global environment.
 </p>
 <hr>
 <a name="Alphabet"></a>
@@ -1387,7 +1387,7 @@ Returns translated <code>dna</code>.
 <div id="footer">
 Copyright &copy; 2008-2016
 The <i>GenomeTools</i> authors.
-Last update: 2016-07-21
+Last update: 2017-07-24
 </div>
 </div>
 <!-- Piwik -->

--- a/www/genometools.org/htdocs/docs.html
+++ b/www/genometools.org/htdocs/docs.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/documentation.html
+++ b/www/genometools.org/htdocs/documentation.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a id="current" href="documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/examples_tmpl.html
+++ b/www/genometools.org/htdocs/examples_tmpl.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/index.html
+++ b/www/genometools.org/htdocs/index.html
@@ -14,7 +14,6 @@ annotation drawing, AnnotationSketch, LTR prediction, bioinformatics, computatio
       <li><a id="current" href="index.html">Overview</a></li>
       <li><a href="pub/">Download</a></li>
       <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-      <li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
       <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
       <li><a href="documentation.html">Documentation</a></li>
       <li><a href="annotationsketch.html"><em>AnnotationSketch</em></a></li>

--- a/www/genometools.org/htdocs/libgenometools.html
+++ b/www/genometools.org/htdocs/libgenometools.html
@@ -371,15 +371,6 @@ Duplicate internal feature nodes of type <code>source_type</code> as features wi
    <code>dest_type</code>. The duplicated features does not inherit the children.
 </p>
 <hr>
-<a name="GtTrackSelectorFunc"></a>
-
-<code>void  GtTrackSelectorFunc(GtBlock*, GtStr*, void*)</code>
-<p>
-A <code>GtTrackSelectorFunc</code> is a callback function which sets a <code>GtStr</code> to a
-   string to be used as a track identifier for assignment of a <code>GtBlock</code>
-   to a given track.
-</p>
-<hr>
 <a name="GtTrackOrderingFunc"></a>
 
 <code>int  GtTrackOrderingFunc(const char *s1, const char *s2, void *data)</code>
@@ -389,6 +380,15 @@ A function describing the order of tracks based on their track identifier
    should appear before the track with ID <code>s2</code> and a positive value if <code>s1</code>
    should appear after <code>s2</code>. Returning a value of 0 will result in an undefined
    ordering of <code>s1</code> and <code>s2</code>.
+</p>
+<hr>
+<a name="GtTrackSelectorFunc"></a>
+
+<code>void  GtTrackSelectorFunc(GtBlock*, GtStr*, void*)</code>
+<p>
+A <code>GtTrackSelectorFunc</code> is a callback function which sets a <code>GtStr</code> to a
+   string to be used as a track identifier for assignment of a <code>GtBlock</code>
+   to a given track.
 </p>
 <hr>
 <a name="GtAddIntronsStream"></a>
@@ -5488,6 +5488,30 @@ Creates a new <code>GtMatch</code> object meant to store results in the BLAST
    and <code>end_seq2</code>.
 </p>
 <hr>
+<a name="gt_match_blast_new_extended"></a>
+
+<code>GtMatch*  gt_match_blast_new_extended(char *seqid1,
+                                     char *seqid2,
+                                     GtUword start_seq1,
+                                     GtUword end_seq1,
+                                     GtUword start_seq2,
+                                     GtUword end_seq2,
+                                     double evalue,
+                                     float bitscore,
+                                     GtUword length,
+                                     double similarity,
+                                     GtUword mm_num,
+                                     GtUword gap_open_num,
+                                     GtMatchDirection dir)</code>
+<p>
+Creates a new <code>GtMatch</code> object meant to store results in the BLAST
+   format. That is, it stores double values <code>evalue</code> for match E-values,
+   <code>bitscore</code>s and the alignment length <code>ali_l</code> in addition to the generic
+   match contents <code>seqid1</code>, <code>seqid2</code>, <code>start_seq1</code>, <code>start_seq2</code>, <code>end_seq1</code>,
+   and <code>end_seq2</code>. In addition to <code>gt_match_blast_new</code> it also stores
+   the number of mismatches and the number of gap
+</p>
+<hr>
 <a name="gt_match_blast_set_evalue"></a>
 
 <code>void  gt_match_blast_set_evalue(GtMatchBlast *mb, double evalue)</code>
@@ -5516,6 +5540,20 @@ Sets <code>length</code> to be the alignment length in <code>mb</code>.
 Sets <code>similarity</code> to be the match similarity in <code>mb</code>.
 </p>
 <hr>
+<a name="gt_match_blast_set_mismatches"></a>
+
+<code>void  gt_match_blast_set_mismatches(GtMatchBlast *mb, GtUword mm_num)</code>
+<p>
+Sets <code>num to be the number of mismatches in <mb</code>.
+</p>
+<hr>
+<a name="gt_match_blast_set_gapopen"></a>
+
+<code>void  gt_match_blast_set_gapopen(GtMatchBlast *mb, GtUword gap_open_num)</code>
+<p>
+Sets <code>num</code> to be the number of gap openings in <code>mb</code>.
+</p>
+<hr>
 <a name="gt_match_blast_get_evalue"></a>
 
 <code>double  gt_match_blast_get_evalue(GtMatchBlast *mb)</code>
@@ -5542,6 +5580,20 @@ Returns the alignment length stored in <code>mb</code>.
 <code>double  gt_match_blast_get_similarity(GtMatchBlast *mb)</code>
 <p>
 Returns the alignment similarity stored in <code>mb</code>.
+</p>
+<hr>
+<a name="gt_match_blast_get_mismatches"></a>
+
+<code>GtUword  gt_match_blast_get_mismatches(GtMatchBlast *mb)</code>
+<p>
+Returns the number of mismatches stored in <code>mb</code>.
+</p>
+<hr>
+<a name="gt_match_blast_get_gapopen"></a>
+
+<code>GtUword  gt_match_blast_get_gapopen(GtMatchBlast *mb)</code>
+<p>
+Returns the number of gap openings stored in <code>mb</code>.
 </p>
 <hr>
 <a name="GtMatchIterator"></a>
@@ -8500,6 +8552,14 @@ Output the current state of <code>timer</code> in a user-defined format given by
    time in seconds. The output is written to <code>fp</code>. The timer is then stopped.
 </p>
 <hr>
+<a name="gt_timer_elapsed_usec"></a>
+
+<code>GtWord  gt_timer_elapsed_usec(GtTimer *t)</code>
+<p>
+return usec of time from start to stop of giben timer. The timer is then
+   stopped.
+</p>
+<hr>
 <a name="gt_timer_get_formatted"></a>
 
 <code>void      gt_timer_get_formatted(GtTimer *t, const char *fmt, GtStr *str)</code>
@@ -11295,15 +11355,25 @@ Similar to <code>vsnprintf(3)</code>, terminates on error.
 
   <a href="#gt_match_blast_get_evalue"><code>gt_match_blast_get_evalue</code></a><br>
 
+  <a href="#gt_match_blast_get_gapopen"><code>gt_match_blast_get_gapopen</code></a><br>
+
+  <a href="#gt_match_blast_get_mismatches"><code>gt_match_blast_get_mismatches</code></a><br>
+
   <a href="#gt_match_blast_get_similarity"><code>gt_match_blast_get_similarity</code></a><br>
 
   <a href="#gt_match_blast_new"><code>gt_match_blast_new</code></a><br>
+
+  <a href="#gt_match_blast_new_extended"><code>gt_match_blast_new_extended</code></a><br>
 
   <a href="#gt_match_blast_set_align_length"><code>gt_match_blast_set_align_length</code></a><br>
 
   <a href="#gt_match_blast_set_bitscore"><code>gt_match_blast_set_bitscore</code></a><br>
 
   <a href="#gt_match_blast_set_evalue"><code>gt_match_blast_set_evalue</code></a><br>
+
+  <a href="#gt_match_blast_set_gapopen"><code>gt_match_blast_set_gapopen</code></a><br>
+
+  <a href="#gt_match_blast_set_mismatches"><code>gt_match_blast_set_mismatches</code></a><br>
 
   <a href="#gt_match_blast_set_similarity"><code>gt_match_blast_set_similarity</code></a><br>
 
@@ -11915,6 +11985,8 @@ Similar to <code>vsnprintf(3)</code>, terminates on error.
 
   <a href="#gt_timer_delete"><code>gt_timer_delete</code></a><br>
 
+  <a href="#gt_timer_elapsed_usec"><code>gt_timer_elapsed_usec</code></a><br>
+
   <a href="#gt_timer_get_formatted"><code>gt_timer_get_formatted</code></a><br>
 
   <a href="#gt_timer_new"><code>gt_timer_new</code></a><br>
@@ -12076,7 +12148,7 @@ Similar to <code>vsnprintf(3)</code>, terminates on error.
 <div id="footer">
 Copyright &copy; 2008-2016
 The <i>GenomeTools</i> authors.
-Last update: 2016-07-21
+Last update: 2017-07-24
 </div>
 </div>
 <!-- Piwik -->

--- a/www/genometools.org/htdocs/libgenometools.html
+++ b/www/genometools.org/htdocs/libgenometools.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/license.html
+++ b/www/genometools.org/htdocs/license.html
@@ -11,7 +11,6 @@
       <li><a href="index.html">Overview</a></li>
       <li><a href="pub/">Download</a></li>
       <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-      <li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
       <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
       <li><a href="documentation.html">Documentation</a></li>
       <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/manuals.html
+++ b/www/genometools.org/htdocs/manuals.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/style_options.html
+++ b/www/genometools.org/htdocs/style_options.html
@@ -23,7 +23,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
 <li><a id="current" href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>

--- a/www/genometools.org/htdocs/tool.conf
+++ b/www/genometools.org/htdocs/tool.conf
@@ -539,7 +539,6 @@ cellspacing="0" cellpadding="4">
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tool_list.conf
+++ b/www/genometools.org/htdocs/tool_list.conf
@@ -539,7 +539,6 @@ cellspacing="0" cellpadding="4">
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools.html
+++ b/www/genometools.org/htdocs/tools.html
@@ -13,7 +13,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt.html
+++ b/www/genometools.org/htdocs/tools/gt.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_bed_to_gff3.html
+++ b/www/genometools.org/htdocs/tools/gt_bed_to_gff3.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_cds.html
+++ b/www/genometools.org/htdocs/tools/gt_cds.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_chain2dim.html
+++ b/www/genometools.org/htdocs/tools/gt_chain2dim.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_chseqids.html
+++ b/www/genometools.org/htdocs/tools/gt_chseqids.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_clean.html
+++ b/www/genometools.org/htdocs/tools/gt_clean.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_compreads.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_compreads_compress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_compress.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_compreads_decompress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_decompress.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_compreads_refcompress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_refcompress.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_compreads_refdecompress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_refdecompress.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_condenseq.html
+++ b/www/genometools.org/htdocs/tools/gt_condenseq.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_congruence.html
+++ b/www/genometools.org/htdocs/tools/gt_congruence.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_congruence_spacedseed.html
+++ b/www/genometools.org/htdocs/tools/gt_congruence_spacedseed.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_convertseq.html
+++ b/www/genometools.org/htdocs/tools/gt_convertseq.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_csa.html
+++ b/www/genometools.org/htdocs/tools/gt_csa.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_dot.html
+++ b/www/genometools.org/htdocs/tools/gt_dot.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_dupfeat.html
+++ b/www/genometools.org/htdocs/tools/gt_dupfeat.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_encseq.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_encseq2spm.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq2spm.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_encseq_bench.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_bench.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_encseq_bitextract.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_bitextract.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_encseq_check.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_check.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_encseq_decode.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_decode.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_encseq_encode.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_encode.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_encseq_info.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_info.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_encseq_md5.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_md5.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_encseq_sample.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_sample.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_eval.html
+++ b/www/genometools.org/htdocs/tools/gt_eval.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_extractfeat.html
+++ b/www/genometools.org/htdocs/tools/gt_extractfeat.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_extractseq.html
+++ b/www/genometools.org/htdocs/tools/gt_extractseq.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_fastq_sample.html
+++ b/www/genometools.org/htdocs/tools/gt_fastq_sample.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_featureindex.html
+++ b/www/genometools.org/htdocs/tools/gt_featureindex.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_fingerprint.html
+++ b/www/genometools.org/htdocs/tools/gt_fingerprint.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_genomediff.html
+++ b/www/genometools.org/htdocs/tools/gt_genomediff.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_gff3.html
+++ b/www/genometools.org/htdocs/tools/gt_gff3.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_gff3_to_gtf.html
+++ b/www/genometools.org/htdocs/tools/gt_gff3_to_gtf.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_gff3validator.html
+++ b/www/genometools.org/htdocs/tools/gt_gff3validator.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_gtf_to_gff3.html
+++ b/www/genometools.org/htdocs/tools/gt_gtf_to_gff3.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_hop.html
+++ b/www/genometools.org/htdocs/tools/gt_hop.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_id_to_md5.html
+++ b/www/genometools.org/htdocs/tools/gt_id_to_md5.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_inlineseq_add.html
+++ b/www/genometools.org/htdocs/tools/gt_inlineseq_add.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_inlineseq_split.html
+++ b/www/genometools.org/htdocs/tools/gt_inlineseq_split.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_interfeat.html
+++ b/www/genometools.org/htdocs/tools/gt_interfeat.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_loccheck.html
+++ b/www/genometools.org/htdocs/tools/gt_loccheck.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_ltrclustering.html
+++ b/www/genometools.org/htdocs/tools/gt_ltrclustering.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_ltrdigest.html
+++ b/www/genometools.org/htdocs/tools/gt_ltrdigest.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_ltrharvest.html
+++ b/www/genometools.org/htdocs/tools/gt_ltrharvest.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_matchtool.html
+++ b/www/genometools.org/htdocs/tools/gt_matchtool.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_matstat.html
+++ b/www/genometools.org/htdocs/tools/gt_matstat.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_md5_to_id.html
+++ b/www/genometools.org/htdocs/tools/gt_md5_to_id.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_merge.html
+++ b/www/genometools.org/htdocs/tools/gt_merge.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_mergefeat.html
+++ b/www/genometools.org/htdocs/tools/gt_mergefeat.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_mkfeatureindex.html
+++ b/www/genometools.org/htdocs/tools/gt_mkfeatureindex.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_mmapandread.html
+++ b/www/genometools.org/htdocs/tools/gt_mmapandread.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_orffinder.html
+++ b/www/genometools.org/htdocs/tools/gt_orffinder.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_packedindex.html
+++ b/www/genometools.org/htdocs/tools/gt_packedindex.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_prebwt.html
+++ b/www/genometools.org/htdocs/tools/gt_prebwt.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_readjoiner.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_readjoiner_assembly.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner_assembly.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_readjoiner_overlap.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner_overlap.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_readjoiner_prefilter.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner_prefilter.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_repfind.html
+++ b/www/genometools.org/htdocs/tools/gt_repfind.html
@@ -127,19 +127,93 @@ as integer in the range from 70 to 99 (for xdrop and greedy extension) (default:
 </p>
 </dd>
 <dt class="hdlist1">
-<strong>-a</strong> [<em>value</em>]
-</dt>
-<dd>
-<p>
-show alignments/sequences for exact matches (optional argument is number of columns per line) (default: 70)
-</p>
-</dd>
-<dt class="hdlist1">
 <strong>-ii</strong> [<em>string</em>]
 </dt>
 <dd>
 <p>
 Specify input index (default: undefined)
+</p>
+</dd>
+<dt class="hdlist1">
+<strong>-outfmt</strong> 
+</dt>
+<dd>
+<p>
+specify what information about the matches to display
+alignment:        show alignment (possibly followed by
+                  =&lt;number&gt; to specify width of alignment
+                  columns, default is )
+seed_in_algn:     mark the seed in alignment
+polinfo:          add polishing information for shown
+                  alignment
+seed:             abbreviation for seed.len seed.s seed.q
+failed_seed:      show the coordinates of a seed extension,
+                  which does not satisfy the filter conditions
+fstperquery:      output only the first found match per query
+tabsep:           separate columns by tabulator, instead of
+                  space as default
+blast:            output matches in blast format 7 (tabular with
+                  comment lines; instead of gap opens, indels are
+                  displayed)
+gfa2:             output matches in gfa2 format
+custom:           output matches in custom format, i.e. no
+                  columns are pre-defined; all columns have to be
+                  specified by the user
+cigar:            display cigar string representing alignment
+                  (no distinction between match and mismatch)
+cigarX:           display cigar string representing alignment
+                  (distinction between match (=) and mismatch
+                  (X))
+trace:            display trace, i.e. a compact representation
+                  of an alignment (possibly followed by =&lt;delta&gt;)
+                  to specify the delta-value; default value of
+                  delta is 50
+dtrace:           display trace as differences; like trace, but
+                  instead of an absolute value x, report the
+                  difference delta-x. This leads to smaller
+                  numbers and thus a more compact representation
+s.len:            display length of match on subject sequence
+s.seqnum:         display sequence number of subject sequence
+subject id:       display sequence description of subject
+                  sequence
+s.start:          display start position of match on subject
+                  sequence
+s.end:            display end position of match on subject
+                  sequence
+strand:           display strand of match using symbols F
+                  (forward) and P (reverse complement)
+q.len:            display length of match on query sequence
+q.seqnum:         display sequence number of query sequence
+query id:         display sequence description of query
+                  sequence
+q.start:          display start position of match on query
+                  sequence
+q.end:            display end position of match on query
+                  sequence
+alignment length: display length of alignment
+mismatches:       display number of mismatches in alignment
+indels:           display number of indels in alignment
+gap opens:        display number of indels in alignment
+score:            display score of match
+editdist:         display unit edit distance
+identity:         display percent identity of match
+seed.len:         display length seed of the match
+seed.s:           display start position of seed in subject
+seed.q:           display start position of seed in query
+s.seqlen:         display length of subject sequence in which
+                  match occurs
+q.seqlen:         display length of query sequence in which
+                  match occurs
+evalue:           display evalue
+bit score:        display bit score
+</p>
+</dd>
+<dt class="hdlist1">
+<strong>-evalue</strong> [<em>value</em>]
+</dt>
+<dd>
+<p>
+switch on evalue filtering of matches (optional argument specifies evalue threshold) (default: 10.000000)
 </p>
 </dd>
 <dt class="hdlist1">

--- a/www/genometools.org/htdocs/tools/gt_repfind.html
+++ b/www/genometools.org/htdocs/tools/gt_repfind.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_scriptfilter.html
+++ b/www/genometools.org/htdocs/tools/gt_scriptfilter.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_seed_extend.html
+++ b/www/genometools.org/htdocs/tools/gt_seed_extend.html
@@ -67,7 +67,15 @@ Query input index (encseq)
 <dd>
 <p>
 Minimum length of a seed
-default: logarithm of input length to the basis alphabet size
+default: logarithm of input length with alphabet size as log-base
+</p>
+</dd>
+<dt class="hdlist1">
+<strong>-spacedseed</strong> [<em>yes|no</em>]
+</dt>
+<dd>
+<p>
+use spaced seed of length specified by option -seedlength (default: no)
 </p>
 </dd>
 <dt class="hdlist1">
@@ -75,7 +83,8 @@ default: logarithm of input length to the basis alphabet size
 </dt>
 <dd>
 <p>
-Logarithm of diagonal band width (for filter) (default: 6)
+Logarithm of diagonal band width in the range
+from 0 to 10 (for filter) (default: 6)
 </p>
 </dd>
 <dt class="hdlist1">
@@ -85,6 +94,15 @@ Logarithm of diagonal band width (for filter) (default: 6)
 <p>
 Minimum coverage in two neighbouring diagonal bands (for filter)
 default: 2.5 x seedlength
+</p>
+</dd>
+<dt class="hdlist1">
+<strong>-diagband-stat</strong> [<em>&#8230;</em>]
+</dt>
+<dd>
+<p>
+Compute statistics from diagonal band scores; parameter specifies kind of statistics, possible choices are
+sum (default: sum)
 </p>
 </dd>
 <dt class="hdlist1">
@@ -108,7 +126,8 @@ Maximum memory usage to determine the maximum frequency of a k-mer (for filter) 
 </dt>
 <dd>
 <p>
-Extend seed to both sides using xdrop algorithm, /noptional parameter specifies sensitivity (default: 97)
+Extend seed to both sides using xdrop algorithm,
+optional parameter specifies sensitivity (default: 97)
 </p>
 </dd>
 <dt class="hdlist1">
@@ -129,11 +148,19 @@ optional parameter specifies sensitivity (default: 97)
 </p>
 </dd>
 <dt class="hdlist1">
+<strong>-maxmat</strong> [<em>value</em>]
+</dt>
+<dd>
+<p>
+compute maximal matches of minimum length specified by option -l (default: 1)
+</p>
+</dd>
+<dt class="hdlist1">
 <strong>-l</strong> [<em>value</em>]
 </dt>
 <dd>
 <p>
-Minimum alignment length (for seed extension) (default: undefined)
+Minimum length of aligned sequences  (default: undefined)
 </p>
 </dd>
 <dt class="hdlist1">
@@ -145,11 +172,93 @@ Minimum identity of matches (for seed extension) (default: 80)
 </p>
 </dd>
 <dt class="hdlist1">
-<strong>-a</strong> [<em>value</em>]
+<strong>-evalue</strong> [<em>value</em>]
 </dt>
 <dd>
 <p>
-show alignments/sequences (optional argument is number of columns per line) (default: 70)
+switch on evalue filtering of matches (optional argument specifies evalue threshold) (default: 10.000000)
+</p>
+</dd>
+<dt class="hdlist1">
+<strong>-outfmt</strong> 
+</dt>
+<dd>
+<p>
+specify what information about the matches to display
+alignment:        show alignment (possibly followed by
+                  =&lt;number&gt; to specify width of alignment
+                  columns, default is )
+seed_in_algn:     mark the seed in alignment
+polinfo:          add polishing information for shown
+                  alignment
+seed:             abbreviation for seed.len seed.s seed.q
+failed_seed:      show the coordinates of a seed extension,
+                  which does not satisfy the filter conditions
+fstperquery:      output only the first found match per query
+tabsep:           separate columns by tabulator, instead of
+                  space as default
+blast:            output matches in blast format 7 (tabular with
+                  comment lines; instead of gap opens, indels are
+                  displayed)
+gfa2:             output matches in gfa2 format
+custom:           output matches in custom format, i.e. no
+                  columns are pre-defined; all columns have to be
+                  specified by the user
+cigar:            display cigar string representing alignment
+                  (no distinction between match and mismatch)
+cigarX:           display cigar string representing alignment
+                  (distinction between match (=) and mismatch
+                  (X))
+trace:            display trace, i.e. a compact representation
+                  of an alignment (possibly followed by =&lt;delta&gt;)
+                  to specify the delta-value; default value of
+                  delta is 50
+dtrace:           display trace as differences; like trace, but
+                  instead of an absolute value x, report the
+                  difference delta-x. This leads to smaller
+                  numbers and thus a more compact representation
+s.len:            display length of match on subject sequence
+s.seqnum:         display sequence number of subject sequence
+subject id:       display sequence description of subject
+                  sequence
+s.start:          display start position of match on subject
+                  sequence
+s.end:            display end position of match on subject
+                  sequence
+strand:           display strand of match using symbols F
+                  (forward) and P (reverse complement)
+q.len:            display length of match on query sequence
+q.seqnum:         display sequence number of query sequence
+query id:         display sequence description of query
+                  sequence
+q.start:          display start position of match on query
+                  sequence
+q.end:            display end position of match on query
+                  sequence
+alignment length: display length of alignment
+mismatches:       display number of mismatches in alignment
+indels:           display number of indels in alignment
+gap opens:        display number of indels in alignment
+score:            display score of match
+editdist:         display unit edit distance
+identity:         display percent identity of match
+seed.len:         display length seed of the match
+seed.s:           display start position of seed in subject
+seed.q:           display start position of seed in query
+s.seqlen:         display length of subject sequence in which
+                  match occurs
+q.seqlen:         display length of query sequence in which
+                  match occurs
+evalue:           display evalue
+bit score:        display bit score
+</p>
+</dd>
+<dt class="hdlist1">
+<strong>-ani</strong> [<em>yes|no</em>]
+</dt>
+<dd>
+<p>
+output average nucleotide identity determined from the computed matches (which are not output) (default: no)
 </p>
 </dd>
 <dt class="hdlist1">
@@ -166,6 +275,14 @@ do not compute matches on reverse complemented strand (default: no)
 <dd>
 <p>
 do not compute matches on forward strand (default: no)
+</p>
+</dd>
+<dt class="hdlist1">
+<strong>-use-apos</strong> [<em>yes|no</em>]
+</dt>
+<dd>
+<p>
+Discard a seed only if both apos and bpos overlap with a previous successful alignment (default: no)
 </p>
 </dd>
 <dt class="hdlist1">

--- a/www/genometools.org/htdocs/tools/gt_seed_extend.html
+++ b/www/genometools.org/htdocs/tools/gt_seed_extend.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_select.html
+++ b/www/genometools.org/htdocs/tools/gt_select.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_seq.html
+++ b/www/genometools.org/htdocs/tools/gt_seq.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_seqfilter.html
+++ b/www/genometools.org/htdocs/tools/gt_seqfilter.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_seqids.html
+++ b/www/genometools.org/htdocs/tools/gt_seqids.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_seqmutate.html
+++ b/www/genometools.org/htdocs/tools/gt_seqmutate.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_seqorder.html
+++ b/www/genometools.org/htdocs/tools/gt_seqorder.html
@@ -94,6 +94,14 @@ shuffle sequences pseudo-randomly (default: no)
 </p>
 </dd>
 <dt class="hdlist1">
+<strong>-sortlength</strong> [<em>yes|no</em>]
+</dt>
+<dd>
+<p>
+sort by decreasing length (default: no)
+</p>
+</dd>
+<dt class="hdlist1">
 <strong>-help</strong> 
 </dt>
 <dd>

--- a/www/genometools.org/htdocs/tools/gt_seqorder.html
+++ b/www/genometools.org/htdocs/tools/gt_seqorder.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_seqstat.html
+++ b/www/genometools.org/htdocs/tools/gt_seqstat.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_seqtransform.html
+++ b/www/genometools.org/htdocs/tools/gt_seqtransform.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_seqtranslate.html
+++ b/www/genometools.org/htdocs/tools/gt_seqtranslate.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_sequniq.html
+++ b/www/genometools.org/htdocs/tools/gt_sequniq.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_shredder.html
+++ b/www/genometools.org/htdocs/tools/gt_shredder.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_shulengthdist.html
+++ b/www/genometools.org/htdocs/tools/gt_shulengthdist.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_simreads.html
+++ b/www/genometools.org/htdocs/tools/gt_simreads.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_sketch.html
+++ b/www/genometools.org/htdocs/tools/gt_sketch.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_sketch_page.html
+++ b/www/genometools.org/htdocs/tools/gt_sketch_page.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_snpper.html
+++ b/www/genometools.org/htdocs/tools/gt_snpper.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_speck.html
+++ b/www/genometools.org/htdocs/tools/gt_speck.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_splicesiteinfo.html
+++ b/www/genometools.org/htdocs/tools/gt_splicesiteinfo.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_splitfasta.html
+++ b/www/genometools.org/htdocs/tools/gt_splitfasta.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_stat.html
+++ b/www/genometools.org/htdocs/tools/gt_stat.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_tagerator.html
+++ b/www/genometools.org/htdocs/tools/gt_tagerator.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_tallymer.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_tallymer_mkindex.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer_mkindex.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_tallymer_occratio.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer_occratio.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_tallymer_search.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer_search.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_tirvish.html
+++ b/www/genometools.org/htdocs/tools/gt_tirvish.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_uniq.html
+++ b/www/genometools.org/htdocs/tools/gt_uniq.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_uniquesub.html
+++ b/www/genometools.org/htdocs/tools/gt_uniquesub.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/tools/gt_wtree.html
+++ b/www/genometools.org/htdocs/tools/gt_wtree.html
@@ -12,7 +12,6 @@
 <li><a href="../index.html">Overview</a></li>
 <li><a href="../pub/">Download</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="../mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
   <ul class="submenu">

--- a/www/genometools.org/htdocs/trackselectors.html
+++ b/www/genometools.org/htdocs/trackselectors.html
@@ -11,7 +11,6 @@
 <li><a href="index.html">Overview</a></li>
 <li><a href="pub/">Download</a></li>
 <li><a href="http://github.com/genometools/genometools">Browse source</a></li>
-<li><a href="mailman/listinfo/gt-users">Mailing list</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
 <li><a href="annotationsketch.html"><tt>AnnotationSketch</tt></a></li>


### PR DESCRIPTION
In order to simplify moving the GenomeTools website to a different server I removed all links to the defunct mailing list from the website.

I think it is OK to lose the archive, unless somebody else wants to do the work of archiving the mailing list.