### PR TITLE
Fix CI builds using Homebrew

### DIFF
--- a/scripts/travis_installdeps.sh
+++ b/scripts/travis_installdeps.sh
@@ -9,6 +9,5 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   sudo apt-get install binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64 -y
 else
   brew update
-  brew install pango cairo
-  brew install homebrew/science/blast
+  brew install pango cairo blast
 fi

--- a/scripts/travis_installdeps.sh
+++ b/scripts/travis_installdeps.sh
@@ -9,5 +9,5 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   sudo apt-get install binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64 -y
 else
   brew update
-  brew install pango cairo blast
+  brew install pango cairo blast --force
 fi

--- a/scripts/travis_installdeps.sh
+++ b/scripts/travis_installdeps.sh
@@ -9,5 +9,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   sudo apt-get install binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64 -y
 else
   brew update
-  brew install pango cairo blast --force
+  brew install pango cairo 
+  brew unlink proj
+  brew install blast --force
 fi


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Fix CI builds using Homebrew dependencies by no longer referencing the discontinued `homebrew/science` tap.
