### PR TITLE
disallow LCP table generation when using >1 threads

### DIFF
--- a/src/match/sfx-opt.c
+++ b/src/match/sfx-opt.c
@@ -26,6 +26,7 @@
 #include "core/readmode.h"
 #include "core/spacecalc.h"
 #include "core/str.h"
+#include "core/thread_api.h"
 #include "core/unused_api.h"
 #include "core/versionfunc.h"
 #include "match/sfx-opt.h"
@@ -114,6 +115,14 @@ static GtOPrval parse_options(int *parsed_args,
     basenameptr = gt_basename(gt_str_get(so->inputindex));
     gt_str_set(so->indexname, basenameptr);
     gt_free(basenameptr);
+  }
+
+  if (oprval == GT_OPTION_PARSER_OK &&
+      gt_jobs > 1 && gt_index_options_outlcptab_value(so->idxopts)) {
+    /* LCP table generation is not implemented in multithreaded
+       operation */
+    gt_error_set(err, "option -lcp cannot be used when using >1 threads");
+    oprval = GT_OPTION_PARSER_ERROR;
   }
 
   gt_option_parser_delete(op);

--- a/testsuite/gt_suffixerator_include.rb
+++ b/testsuite/gt_suffixerator_include.rb
@@ -601,3 +601,11 @@ Test do
   run "#{$bin}/gt dev sfxmap -enumlcpitvtree -esa sfx > noBU.txt"
   run "diff withBU.txt noBU.txt"
 end
+
+Name "gt suffixerator multithreaded -lcp"
+Keywords "gt_suffixerator multithreaded"
+Test do
+  run "#{$bin}/gt -j 3 suffixerator -db #{$testdata}/at1MB -indexname foo " + \
+      "-lcp -suf", :retval => 1
+  grep(last_stderr, /cannot be used when/)
+end


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Disallow use of the `-j n` and `-lcp` switches in `gt suffixerator` when _n_ > 1. This is a result of an incomplete implementation of the experimental multithreaded ESA generation.

## Related issues

Fixes #922.
