### PR TITLE
fix off-by-one error

### DIFF
--- a/src/ltr/ltr_cluster_prepare_seq_visitor.c
+++ b/src/ltr/ltr_cluster_prepare_seq_visitor.c
@@ -59,8 +59,8 @@ static int extract_feature_seq(GtEncseqBuilder *b, const char *header,
   if (!had_err) {
     buffer = gt_calloc((size_t) gt_range_length(&range) + 1, sizeof (char));
     startpos = gt_encseq_seqstartpos(encseq, seqnum);
-    gt_encseq_extract_decoded(encseq, buffer, startpos + range.start,
-                              startpos + range.end);
+    gt_encseq_extract_decoded(encseq, buffer, startpos + range.start - 1,
+                              startpos + range.end - 1);
     gt_encseq_builder_add_cstr(b, buffer, gt_range_length(&range), header);
     gt_free(buffer);
   }


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Make sure that the correct range is extracted for clustering in `gt ltrclustering` and LTRsift.

## Related issues

Fixes #858.
