### PR TITLE
Sk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -495,6 +495,7 @@ ifeq ($(amalgamation),yes)
   LIBGENOMETOOLS_PRESRC:=$(filter-out $(SQLITE3_SRC),\
                          $(LIBGENOMETOOLS_PRESRC))
   LIBGENOMETOOLS_SRC:=obj/amalgamation.c
+  GT_CFLAGS+=-Wno-strict-overflow
 else
   LIBGENOMETOOLS_SRC:=$(LIBGENOMETOOLS_PRESRC)
 endif

--- a/src/match/dbs_spaced_seeds.c
+++ b/src/match/dbs_spaced_seeds.c
@@ -1,0 +1,396 @@
+/*
+  Copyright (c) 2017 Stefan Kurtz <kurtz@zbh.uni-hamburg.de>
+  Copyright (c) 2017 Center for Bioinformatics, University of Hamburg
+
+  Permission to use, copy, modify, and distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "core/ma_api.h"
+#include "core/assert_api.h"
+#include "core/codetype.h"
+#include "match/dbs_spaced_seeds.h"
+
+int gt_spaced_seed_span(GtCodetype spaced_seed)
+{
+  int span = 0;
+
+  for (/* Nothing */; spaced_seed > 0; spaced_seed >>= 1)
+  {
+    span++;
+  }
+  return span;
+}
+
+int gt_spaced_seed_weight(GtCodetype spaced_seed)
+{
+  int weight = 0;
+
+  for (/* Nothing */; spaced_seed > 0; spaced_seed >>= 1)
+  {
+    if (spaced_seed & (GtCodetype) 1)
+    {
+      weight++;
+    }
+  }
+  return weight;
+}
+
+static GtCodetype gt_spaced_seed_spec_tab[] = {
+  23075ULL /* 7, 15 */,
+  29331ULL /* 8 */,
+  27975ULL /* 9 */,
+  27823ULL /* 10 */,
+  30135ULL /* 11 */,
+  30575ULL /* 12 */,
+  32495ULL /* 13 */,
+  32511ULL /* 14 */,
+  39559ULL /* 8, 16 */,
+  54039ULL /* 9 */,
+  55511ULL /* 10 */,
+  59767ULL /* 11 */,
+  56687ULL /* 12 */,
+  63215ULL /* 13 */,
+  64479ULL /* 14 */,
+  65471ULL /* 15 */,
+  100891ULL /* 8, 17 */,
+  108075ULL /* 9 */,
+  111271ULL /* 10 */,
+  119415ULL /* 11 */,
+  125751ULL /* 12 */,
+  122287ULL /* 13 */,
+  128879ULL /* 14 */,
+  128959ULL /* 15 */,
+  130943ULL /* 16 */,
+  217383ULL /* 9, 18 */,
+  234071ULL /* 10 */,
+  238903ULL /* 11 */,
+  240951ULL /* 12 */,
+  251503ULL /* 13 */,
+  256887ULL /* 14 */,
+  259823ULL /* 15 */,
+  261087ULL /* 16 */,
+  262015ULL /* 17 */,
+  412715ULL /* 9, 19 */,
+  469271ULL /* 10 */,
+  469399ULL /* 11 */,
+  469615ULL /* 12 */,
+  486575ULL /* 13 */,
+  504751ULL /* 14 */,
+  513775ULL /* 15 */,
+  507359ULL /* 16 */,
+  520127ULL /* 17 */,
+  523263ULL /* 18 */,
+  860951ULL /* 10, 20 */,
+  893607ULL /* 11 */,
+  995927ULL /* 12 */,
+  963375ULL /* 13 */,
+  1009327ULL /* 14 */,
+  1029039ULL /* 15 */,
+  1027551ULL /* 16 */,
+  1031647ULL /* 17 */,
+  1040255ULL /* 18 */,
+  1048319ULL /* 19 */,
+  1902795ULL /* 10, 21 */,
+  1739175ULL /* 11 */,
+  1880663ULL /* 12 */,
+  1992015ULL /* 13 */,
+  1952559ULL /* 14 */,
+  1955487ULL /* 15 */,
+  2055031ULL /* 16 */,
+  2060015ULL /* 17 */,
+  2080223ULL /* 18 */,
+  2080511ULL /* 19 */,
+  2095103ULL /* 20 */,
+  3754263ULL /* 11, 22 */,
+  3969703ULL /* 12 */,
+  3970407ULL /* 13 */,
+  3847375ULL /* 14 */,
+  3905119ULL /* 15 */,
+  3909487ULL /* 16 */,
+  4110063ULL /* 17 */,
+  4126447ULL /* 18 */,
+  4176863ULL /* 19 */,
+  4177791ULL /* 20 */,
+  4193791ULL /* 21 */,
+  7508247ULL /* 11, 23 */,
+  7490215ULL /* 12 */,
+  7950951ULL /* 13 */,
+  7956055ULL /* 14 */,
+  7951983ULL /* 15 */,
+  8074607ULL /* 16 */,
+  8219887ULL /* 17 */,
+  8220399ULL /* 18 */,
+  8240607ULL /* 19 */,
+  8320991ULL /* 20 */,
+  8355583ULL /* 21 */,
+  8387583ULL /* 22 */,
+  14848567ULL /* 12, 24 */,
+  15280743ULL /* 13 */,
+  15911479ULL /* 14 */,
+  15912111ULL /* 15 */,
+  16149199ULL /* 16 */,
+  16174767ULL /* 17 */,
+  16469743ULL /* 18 */,
+  16217535ULL /* 19 */,
+  16629215ULL /* 20 */,
+  16644031ULL /* 21 */,
+  16760703ULL /* 22 */,
+  16776191ULL /* 23 */,
+  28387495ULL /* 12, 25 */,
+  31755435ULL /* 13 */,
+  30624311ULL /* 14 */,
+  31019727ULL /* 15 */,
+  30775663ULL /* 16 */,
+  32872879ULL /* 17 */,
+  32303839ULL /* 18 */,
+  32988063ULL /* 19 */,
+  33222127ULL /* 20 */,
+  32996319ULL /* 21 */,
+  33283967ULL /* 22 */,
+  33488639ULL /* 23 */,
+  33546239ULL /* 24 */,
+  61019287ULL /* 13, 26 */,
+  62007631ULL /* 14 */,
+  62178639ULL /* 15 */,
+  64578391ULL /* 16 */,
+  64330095ULL /* 17 */,
+  65755551ULL /* 18 */,
+  65756383ULL /* 19 */,
+  65894255ULL /* 20 */,
+  66022335ULL /* 21 */,
+  66026431ULL /* 22 */,
+  66576127ULL /* 23 */,
+  66977279ULL /* 24 */,
+  67092479ULL /* 25 */,
+  126495003ULL /* 13, 27 */,
+  122309719ULL /* 14 */,
+  124131927ULL /* 15 */,
+  124308175ULL /* 16 */,
+  124954271ULL /* 17 */,
+  129160607ULL /* 18 */,
+  128896367ULL /* 19 */,
+  131786479ULL /* 20 */,
+  131784159ULL /* 21 */,
+  131984863ULL /* 22 */,
+  133151711ULL /* 23 */,
+  133685183ULL /* 24 */,
+  133954559ULL /* 25 */,
+  134201343ULL /* 26 */,
+  244880463ULL /* 14, 28 */,
+  254945615ULL /* 15 */,
+  256519375ULL /* 16 */,
+  255145071ULL /* 17 */,
+  249914783ULL /* 18 */,
+  262878623ULL /* 19 */,
+  263615855ULL /* 20 */,
+  263579375ULL /* 21 */,
+  263634399ULL /* 22 */,
+  264092639ULL /* 23 */,
+  266303423ULL /* 24 */,
+  267378559ULL /* 25 */,
+  267909119ULL /* 26 */,
+  268402687ULL /* 27 */,
+  508768943ULL /* 17, 29 */,
+  513435311ULL /* 18 */,
+  499881567ULL /* 19 */,
+  525769951ULL /* 20 */,
+  527260911ULL /* 21 */,
+  527674815ULL /* 22 */,
+  527920095ULL /* 23 */,
+  532134879ULL /* 24 */,
+  534640575ULL /* 25 */,
+  534740735ULL /* 26 */,
+  536345599ULL /* 27 */,
+  1051087767ULL /* 18, 30 */,
+  1028869743ULL /* 19 */,
+  1047213423ULL /* 20 */,
+  1035629407ULL /* 21 */,
+  1054521823ULL /* 22 */,
+  1055717055ULL /* 23 */,
+  1055878079ULL /* 24 */,
+  1056373695ULL /* 25 */,
+  1065220031ULL /* 26 */,
+  1069514239ULL /* 27 */,
+  1073479167ULL /* 28 */,
+  2040932015ULL /* 18, 31 */,
+  2057774495ULL /* 19 */,
+  2067064495ULL /* 20 */,
+  2103078127ULL /* 21 */,
+  2071258815ULL /* 22 */,
+  2104348351ULL /* 23 */,
+  2111548911ULL /* 24 */,
+  2126216159ULL /* 25 */,
+  2130115519ULL /* 26 */,
+  2138828735ULL /* 27 */,
+  2143223551ULL /* 28 */,
+  2147220991ULL /* 29 */,
+  4207733599ULL /* 22, 32 */,
+  4208813935ULL /* 23 */,
+  4218133983ULL /* 24 */,
+  4225429215ULL /* 25 */,
+  4223523807ULL /* 26 */,
+  4226775999ULL /* 27 */,
+  4260872063ULL /* 28 */,
+  4286545663ULL /* 29 */,
+  4292868095ULL /* 30 */
+};
+
+static int gt_spaced_seed_span_start_tab[] = {
+  0, 8, 16, 25, 34, 44, 54, 65, 76, 88, 100, 113, 126, 140, 154, 165, 176, 188
+};
+
+static int gt_spaced_seed_first_weight_tab[] = {
+  7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 17, 18, 18, 22
+};
+
+#define GT_SPACED_SEED_FIRST_SPAN 15
+
+void gt_spaced_seed_weight_range(int *min_weight,int *max_weight, int span)
+{
+  const int size_table = sizeof gt_spaced_seed_spec_tab/
+                         sizeof gt_spaced_seed_spec_tab[0];
+  const int num_spans = sizeof gt_spaced_seed_span_start_tab/
+                        sizeof gt_spaced_seed_span_start_tab[0];
+  int span_offset, end_of_span;
+
+  gt_assert(GT_SPACED_SEED_FIRST_SPAN <= span &&
+            span - GT_SPACED_SEED_FIRST_SPAN <= num_spans - 1);
+  *min_weight
+    = gt_spaced_seed_first_weight_tab[span - GT_SPACED_SEED_FIRST_SPAN];
+  if (span - GT_SPACED_SEED_FIRST_SPAN == num_spans - 1)
+  {
+    end_of_span = size_table;
+  } else
+  {
+    end_of_span
+      = gt_spaced_seed_span_start_tab[span + 1 - GT_SPACED_SEED_FIRST_SPAN];
+  }
+  span_offset = gt_spaced_seed_span_start_tab[span - GT_SPACED_SEED_FIRST_SPAN];
+  *max_weight = *min_weight + end_of_span - span_offset - 1;
+}
+
+typedef struct
+{
+  GtCodetype extract;
+  int shiftright;
+} GtSpacedSeedSpecValue;
+
+struct GtSpacedSeedSpec
+{
+  GtSpacedSeedSpecValue *spec_tab;
+  size_t num_specs;
+};
+
+GtSpacedSeedSpec *gt_spaced_seed_spec_new(GtCodetype spacedseed)
+{
+  uint8_t blocks_length[32] = {0}, shiftleft = 0, shiftright = 0;
+  int span = 1, weight = 1;
+  GtCodetype ss_copy, last = (GtCodetype) 1, from_blocks = 0;
+  GtUword idx, block_num = 0, spec_counter = 0;
+  GtSpacedSeedSpec *seed_spec;
+
+  gt_assert(spacedseed & ((GtCodetype) 1));
+  blocks_length[0] = 1;
+  for (ss_copy = spacedseed >> 1; ss_copy > 0; ss_copy >>= 1)
+  {
+    GtCodetype current = ss_copy & (GtCodetype) 1;
+
+    if (current == (GtCodetype) 1)
+    {
+      weight++;
+    }
+    if (current != last)
+    {
+      block_num++;
+      last = current;
+    }
+    gt_assert(block_num < sizeof blocks_length/sizeof blocks_length[0]);
+    blocks_length[block_num]++;
+    span++;
+  }
+  block_num++;
+  gt_assert(block_num % 2 == 1);
+  seed_spec = gt_malloc(sizeof *seed_spec);
+  seed_spec->num_specs = 1 + block_num/2;
+  seed_spec->spec_tab = gt_malloc(seed_spec->num_specs *
+                                  sizeof *seed_spec->spec_tab);
+  gt_assert(seed_spec->spec_tab != NULL);
+  last = (GtCodetype) 1;
+  for (idx = 0; idx < block_num; idx++)
+  {
+    const uint8_t width = blocks_length[idx];
+    if (last == (GtCodetype) 1)
+    {
+      from_blocks |= (((((GtCodetype) 1) << width) - 1) << shiftleft);
+      last = 0;
+      gt_assert(spec_counter < seed_spec->num_specs);
+      seed_spec->spec_tab[spec_counter].extract
+        = ((((GtCodetype) 1) << (2 * width)) - 1) << (2 * shiftleft);
+      seed_spec->spec_tab[spec_counter++].shiftright = 2 * shiftright;
+    } else
+    {
+      last = (GtCodetype) 1;
+      shiftright += width;
+    }
+    shiftleft += width;
+  }
+  gt_assert(spec_counter == seed_spec->num_specs && from_blocks == spacedseed);
+  return seed_spec;
+}
+
+void gt_spaced_seed_spec_delete(GtSpacedSeedSpec *seed_spec)
+{
+  if (seed_spec != NULL)
+  {
+    gt_free(seed_spec->spec_tab);
+    gt_free(seed_spec);
+  }
+}
+
+static int gt_spaced_seed_tab_num_extract(int weight,int span)
+{
+  int first_weight, span_offset;
+
+  gt_assert(GT_SPACED_SEED_FIRST_SPAN <= span);
+  span_offset = gt_spaced_seed_span_start_tab[span - GT_SPACED_SEED_FIRST_SPAN];
+  first_weight
+    = gt_spaced_seed_first_weight_tab[span - GT_SPACED_SEED_FIRST_SPAN];
+  gt_assert(first_weight <= weight);
+  return span_offset + weight - first_weight;
+}
+
+GtSpacedSeedSpec *gt_spaced_seed_spec_new_from_ws(int weight,int span)
+{
+  int min_weight, max_weight, seed_num;;
+
+  gt_spaced_seed_weight_range(&min_weight,&max_weight, span);
+  gt_assert(min_weight <= weight && weight <= max_weight);
+  seed_num = gt_spaced_seed_tab_num_extract(weight,span);
+  return gt_spaced_seed_spec_new(gt_spaced_seed_spec_tab[seed_num]);
+}
+
+GtCodetype gt_spaced_seed_extract_generic(const GtSpacedSeedSpec *seed_spec,
+                                          GtCodetype kmer)
+{
+  GtCodetype ext = 0;
+  const GtSpacedSeedSpecValue *seed_spec_ptr;
+
+  gt_assert(seed_spec != NULL);
+  for (seed_spec_ptr = seed_spec->spec_tab;
+       seed_spec_ptr < seed_spec->spec_tab + seed_spec->num_specs;
+       seed_spec_ptr++)
+  {
+    ext |= ((kmer & seed_spec_ptr->extract) >> seed_spec_ptr->shiftright);
+  }
+  return ext;
+}

--- a/src/match/dbs_spaced_seeds.c
+++ b/src/match/dbs_spaced_seeds.c
@@ -253,8 +253,6 @@ static int gt_spaced_seed_first_weight_tab[] = {
   7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 17, 18, 18, 22
 };
 
-#define GT_SPACED_SEED_FIRST_SPAN 15
-
 void gt_spaced_seed_weight_range(int *min_weight,int *max_weight, int span)
 {
   const int size_table = sizeof gt_spaced_seed_spec_tab/

--- a/src/match/dbs_spaced_seeds.c
+++ b/src/match/dbs_spaced_seeds.c
@@ -15,6 +15,7 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
+#include <inttypes.h>
 #include "core/ma_api.h"
 #include "core/assert_api.h"
 #include "core/codetype.h"

--- a/src/match/dbs_spaced_seeds.h
+++ b/src/match/dbs_spaced_seeds.h
@@ -1,0 +1,39 @@
+/*
+  Copyright (c) 2017 Stefan Kurtz <kurtz@zbh.uni-hamburg.de>
+  Copyright (c) 2017 Center for Bioinformatics, University of Hamburg
+
+  Permission to use, copy, modify, and distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef DBS_SPACED_SEEDS_H
+#define DBS_SPACED_SEEDS_H
+#include "core/codetype.h"
+
+int gt_spaced_seed_span(GtCodetype spaced_seed);
+
+int gt_spaced_seed_weight(GtCodetype spaced_seed);
+
+void gt_spaced_seed_weight_range(int *min_weight,int *max_weight, int span);
+
+typedef struct GtSpacedSeedSpec GtSpacedSeedSpec;
+
+GtSpacedSeedSpec *gt_spaced_seed_spec_new(GtCodetype spacedseed);
+
+GtSpacedSeedSpec *gt_spaced_seed_spec_new_from_ws(int weight,int span);
+
+void gt_spaced_seed_spec_delete(GtSpacedSeedSpec *seed_spec);
+
+GtCodetype gt_spaced_seed_extract_generic(const GtSpacedSeedSpec *seed_spec,
+                                          GtCodetype kmer);
+
+#endif

--- a/src/match/dbs_spaced_seeds.h
+++ b/src/match/dbs_spaced_seeds.h
@@ -19,6 +19,8 @@
 #define DBS_SPACED_SEEDS_H
 #include "core/codetype.h"
 
+#define GT_SPACED_SEED_FIRST_SPAN 15
+
 int gt_spaced_seed_span(GtCodetype spaced_seed);
 
 int gt_spaced_seed_weight(GtCodetype spaced_seed);

--- a/src/match/declare-readfunc.h
+++ b/src/match/declare-readfunc.h
@@ -58,4 +58,7 @@
           return 1;\
         }
 
+GT_DECLAREBufferedfiletype(GtUword);
+GT_DECLAREREADFUNCTION(GtUword);
+
 #endif

--- a/src/match/declare-readfunc.h
+++ b/src/match/declare-readfunc.h
@@ -22,9 +22,9 @@
 #include <stdio.h>
 #include "core/unused_api.h"
 
-#define FILEBUFFERSIZE 4096
+#define GT_FILEBUFFERSIZE 4096
 
-#define DECLAREBufferedfiletype(TYPE)\
+#define GT_DECLAREBufferedfiletype(TYPE)\
         typedef struct\
         {\
           unsigned int nextfree,\
@@ -33,7 +33,7 @@
           FILE *fp;\
         } GtBufferedfile_ ## TYPE
 
-#define DECLAREREADFUNCTION(TYPE)\
+#define GT_DECLAREREADFUNCTION(TYPE)\
         GT_UNUSED static int gt_readnextfromstream_ ## TYPE (TYPE *val,\
                                                   GtBufferedfile_ ## TYPE *buf)\
         {\
@@ -41,7 +41,7 @@
           {\
             buf->nextfree = (unsigned int) fread(buf->bufferedfilespace,\
                                                  sizeof (TYPE),\
-                                                 (size_t) FILEBUFFERSIZE,\
+                                                 (size_t) GT_FILEBUFFERSIZE,\
                                                  buf->fp);\
             if (ferror(buf->fp))\
             {\

--- a/src/match/diagbandseed.h
+++ b/src/match/diagbandseed.h
@@ -32,12 +32,12 @@ typedef struct GtDiagbandseedInfo GtDiagbandseedInfo;
 typedef struct GtDiagbandseedExtendParams GtDiagbandseedExtendParams;
 
 typedef enum
-{ /* keep the order consistent with gt_splt_arguments */
-  GT_DIAGBANDSEED_SPLT_STRUCT,
-  GT_DIAGBANDSEED_SPLT_ULONG,
-  GT_DIAGBANDSEED_SPLT_BYTESTRING,
-  GT_DIAGBANDSEED_SPLT_UNDEFINED
-} GtDiagbandseedPairlisttype;
+{ /* keep the order consistent with gt_base_list_arguments */
+  GT_DIAGBANDSEED_BASE_LIST_STRUCT,
+  GT_DIAGBANDSEED_BASE_LIST_ULONG,
+  GT_DIAGBANDSEED_BASE_LIST_BYTESTRING,
+  GT_DIAGBANDSEED_BASE_LIST_UNDEFINED
+} GtDiagbandseedBaseListType;
 
 /* Run the whole algorithm. */
 int gt_diagbandseed_run(const GtDiagbandseedInfo *arg,
@@ -56,7 +56,8 @@ GtDiagbandseedInfo *gt_diagbandseed_info_new(const GtEncseq *aencseq,
                                              bool norev,
                                              bool nofwd,
                                              const GtRange *seedpairdistance,
-                                             GtDiagbandseedPairlisttype splt,
+                                             GtDiagbandseedBaseListType splt,
+                                             GtDiagbandseedBaseListType kmplt,
                                              bool verify,
                                              bool verbose,
                                              bool debug_kmer,
@@ -72,8 +73,11 @@ GtDiagbandseedInfo *gt_diagbandseed_info_new(const GtEncseq *aencseq,
 
 const char *gt_diagbandseed_splt_comment(void);
 
-GtDiagbandseedPairlisttype gt_diagbandseed_splt_get(const char *splt_string,
-                                                    GtError *err);
+const char *gt_diagbandseed_kmplt_comment(void);
+
+GtDiagbandseedBaseListType gt_diagbandseed_base_list_get(
+                                   bool with_splt,
+                                   const char *base_list_string,GtError *err);
 
 typedef struct
 {

--- a/src/match/esa-map.c
+++ b/src/match/esa-map.c
@@ -48,7 +48,7 @@
           (STREAM)->nextfree = 0;\
           (STREAM)->bufferedfilespace\
             = gt_malloc(sizeof *((STREAM)->bufferedfilespace)\
-                        * (FILEBUFFERSIZE));\
+                        * (GT_FILEBUFFERSIZE));\
         }
 
 static int scanprjfileuintkeysviafileptr(Suffixarray *suffixarray,

--- a/src/match/esa-seqread.h
+++ b/src/match/esa-seqread.h
@@ -57,7 +57,7 @@ int gt_nextSequentialsuftabvalue(GtUword *currentsuffix,
             buf->nextfree\
               = (unsigned int) fread(buf->bufferedfilespace,\
                                      sizeof (*buf->bufferedfilespace),\
-                                     (size_t) FILEBUFFERSIZE,\
+                                     (size_t) GT_FILEBUFFERSIZE,\
                                      buf->fp);\
             if (ferror(buf->fp))\
             {\

--- a/src/match/sarr-def.h
+++ b/src/match/sarr-def.h
@@ -45,9 +45,6 @@
                      SARR_DESTAB |\
                      SARR_SSPTAB)
 
-GT_DECLAREBufferedfiletype(GtUword);
-GT_DECLAREREADFUNCTION(GtUword);
-
 #if defined (_LP64) || defined (_WIN64)
 GT_DECLAREBufferedfiletype(uint32_t);
 GT_DECLAREREADFUNCTION(uint32_t);

--- a/src/match/sarr-def.h
+++ b/src/match/sarr-def.h
@@ -45,19 +45,19 @@
                      SARR_DESTAB |\
                      SARR_SSPTAB)
 
-DECLAREBufferedfiletype(GtUword);
-DECLAREREADFUNCTION(GtUword);
+GT_DECLAREBufferedfiletype(GtUword);
+GT_DECLAREREADFUNCTION(GtUword);
 
 #if defined (_LP64) || defined (_WIN64)
-DECLAREBufferedfiletype(uint32_t);
-DECLAREREADFUNCTION(uint32_t);
+GT_DECLAREBufferedfiletype(uint32_t);
+GT_DECLAREREADFUNCTION(uint32_t);
 #endif
 
-DECLAREBufferedfiletype(GtUchar);
-DECLAREREADFUNCTION(GtUchar);
+GT_DECLAREBufferedfiletype(GtUchar);
+GT_DECLAREREADFUNCTION(GtUchar);
 
-DECLAREBufferedfiletype(Largelcpvalue);
-DECLAREREADFUNCTION(Largelcpvalue);
+GT_DECLAREBufferedfiletype(Largelcpvalue);
+GT_DECLAREREADFUNCTION(Largelcpvalue);
 
 typedef GtUword ESASuffixptr;
 

--- a/src/match/sfx-suffixer.c
+++ b/src/match/sfx-suffixer.c
@@ -942,7 +942,7 @@ void getencseqkmers_rangetwobitencoding(const GtEncseq *encseq,
   }
 }
 
-void getencseqkmers_twobitencoding_slice(const GtEncseq *encseq,
+void gt_getencseqkmers_twobitencoding_slice(const GtEncseq *encseq,
                                          GtReadmode readmode,
                                          unsigned int kmersize,
                                          unsigned int upperkmersize,
@@ -1054,17 +1054,17 @@ void getencseqkmers_twobitencoding(const GtEncseq *encseq,
                                                              GtUword),
                                    void *processkmerspecialinfo)
 {
-  getencseqkmers_twobitencoding_slice(encseq,
-                                      readmode,
-                                      kmersize,
-                                      upperkmersize,
-                                      onlyfirst,
-                                      processkmercode,
-                                      processkmercodeinfo,
-                                      processkmerspecial,
-                                      processkmerspecialinfo,
-                                      0,
-                                      gt_encseq_total_length(encseq));
+  gt_getencseqkmers_twobitencoding_slice(encseq,
+                                         readmode,
+                                         kmersize,
+                                         upperkmersize,
+                                         onlyfirst,
+                                         processkmercode,
+                                         processkmercodeinfo,
+                                         processkmerspecial,
+                                         processkmerspecialinfo,
+                                         0,
+                                         gt_encseq_total_length(encseq));
 }
 
 static void gt_updateleftborderforkmer(Sfxiterator *sfi,

--- a/src/match/sfx-suffixer.h
+++ b/src/match/sfx-suffixer.h
@@ -90,7 +90,7 @@ void getencseqkmers_twobitencoding(const GtEncseq *encseq,
                                                              GtUword),
                                    void *processkmerspecialinfo);
 
-void getencseqkmers_twobitencoding_slice(const GtEncseq *encseq,
+void gt_getencseqkmers_twobitencoding_slice(const GtEncseq *encseq,
                                          GtReadmode readmode,
                                          unsigned int kmersize,
                                          unsigned int upperkmersize,

--- a/src/tools/gt_seed_extend.c
+++ b/src/tools/gt_seed_extend.c
@@ -862,7 +862,7 @@ static int gt_seed_extend_runner(int argc,
     kmplt = gt_diagbandseed_base_list_get(false,
                                           gt_str_get(arguments->kmplt_string),
                                           err);
-    if ((int) splt == -1) {
+    if ((int) kmplt == -1) {
       had_err = -1;
     }
   }

--- a/testsuite/gt_seed_extend_include.rb
+++ b/testsuite/gt_seed_extend_include.rb
@@ -238,6 +238,27 @@ Test do
   run_test "#{$bin}gt seed_extend -ii at1MB -outfmt gfa2 identity dtrace", :retval => 1
   run_test "#{$bin}gt seed_extend -ii at1MB -outfmt cigar"
   run_test "#{$bin}gt dev show_seedext -f #{last_stdout} -outfmt cigarX",:retval => 1
+  run_test "#{$bin}gt seed_extend -spacedseed 16 -seedlength 30 -ii at1MB", :retval => 1
+  grep last_stderr, /illegal weight 16: for spaced seeds of span 30 the weight must be in the range from 18 to 28/
+  run_test build_encseq("sw100K1", "#{$testdata}sw100K1.fsa")
+  run_test "#{$bin}gt seed_extend -spacedseed 7 -seedlength 10 -ii sw100K1", :retval => 1
+  grep last_stderr, /spaced seeds only work for sequences over an alphabet of size 4/
+  run_test "#{$bin}gt seed_extend -spacedseed -seedlength 14 -ii at1MB", :retval => 1
+  grep last_stderr, /illegal seedlength 14: for this set of sequences can only handle spaced seeds of span between 15 and 30/
+  run_test "#{$bin}gt seed_extend -spacedseed 13 -seedlength 28 -ii at1MB", :retval => 1
+  grep last_stderr, /illegal weight 13: for spaced seeds of span 28 the weight must be in the range from 14 to 27/
+end
+
+Name "gt seedext spaced seeds"
+Keywords "gt_seed_extend gt_seed_extend_spaced_seeds"
+Test do
+  run_test build_encseq("at1MB", "#{$testdata}at1MB")
+  run_test build_encseq("U89959_genomic", "#{$testdata}U89959_genomic.fas")
+  [" "," -qii U89959_genomic "].each do |qidx|
+    run_test "#{$bin}gt seed_extend -spacedseed 22 -seedlength 30 -ii at1MB#{qidx}"
+    run_test "#{$bin}gt seed_extend -spacedseed -seedlength 30 -ii at1MB#{qidx}"
+    run_test "#{$bin}gt seed_extend -spacedseed -ii at1MB#{qidx}"
+  end
 end
 
 Name "gt dev show_seedext without alignment"

--- a/testsuite/gt_seed_extend_include.rb
+++ b/testsuite/gt_seed_extend_include.rb
@@ -27,6 +27,7 @@ seeds = [170039800390891361279027638963673934519,
          255642063275935424280602245704332672807]
 
 $SPLT_LIST = ["-splt struct","-splt ulong"]
+$KMPLT_LIST = ["struct","ulong"]
 $CAM_LIST = ["encseq", "encseq_reader","bytes"]
 $OUTFMT_ARGS = ["alignment","cigar","cigarX","polinfo","fstperquery","seed.len",
                 "seed.s","seed.q","seed_in_algn","s.seqlen",
@@ -192,6 +193,10 @@ Keywords "gt_seed_extend gt_seed_extend_failure"
 Test do
   run_test build_encseq("at1MB", "#{$testdata}at1MB")
   run_test build_encseq("foo", "#{$testdata}foo.fas")
+  run_test "#{$bin}gt seed_extend -splt xx -ii foo", :retval => 1
+  grep last_stderr, /illegal parameter for option -splt/
+  run_test "#{$bin}gt seed_extend -kmplt yy -ii foo", :retval => 1
+  grep last_stderr, /illegal parameter for option -kmplt/
   run_test "#{$bin}gt seed_extend -seedlength 10 -ii foo", :retval => 1
   grep last_stderr, /integer <= 8 \(length of longest sequence\)/
   run_test "#{$bin}gt seed_extend -maxfreq 1 -ii at1MB", :retval => 1
@@ -302,14 +307,17 @@ Keywords "gt_seed_extend cam"
 Test do
   run_test build_encseq("at1MB", "#{$testdata}at1MB")
   $SPLT_LIST.each do |splt|
-    $CAM_LIST.each do |a_cam|
-      $CAM_LIST.each do |b_cam|
-        run_test "#{$bin}gt seed_extend -extendgreedy " +
-                 "-cam #{a_cam},#{b_cam} -ii at1MB #{splt}", :retval => 0
-        run "grep -v '^#' #{last_stdout}"
-        run "sort #{last_stdout}"
-        run "mv #{last_stdout} see-ext-at1MB-#{a_cam}-#{b_cam}.matches"
-        run "diff -I '^#' see-ext-at1MB-#{a_cam}-#{b_cam}.matches #{$testdata}see-ext-at1MB.matches"
+    $KMPLT_LIST.each do |kmplt|
+      $CAM_LIST.each do |a_cam|
+        $CAM_LIST.each do |b_cam|
+          run_test "#{$bin}gt seed_extend -extendgreedy " +
+                   "-cam #{a_cam},#{b_cam} -ii at1MB #{splt} -kmplt #{kmplt}", 
+                   :retval => 0
+          run "grep -v '^#' #{last_stdout}"
+          run "sort #{last_stdout}"
+          run "mv #{last_stdout} see-ext-at1MB-#{a_cam}-#{b_cam}.matches"
+          run "diff -I '^#' see-ext-at1MB-#{a_cam}-#{b_cam}.matches #{$testdata}see-ext-at1MB.matches"
+        end
       end
     end
   end
@@ -332,7 +340,7 @@ end
 
 # Threading
 Name "gt seed_extend: threading"
-Keywords "gt_seed_extend thread"
+Keywords "gt_seed_extend thread gt_seed_extend_thread"
 Test do
   run_test build_encseq("at1MB", "#{$testdata}at1MB")
   run_test build_encseq("fastq_long", "#{$testdata}fastq_long.fastq")
@@ -391,13 +399,15 @@ Name "gt seed_extend: small_poly, xdrop vs greedy extension"
 Keywords "gt_seed_extend extendgreedy extendxdrop small_poly"
 Test do
   run_test build_encseq("small_poly", "#{$testdata}small_poly.fas")
-  for splt in $SPLT_LIST do
-    run_test "#{$bin}gt seed_extend -extendxdrop 97 " +
-             "-l 10 -ii small_poly -verify-alignment #{splt}"
-    run "diff -I '^#' #{last_stdout} #{$testdata}seedextend3.out"
-    run_test "#{$bin}gt seed_extend -extendgreedy 97 " +
-             "-l 10 -ii small_poly -verify-alignment #{splt}"
-    run "diff -I '^#' #{last_stdout} #{$testdata}seedextend3.out"
+  for kmplt in $KMPLT_LIST do
+    for splt in $SPLT_LIST do
+      run_test "#{$bin}gt seed_extend -extendxdrop 97 " +
+               "-l 10 -ii small_poly -verify-alignment #{splt} -kmplt #{kmplt}"
+      run "diff -I '^#' #{last_stdout} #{$testdata}seedextend3.out"
+      run_test "#{$bin}gt seed_extend -extendgreedy 97 " +
+               "-l 10 -ii small_poly -verify-alignment #{splt} -kmplt #{kmplt}"
+      run "diff -I '^#' #{last_stdout} #{$testdata}seedextend3.out"
+    end
   end
 end
 
@@ -422,7 +432,7 @@ end
 
 # Filter options
 Name "gt seed_extend: diagbandwidth, mincoverage, seedlength"
-Keywords "gt_seed_extend filter diagbandwidth mincoverage memlimit"
+Keywords "gt_seed_extend filter diagbandwidth mincoverage"
 Test do
   run_test build_encseq("gt_bioseq_succ_3", "#{$testdata}gt_bioseq_succ_3.fas")
   for diagbandwidth in [0, 1, 5, 10] do


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - 246 spaced seeds with flexible access to them
  - reduce space of kmers with positions from 16 bytes to 8 bytes (if sum of
    log_{2}-values of the code, the sequence number and the relative position
   fit in 64 bits



