### PR TITLE
use safer buffer sizes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,13 @@ matrix:
       env: opt=no cairo=no
     - os: osx
       compiler: gcc
-      env: default=yes
+      env: default=yes PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"
     - os: osx
       compiler: gcc
-      env: assert=no
+      env: assert=no PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"
     - os: osx
       compiler: gcc
-      env: amalgamation=yes
+      env: amalgamation=yes PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"
     - os: linux
       compiler: gcc
       env: opt=no cairo=no

--- a/scripts/travis_installdeps.sh
+++ b/scripts/travis_installdeps.sh
@@ -9,7 +9,8 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   sudo apt-get install binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64 -y
 else
   brew update
-  brew install pango cairo 
+  brew install pkg-config
+  brew install pango cairo libffi
   brew unlink proj
   brew install blast --force
 fi

--- a/src/ltr/ltr_cluster_prepare_seq_visitor.c
+++ b/src/ltr/ltr_cluster_prepare_seq_visitor.c
@@ -101,12 +101,12 @@ static int gt_ltr_cluster_prepare_seq_visitor_feature_node(GtNodeVisitor *nv,
       GtRange range;
       const char *attr;
       GtEncseqBuilder *eb;
-      char header[BUFSIZ];
+      char header[2*BUFSIZ];
       attr = gt_feature_node_get_attribute(curnode, "name");
       if (!attr)
         continue;
       range = gt_genome_node_get_range((GtGenomeNode*) curnode);
-      (void) snprintf(header, BUFSIZ, "%s_"GT_WU"_"GT_WU"", buffer, range.start,
+      (void) snprintf(header, 2*BUFSIZ, "%s_"GT_WU"_"GT_WU"", buffer, range.start,
                       range.end);
       if (!gt_hashmap_get(lcv->encseq_builders, attr)) {
         eb = gt_encseq_builder_new(gt_encseq_alphabet(lcv->src_encseq));
@@ -129,7 +129,7 @@ static int gt_ltr_cluster_prepare_seq_visitor_feature_node(GtNodeVisitor *nv,
       char *tmp;
       GtRange range;
       GtEncseqBuilder *eb;
-      char header[BUFSIZ];  /* XXX: use GtStr for safety */
+      char header[2*BUFSIZ];  /* XXX: use GtStr for safety */
       if (strcmp(fnt, gt_ft_long_terminal_repeat) == 0) {
         if (first_ltr) {
           tmp = gt_cstr_dup("lLTR");
@@ -143,7 +143,7 @@ static int gt_ltr_cluster_prepare_seq_visitor_feature_node(GtNodeVisitor *nv,
         gt_free(tmp);
         continue;
       }
-      (void) snprintf(header, BUFSIZ, "%s_"GT_WU"_"GT_WU"", buffer, range.start,
+      (void) snprintf(header, 2*BUFSIZ, "%s_"GT_WU"_"GT_WU"", buffer, range.start,
                       range.end);
       if (!gt_hashmap_get(lcv->encseq_builders, tmp)) {
         eb = gt_encseq_builder_new(gt_encseq_alphabet(lcv->src_encseq));

--- a/src/ltr/ltr_cluster_stream.c
+++ b/src/ltr/ltr_cluster_stream.c
@@ -321,7 +321,7 @@ static int cluster_annotate_nodes(GtClusteredSet *cs, GtEncseq *encseq,
       continue;
     fni = gt_feature_node_iterator_new((GtFeatureNode*) gn);
     while ((curnode = gt_feature_node_iterator_next(fni)) != NULL) {
-      char header[BUFSIZ];
+      char header[2*BUFSIZ];
       fnt = gt_feature_node_get_type(curnode);
       if (strcmp(fnt, gt_ft_repeat_region) == 0) {
         const char *rid;
@@ -341,7 +341,7 @@ static int cluster_annotate_nodes(GtClusteredSet *cs, GtEncseq *encseq,
         range = gt_genome_node_get_range((GtGenomeNode*) curnode);
         if ((range.end - range.start + 1) < 10UL)
           continue;
-        (void) snprintf(header, BUFSIZ, "%s_"GT_WU"_"GT_WU"", buffer,
+        (void) snprintf(header, 2*BUFSIZ, "%s_"GT_WU"_"GT_WU"", buffer,
                         range.start, range.end);
         gt_hashmap_add(desc2node, (void*) gt_cstr_dup(header), (void*) curnode);
       } else if (strcmp(fnt, real_feature) == 0) {
@@ -349,7 +349,7 @@ static int cluster_annotate_nodes(GtClusteredSet *cs, GtEncseq *encseq,
         range = gt_genome_node_get_range((GtGenomeNode*) curnode);
         if ((range.end - range.start + 1) < 10UL)
           continue;
-        (void) snprintf(header, BUFSIZ, "%s_"GT_WU"_"GT_WU"", buffer,
+        (void) snprintf(header, 2*BUFSIZ, "%s_"GT_WU"_"GT_WU"", buffer,
                         range.start, range.end);
         gt_hashmap_add(desc2node, (void*) gt_cstr_dup(header), (void*) curnode);
       }

--- a/src/match/eis-bwtseq-context.c
+++ b/src/match/eis-bwtseq-context.c
@@ -287,7 +287,7 @@ BWTSeqCRMapOpen(unsigned short mapIntervalLog2,
                             seqLen, mapIntervalLog2));
     mapName = gt_str_new_cstr(projectName);
     {
-      char buf[1 + 4 + 3 + 2];
+      char buf[1 + 4 + 3 + 3];
       snprintf(buf, sizeof (buf), ".%ucxm", (unsigned)mapIntervalLog2);
       gt_str_append_cstr(mapName, buf);
       if (createMapFile)


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Use larger buffer sizes to make sure that formatted strings _always_ fit into them.
    This addresses some build errors caused by stricter static checking in newer compilers.
  - Adjust environment variables in Travis macOS runs. (cf. https://github.com/Homebrew/homebrew-core/issues/40179 and https://github.com/gtk-rs/cairo/pull/264)

## Related issues

Fixes and closes #915 and #916.
