### PR TITLE
Ensure presence of prefixes

### DIFF
--- a/scripts/mk_ft_longest_common.rb
+++ b/scripts/mk_ft_longest_common.rb
@@ -25,7 +25,7 @@ def gen_compare(a_mode,b_mode,wildcard,complement)
              " " * 10 + "break"
   if wildcard
     return "const GtUchar cu = #{gen_access_raw(a_mode,"useq","u")};\n" +
-           " " * 8 + "if (cu == WILDCARD ||" + splitter + "cu !=" + splitter +
+           " " * 8 + "if (cu == GT_WILDCARD ||" + splitter + "cu !=" + splitter +
            cmp_expr
   else
     return "if (#{gen_access_raw(a_mode,"useq","u")} !=" + splitter +

--- a/scripts/mksainseq.rb
+++ b/scripts/mksainseq.rb
@@ -27,13 +27,13 @@ def getc_call(key,posexpr,seqaccess = false)
     return "(GtUword) array[#{posexpr}]"
   elsif key == "BARE_ENCSEQ"
     if seqaccess
-      return "(GtUword)\nISSPECIAL(tmpcc =\nplainseq[#{posexpr}])\n" +
+      return "(GtUword)\nGT_ISSPECIAL(tmpcc =\nplainseq[#{posexpr}])\n" +
              "  ? GT_UNIQUEINT(#{posexpr}) : (GtUword) tmpcc"
     else
       return "(GtUword)\nplainseq[#{posexpr}]"
     end
   elsif seqaccess
-    return "ISSPECIAL(tmpcc =\ngt_encseq_reader_next_encoded_char(esr))\n" +
+    return "GT_ISSPECIAL(tmpcc =\ngt_encseq_reader_next_encoded_char(esr))\n" +
                " ? GT_UNIQUEINT(#{posexpr}) : (GtUword) tmpcc"
   else
     return "(GtUword) gt_encseq_get_encoded_char(\n" +
@@ -45,7 +45,7 @@ end
 
 def special2unique(key,cc,start)
   if key == "ENCSEQ" || key == "BARE_ENCSEQ"
-    return "if (ISSPECIAL(#{cc})) { #{cc} = GT_UNIQUEINT(#{start}); }"
+    return "if (GT_ISSPECIAL(#{cc})) { #{cc} = GT_UNIQUEINT(#{start}); }"
   else
     return ""
   end

--- a/src/annotationsketch/custom_track_gc_content.c
+++ b/src/annotationsketch/custom_track_gc_content.c
@@ -57,7 +57,7 @@ static double get_val_for_pos(GtCustomTrackGcContent *ctgc, GtUword pos)
     }
     bases++;
   }
-  return ((double) gc_count)/((double) MIN(ctgc->windowsize, bases));
+  return ((double) gc_count)/((double) GT_MIN(ctgc->windowsize, bases));
 }
 
 int gt_custom_track_gc_content_sketch(GtCustomTrack *ct, GtGraphics *graphics,

--- a/src/core/accspecialrange.gen
+++ b/src/core/accspecialrange.gen
@@ -76,7 +76,7 @@ static int GT_APPENDINT(fillSWtable)(GtEncseq *encseq,
     retval = gt_sequence_buffer_next_with_original(fb,&cc,&orig,err);
     if (retval > 0)
     {
-      if (encseq->has_exceptiontable && cc != (GtUchar) SEPARATOR) {
+      if (encseq->has_exceptiontable && cc != (GtUchar) GT_SEPARATOR) {
         if (orig == encseq->maxchars[cc]) {
           if (lastexceptionrangelength > 0) {
             exceptiontable->rangelengths[fillexceptionrangeidx-1]
@@ -112,7 +112,7 @@ static int GT_APPENDINT(fillSWtable)(GtEncseq *encseq,
                                    (uint32_t) encseq->subsymbolmap[(int) orig]);
         }
       }
-      if (ISNOTSPECIAL(cc))
+      if (GT_ISNOTSPECIAL(cc))
       {
         if (lastwildcardrangelength > 0)
         {
@@ -128,7 +128,7 @@ static int GT_APPENDINT(fillSWtable)(GtEncseq *encseq,
         }
       } else
       {
-        if (cc == (GtUchar) WILDCARD)
+        if (cc == (GtUchar) GT_WILDCARD)
         {
 #ifndef NDEBUG
           countwildcards++;
@@ -225,7 +225,7 @@ static int GT_APPENDINT(fillSWtable)(GtEncseq *encseq,
 
     ssptaboutinfo_processanyposition(ssptaboutinfo,currentposition);
     bitwise <<= 2;
-    if (ISNOTSPECIAL(cc))
+    if (GT_ISNOTSPECIAL(cc))
     {
       bitwise |= (GtTwobitencoding) cc;
     } else
@@ -927,7 +927,7 @@ static GtUchar GT_APPENDINT(seqdelivercharSpecial)(GtEncseqReader *esr)
   if (esr->encseq->numofdbsequences > 1UL &&
       GT_APPENDINT(checknextSW)(esr,SWtable_ssptab))
   {
-    cc = (GtUchar) SEPARATOR;
+    cc = (GtUchar) GT_SEPARATOR;
     defined = true;
   }
   if (GT_APPENDINT(esr->encseq->wildcardrangetable.st).numofpositionstostore
@@ -935,7 +935,7 @@ static GtUchar GT_APPENDINT(seqdelivercharSpecial)(GtEncseqReader *esr)
       GT_APPENDINT(checknextSW)(esr,SWtable_wildcardrange))
   {
     gt_assert(!defined);
-    cc = (GtUchar) WILDCARD;
+    cc = (GtUchar) GT_WILDCARD;
     defined = true;
   }
   if (defined)

--- a/src/core/alphabet.c
+++ b/src/core/alphabet.c
@@ -175,7 +175,7 @@ static int read_symbolmap_from_lines(GtAlphabet *alpha,
   alpha->domainsize = alpha->mapsize = alpha->mappedwildcards = 0;
   for (cnum=0; cnum<=(unsigned int) GT_MAXALPHABETCHARACTER; cnum++)
   {
-    alpha->symbolmap[cnum] = (GtUchar) UNDEFCHAR;
+    alpha->symbolmap[cnum] = (GtUchar) GT_UNDEFCHAR;
   }
   alpha->mapdomain = NULL;
   alpha->characters = gt_malloc(sizeof (GtUchar) *
@@ -206,7 +206,7 @@ static int read_symbolmap_from_lines(GtAlphabet *alpha,
           cc = LINE(column);
           if (ispunct((int) cc) || isalnum((int) cc))
           {
-            if (alpha->symbolmap[(unsigned int) cc] != (GtUchar) UNDEFCHAR)
+            if (alpha->symbolmap[(unsigned int) cc] != (GtUchar) GT_UNDEFCHAR)
             {
               gt_error_set(err,"cannot map symbol '%c' to %u: "
                             "it is already mapped to %u",
@@ -293,7 +293,7 @@ static int read_symbolmap_from_lines(GtAlphabet *alpha,
     {
       if (alpha->symbolmap[cnum] == (GtUchar) (alpha->mapsize - 1))
       {
-        alpha->symbolmap[cnum] = (GtUchar) WILDCARD;
+        alpha->symbolmap[cnum] = (GtUchar) GT_WILDCARD;
         alpha->mappedwildcards++;
       }
     }
@@ -339,7 +339,7 @@ static void assign_dna_symbolmap(GtUchar *symbolmap)
 
   for (cnum=0; cnum<=(unsigned int) GT_MAXALPHABETCHARACTER; cnum++)
   {
-    symbolmap[cnum] = (GtUchar) UNDEFCHAR;
+    symbolmap[cnum] = (GtUchar) GT_UNDEFCHAR;
   }
   symbolmap[(unsigned int) 'a'] = (GtUchar) 0;
   symbolmap[(unsigned int) 'A'] = (GtUchar) 0;
@@ -353,7 +353,7 @@ static void assign_dna_symbolmap(GtUchar *symbolmap)
   symbolmap[(unsigned int) 'U'] = (GtUchar) 3;
   for (cnum=0; DNAWILDCARDS[cnum] != '\0'; cnum++)
   {
-    symbolmap[(unsigned int) DNAWILDCARDS[cnum]] = (GtUchar) WILDCARD;
+    symbolmap[(unsigned int) DNAWILDCARDS[cnum]] = (GtUchar) GT_WILDCARD;
   }
 }
 
@@ -447,8 +447,8 @@ void gt_alphabet_add_wildcard(GtAlphabet *alphabet, char wildcard)
                                    (size_t) alphabet->domainsize + 1);
   alphabet->mapdomain[alphabet->domainsize] = (GtUchar) wildcard;
   alphabet->domainsize++;
-  alphabet->symbolmap[(int) wildcard] = (GtUchar) WILDCARD;
-  if (alphabet->wildcardshow == (GtUchar) UNDEFCHAR) {
+  alphabet->symbolmap[(int) wildcard] = (GtUchar) GT_WILDCARD;
+  if (alphabet->wildcardshow == (GtUchar) GT_UNDEFCHAR) {
     alphabet->wildcardshow = (GtUchar) wildcard;
     alphabet->mapsize++;
   }
@@ -480,7 +480,7 @@ static void assign_dna_alphabet(GtAlphabet *alpha)
   alpha->mapsize = MAPSIZEDNA;
   alpha->characters = gt_calloc((size_t) UCHAR_MAX+1, sizeof (GtUchar));
   memcpy(alpha->characters,"acgt",(size_t) (MAPSIZEDNA-1));
-  alpha->characters[WILDCARD] = (GtUchar) DNAWILDCARDS[0];
+  alpha->characters[GT_WILDCARD] = (GtUchar) DNAWILDCARDS[0];
   alpha->characters[MAPSIZEDNA-1] = (GtUchar) DNAWILDCARDS[0];
   assign_dna_symbolmap(alpha->symbolmap);
 }
@@ -491,7 +491,7 @@ static void assignproteinsymbolmap(GtUchar *symbolmap)
 
   for (cnum=0; cnum<=(unsigned int) GT_MAXALPHABETCHARACTER; cnum++)
   {
-    symbolmap[cnum] = (GtUchar) UNDEFCHAR;
+    symbolmap[cnum] = (GtUchar) GT_UNDEFCHAR;
   }
   for (cnum=0; PROTEINUPPERAMINOACIDS[cnum] != '\0'; cnum++)
   {
@@ -499,7 +499,7 @@ static void assignproteinsymbolmap(GtUchar *symbolmap)
   }
   for (cnum=0; PROTEINWILDCARDS[cnum] != '\0'; cnum++)
   {
-    symbolmap[(unsigned int) PROTEINWILDCARDS[cnum]] = (GtUchar) WILDCARD;
+    symbolmap[(unsigned int) PROTEINWILDCARDS[cnum]] = (GtUchar) GT_WILDCARD;
   }
 }
 
@@ -547,7 +547,7 @@ static void assign_protein_alphabet(GtAlphabet *alpha)
   alpha->mapsize = MAPSIZEPROTEIN;
   alpha->characters = gt_calloc((size_t) UCHAR_MAX+1, sizeof (GtUchar));
   memcpy(alpha->characters,PROTEINUPPERAMINOACIDS,(size_t) (MAPSIZEPROTEIN-1));
-  alpha->characters[WILDCARD] = (GtUchar) PROTEINWILDCARDS[0];
+  alpha->characters[GT_WILDCARD] = (GtUchar) PROTEINWILDCARDS[0];
   alpha->characters[MAPSIZEPROTEIN-1] = (GtUchar) PROTEINWILDCARDS[0];
   assignproteinsymbolmap(alpha->symbolmap);
 }
@@ -621,8 +621,8 @@ GtAlphabet* gt_alphabet_new_empty(void)
   a->bitspersymbol = 0;
   a->reference_count = 0;
   a->refmutex = gt_mutex_new();
-  a->wildcardshow = (GtUchar) UNDEFCHAR;
-  memset(a->symbolmap, (int) UNDEFCHAR, (size_t) GT_MAXALPHABETCHARACTER+1);
+  a->wildcardshow = (GtUchar) GT_UNDEFCHAR;
+  memset(a->symbolmap, (int) GT_UNDEFCHAR, (size_t) GT_MAXALPHABETCHARACTER+1);
   a->mapdomain = NULL;
   a->characters = NULL;
   a->alphadef = NULL;
@@ -776,8 +776,8 @@ void gt_alphabet_printf_symbolstring(const GtAlphabet *alphabet,
 static inline char converttoprettysymbol(const GtAlphabet *alphabet,
                                          GtUchar currentchar)
 {
-  gt_assert(alphabet != NULL && currentchar != (GtUchar) SEPARATOR);
-  if (currentchar < (GtUchar) WILDCARD)
+  gt_assert(alphabet != NULL && currentchar != (GtUchar) GT_SEPARATOR);
+  if (currentchar < (GtUchar) GT_WILDCARD)
   {
     gt_assert((unsigned int) currentchar < alphabet->mapsize-1);
     return (char) alphabet->characters[(int) currentchar];
@@ -935,7 +935,7 @@ bool gt_alphabet_is_dna(const GtAlphabet *alphabet)
 
 bool gt_alphabet_valid_input(const GtAlphabet *alphabet, char c)
 {
-  if (alphabet->symbolmap[(int) c] != (GtUchar) UNDEFCHAR)
+  if (alphabet->symbolmap[(int) c] != (GtUchar) GT_UNDEFCHAR)
     return true;
   return false;
 }
@@ -943,7 +943,7 @@ bool gt_alphabet_valid_input(const GtAlphabet *alphabet, char c)
 GtUchar gt_alphabet_encode(const GtAlphabet *alphabet, char c)
 {
   gt_assert(alphabet);
-  gt_assert(alphabet->symbolmap[(int) c] != (GtUchar) UNDEFCHAR);
+  gt_assert(alphabet->symbolmap[(int) c] != (GtUchar) GT_UNDEFCHAR);
   return alphabet->symbolmap[(int) c];
 }
 
@@ -962,7 +962,7 @@ void gt_alphabet_encode_seq(const GtAlphabet *alphabet, GtUchar *out,
   gt_assert(alphabet && out && in);
   for (i = 0; i < length; i++) {
     GtUchar cc = alphabet->symbolmap[(int) in[i]];
-    gt_assert(cc != (GtUchar) UNDEFCHAR);
+    gt_assert(cc != (GtUchar) GT_UNDEFCHAR);
     out[i] = cc;
   }
 }

--- a/src/core/bitpackstringop.c
+++ b/src/core/bitpackstringop.c
@@ -308,8 +308,8 @@ gt_bsCopy(constBitString src, BitOffset offsetSrc,
           while (bitsInAccum < bits2Write)
           {
             GtUword mask;
-            unsigned bits2Read = GT_MIN3(sizeof (accum) * CHAR_BIT - bitsInAccum,
-                                      bitsLeft, bitElemBits);
+            unsigned bits2Read = GT_MIN3(sizeof (accum) * CHAR_BIT
+                                         - bitsInAccum, bitsLeft, bitElemBits);
             unsigned unreadRightBits = (bitElemBits - bits2Read);
             mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
             accum = (accum << bits2Read) | ((*p) & mask) >> unreadRightBits;

--- a/src/core/bitpackstringop.c
+++ b/src/core/bitpackstringop.c
@@ -129,7 +129,7 @@ int gt_bsCompare(constBitString a, BitOffset offsetA, BitOffset numBitsA,
       if (bitTopB)
       {
         GtUword mask; /*< all of the bits we want to get from *pB */
-        unsigned bits2Read = MIN(bitElemBits - bitTopB, comparePreBits);
+        unsigned bits2Read = GT_MIN(bitElemBits - bitTopB, comparePreBits);
         unsigned unreadRightBits = (bitElemBits - bitTopB - bits2Read);
         mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
         accumB = ((*pB++) & mask) >> unreadRightBits;
@@ -142,7 +142,7 @@ int gt_bsCompare(constBitString a, BitOffset offsetA, BitOffset numBitsA,
         unsigned bits2Read,
           bitsFree = (CHAR_BIT * sizeof (accumA)) - bitsInAccumB;
         GtUword mask;
-        bits2Read = MIN3(bitsFree, bitElemBits, comparePreBits);
+        bits2Read = GT_MIN3(bitsFree, bitElemBits, comparePreBits);
         mask = ~((~(GtUword)0) << bits2Read);
         accumB = accumB << bits2Read
           | (((*pB) >> (bitElemBits - bits2Read)) & mask);
@@ -165,7 +165,7 @@ int gt_bsCompare(constBitString a, BitOffset offsetA, BitOffset numBitsA,
     if (bitTopA)
     {
       GtUword mask; /*< all of the bits we want to get from *pA */
-      unsigned bits2Read = MIN(bitElemBits - bitTopA, totalBitsLeftA);
+      unsigned bits2Read = GT_MIN(bitElemBits - bitTopA, totalBitsLeftA);
       unsigned unreadRightBits = (bitElemBits - bitTopA - bits2Read);
       mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
       accumA = ((*pA++) & mask) >> unreadRightBits;
@@ -178,7 +178,7 @@ int gt_bsCompare(constBitString a, BitOffset offsetA, BitOffset numBitsA,
     if (bitTopB)
     {
       GtUword mask; /*< all of the bits we want to get from *pB */
-      unsigned bits2Read = MIN(bitElemBits - bitTopB, totalBitsLeftB);
+      unsigned bits2Read = GT_MIN(bitElemBits - bitTopB, totalBitsLeftB);
       unsigned unreadRightBits = (bitElemBits - bitTopB - bits2Read);
       mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
       accumB = ((*pB++) & mask) >> unreadRightBits;
@@ -192,7 +192,7 @@ int gt_bsCompare(constBitString a, BitOffset offsetA, BitOffset numBitsA,
       unsigned bits2Read,
                bitsFree = (CHAR_BIT * sizeof (accumA)) - bitsInAccumA;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits, totalBitsLeftA);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits, totalBitsLeftA);
       mask = (~((~(GtUword)0) << bits2Read));
       accumA = accumA << bits2Read
         | (((*pA) >> (bitElemBits - bits2Read)) & mask);
@@ -209,7 +209,7 @@ int gt_bsCompare(constBitString a, BitOffset offsetA, BitOffset numBitsA,
       unsigned bits2Read,
         bitsFree = (CHAR_BIT * sizeof (accumA)) - bitsInAccumB;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits, totalBitsLeftB);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits, totalBitsLeftB);
       mask = (~((~(GtUword)0) << bits2Read));
       accumB = accumB << bits2Read
         | (((*pB) >> (bitElemBits - bits2Read)) & mask);
@@ -280,7 +280,7 @@ gt_bsCopy(constBitString src, BitOffset offsetSrc,
       if (bitTopSrc)
       {
         GtUword mask;
-        unsigned bits2Read = MIN3(bitElemBits - bitTopSrc, bitsLeft,
+        unsigned bits2Read = GT_MIN3(bitElemBits - bitTopSrc, bitsLeft,
                                   sizeof (accum) * CHAR_BIT - bitsInAccum);
         unsigned unreadRightBits = (bitElemBits - bitTopSrc - bits2Read);
         mask = (~((~(GtUword)0) << bits2Read));
@@ -292,7 +292,7 @@ gt_bsCopy(constBitString src, BitOffset offsetSrc,
       }
       if (bitTopDest)
       {
-        unsigned bits2Write = MIN(bitsLeft + bitsInAccum,
+        unsigned bits2Write = GT_MIN(bitsLeft + bitsInAccum,
                                   bitElemBits - bitTopDest);
         while (bitsLeft >= bitElemBits
                && sizeof (accum) * CHAR_BIT - bitsInAccum > bitElemBits)
@@ -308,7 +308,7 @@ gt_bsCopy(constBitString src, BitOffset offsetSrc,
           while (bitsInAccum < bits2Write)
           {
             GtUword mask;
-            unsigned bits2Read = MIN3(sizeof (accum) * CHAR_BIT - bitsInAccum,
+            unsigned bits2Read = GT_MIN3(sizeof (accum) * CHAR_BIT - bitsInAccum,
                                       bitsLeft, bitElemBits);
             unsigned unreadRightBits = (bitElemBits - bits2Read);
             mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
@@ -359,7 +359,7 @@ gt_bsCopy(constBitString src, BitOffset offsetSrc,
     {
       while (bitsLeft && bitsInAccum < sizeof (accum) * CHAR_BIT)
       {
-        unsigned bits2Read = MIN3(bitsLeft, bitElemBits - bitTopSrc,
+        unsigned bits2Read = GT_MIN3(bitsLeft, bitElemBits - bitTopSrc,
                                   sizeof (accum) * CHAR_BIT - bitsInAccum);
         unsigned unreadRightBits = (bitElemBits - bitTopSrc - bits2Read);
         GtUword mask =
@@ -372,7 +372,7 @@ gt_bsCopy(constBitString src, BitOffset offsetSrc,
       }
       while (bitsInAccum)
       {
-        unsigned bits2Write = MIN(bitsInAccum, bitElemBits - bitTopDest),
+        unsigned bits2Write = GT_MIN(bitsInAccum, bitElemBits - bitTopDest),
           unwrittenRightBits = bitElemBits - bits2Write - bitTopDest;
         GtUword mask = (~(GtUword)0);
         if (bits2Write != bitElemBits)
@@ -453,7 +453,7 @@ BitOffset gt_bs1BitsCount(constBitString str, BitOffset offset,
   if (bitTop)
   {
     uint32_t mask;
-    unsigned bits2Read = MIN(bitElemBits - bitTop, bitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, bitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(uint32_t)0) << bits2Read)) << unreadRightBits;
     weight += bitCountUInt32(((*p++) & mask) >> unreadRightBits);
@@ -517,7 +517,7 @@ int gt_bsPrint(FILE *fp, constBitString str, BitOffset offset,
     if (bitTop)
     {
       uint32_t mask;
-      unsigned bits2Read = MIN(bitElemBits - bitTop, bitsLeft);
+      unsigned bits2Read = GT_MIN(bitElemBits - bitTop, bitsLeft);
       unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
       mask = (~((~(uint32_t)0) << bits2Read)) << unreadRightBits;
       ACCUM2FP(((*p++) & mask) >> unreadRightBits, bits2Read);

--- a/src/core/bitpackstringop.template
+++ b/src/core/bitpackstringop.template
@@ -37,7 +37,7 @@ gt_bsGet@uTypeTag@(constBitString str, BitOffset offset, unsigned numBits)
   if (bitTop)
   {
     @AccumType@ mask;
-    unsigned bits2Read = MIN(bitElemBits - bitTop, bitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, bitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(@AccumType@)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;

--- a/src/core/bitpackstringop16.c
+++ b/src/core/bitpackstringop16.c
@@ -40,7 +40,7 @@ gt_bsGetUInt16(constBitString str, BitOffset offset, unsigned numBits)
   if (bitTop)
   {
     GtUword mask;
-    unsigned bits2Read = MIN(bitElemBits - bitTop, bitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, bitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -183,7 +183,7 @@ gt_bsGetUniformUInt16Array(constBitString str, BitOffset offset,
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -196,7 +196,7 @@ gt_bsGetUniformUInt16Array(constBitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -242,7 +242,7 @@ gt_bsGetNonUniformUInt16Array(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -255,7 +255,7 @@ gt_bsGetNonUniformUInt16Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -309,7 +309,7 @@ gt_bsGetNonUniformInt16Array(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -322,7 +322,7 @@ gt_bsGetNonUniformInt16Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -412,7 +412,7 @@ gt_bsStoreUniformUInt16Array(BitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
 
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         accum = accum << bits2Read
           | ((currentVal) >> (bitsLeft - bits2Read));
@@ -452,7 +452,7 @@ gt_bsStoreUniformUInt16Array(BitString str, BitOffset offset,
               || (bitsLeft < sizeof (accum)*CHAR_BIT - bitsInAccum)))
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         GtUword mask = ~((~(GtUword)0) << bits2Read);
         accum = accum << bits2Read
@@ -540,7 +540,7 @@ gt_bsStoreNonUniformUInt16Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
 
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         accum = accum << bits2Read
           | ((currentVal) >> (bitsLeft - bits2Read));
@@ -586,7 +586,7 @@ gt_bsStoreNonUniformUInt16Array(
               || (bitsLeft < sizeof (accum)*CHAR_BIT - bitsInAccum)))
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         GtUword mask = ~((~(GtUword)0) << bits2Read);
         accum = accum << bits2Read
@@ -675,7 +675,7 @@ gt_bsGetUniformUInt16ArrayAdd(constBitString str, BitOffset offset,
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -688,7 +688,7 @@ gt_bsGetUniformUInt16ArrayAdd(constBitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -734,7 +734,7 @@ gt_bsGetNonUniformUInt16ArrayAdd(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -747,7 +747,7 @@ gt_bsGetNonUniformUInt16ArrayAdd(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -801,7 +801,7 @@ gt_bsGetNonUniformInt16ArrayAdd(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -814,7 +814,7 @@ gt_bsGetNonUniformInt16ArrayAdd(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);

--- a/src/core/bitpackstringop32.c
+++ b/src/core/bitpackstringop32.c
@@ -40,7 +40,7 @@ gt_bsGetUInt32(constBitString str, BitOffset offset, unsigned numBits)
   if (bitTop)
   {
     GtUword mask;
-    unsigned bits2Read = MIN(bitElemBits - bitTop, bitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, bitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -183,7 +183,7 @@ gt_bsGetUniformUInt32Array(constBitString str, BitOffset offset,
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -196,7 +196,7 @@ gt_bsGetUniformUInt32Array(constBitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -242,7 +242,7 @@ gt_bsGetNonUniformUInt32Array(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -255,7 +255,7 @@ gt_bsGetNonUniformUInt32Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -309,7 +309,7 @@ gt_bsGetNonUniformInt32Array(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -322,7 +322,7 @@ gt_bsGetNonUniformInt32Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -412,7 +412,7 @@ gt_bsStoreUniformUInt32Array(BitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
 
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         accum = accum << bits2Read
           | ((currentVal) >> (bitsLeft - bits2Read));
@@ -452,7 +452,7 @@ gt_bsStoreUniformUInt32Array(BitString str, BitOffset offset,
               || (bitsLeft < sizeof (accum)*CHAR_BIT - bitsInAccum)))
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         GtUword mask = ~((~(GtUword)0) << bits2Read);
         accum = accum << bits2Read
@@ -540,7 +540,7 @@ gt_bsStoreNonUniformUInt32Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
 
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         accum = accum << bits2Read
           | ((currentVal) >> (bitsLeft - bits2Read));
@@ -586,7 +586,7 @@ gt_bsStoreNonUniformUInt32Array(
               || (bitsLeft < sizeof (accum)*CHAR_BIT - bitsInAccum)))
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         GtUword mask = ~((~(GtUword)0) << bits2Read);
         accum = accum << bits2Read
@@ -675,7 +675,7 @@ gt_bsGetUniformUInt32ArrayAdd(constBitString str, BitOffset offset,
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -688,7 +688,7 @@ gt_bsGetUniformUInt32ArrayAdd(constBitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -734,7 +734,7 @@ gt_bsGetNonUniformUInt32ArrayAdd(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -747,7 +747,7 @@ gt_bsGetNonUniformUInt32ArrayAdd(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -801,7 +801,7 @@ gt_bsGetNonUniformInt32ArrayAdd(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -814,7 +814,7 @@ gt_bsGetNonUniformInt32ArrayAdd(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);

--- a/src/core/bitpackstringop64.c
+++ b/src/core/bitpackstringop64.c
@@ -40,7 +40,7 @@ gt_bsGetUInt64(constBitString str, BitOffset offset, unsigned numBits)
   if (bitTop)
   {
     GtUint64 mask;
-    unsigned bits2Read = MIN(bitElemBits - bitTop, bitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, bitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUint64)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -183,7 +183,7 @@ gt_bsGetUniformUInt64Array(constBitString str, BitOffset offset,
   if (bitTop)
   {
     GtUint64 mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUint64)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -196,7 +196,7 @@ gt_bsGetUniformUInt64Array(constBitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUint64 mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUint64)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -242,7 +242,7 @@ gt_bsGetNonUniformUInt64Array(
   if (bitTop)
   {
     GtUint64 mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUint64)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -255,7 +255,7 @@ gt_bsGetNonUniformUInt64Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUint64 mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUint64)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -309,7 +309,7 @@ gt_bsGetNonUniformInt64Array(
   if (bitTop)
   {
     GtUint64 mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUint64)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -322,7 +322,7 @@ gt_bsGetNonUniformInt64Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUint64 mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUint64)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -412,7 +412,7 @@ gt_bsStoreUniformUInt64Array(BitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
 
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         accum = accum << bits2Read
           | ((currentVal) >> (bitsLeft - bits2Read));
@@ -452,7 +452,7 @@ gt_bsStoreUniformUInt64Array(BitString str, BitOffset offset,
               || (bitsLeft < sizeof (accum)*CHAR_BIT - bitsInAccum)))
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         GtUint64 mask = ~((~(GtUint64)0) << bits2Read);
         accum = accum << bits2Read
@@ -540,7 +540,7 @@ gt_bsStoreNonUniformUInt64Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
 
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         accum = accum << bits2Read
           | ((currentVal) >> (bitsLeft - bits2Read));
@@ -586,7 +586,7 @@ gt_bsStoreNonUniformUInt64Array(
               || (bitsLeft < sizeof (accum)*CHAR_BIT - bitsInAccum)))
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         GtUint64 mask = ~((~(GtUint64)0) << bits2Read);
         accum = accum << bits2Read
@@ -675,7 +675,7 @@ gt_bsGetUniformUInt64ArrayAdd(constBitString str, BitOffset offset,
   if (bitTop)
   {
     GtUint64 mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUint64)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -688,7 +688,7 @@ gt_bsGetUniformUInt64ArrayAdd(constBitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUint64 mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUint64)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -734,7 +734,7 @@ gt_bsGetNonUniformUInt64ArrayAdd(
   if (bitTop)
   {
     GtUint64 mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUint64)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -747,7 +747,7 @@ gt_bsGetNonUniformUInt64ArrayAdd(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUint64 mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUint64)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -801,7 +801,7 @@ gt_bsGetNonUniformInt64ArrayAdd(
   if (bitTop)
   {
     GtUint64 mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUint64)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -814,7 +814,7 @@ gt_bsGetNonUniformInt64ArrayAdd(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUint64 mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUint64)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);

--- a/src/core/bitpackstringop8.c
+++ b/src/core/bitpackstringop8.c
@@ -40,7 +40,7 @@ gt_bsGetUInt8(constBitString str, BitOffset offset, unsigned numBits)
   if (bitTop)
   {
     GtUword mask;
-    unsigned bits2Read = MIN(bitElemBits - bitTop, bitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, bitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -183,7 +183,7 @@ gt_bsGetUniformUInt8Array(constBitString str, BitOffset offset,
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -196,7 +196,7 @@ gt_bsGetUniformUInt8Array(constBitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -242,7 +242,7 @@ gt_bsGetNonUniformUInt8Array(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -255,7 +255,7 @@ gt_bsGetNonUniformUInt8Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -309,7 +309,7 @@ gt_bsGetNonUniformInt8Array(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -322,7 +322,7 @@ gt_bsGetNonUniformInt8Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -412,7 +412,7 @@ gt_bsStoreUniformUInt8Array(BitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
 
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         accum = accum << bits2Read
           | ((currentVal) >> (bitsLeft - bits2Read));
@@ -452,7 +452,7 @@ gt_bsStoreUniformUInt8Array(BitString str, BitOffset offset,
               || (bitsLeft < sizeof (accum)*CHAR_BIT - bitsInAccum)))
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         GtUword mask = ~((~(GtUword)0) << bits2Read);
         accum = accum << bits2Read
@@ -540,7 +540,7 @@ gt_bsStoreNonUniformUInt8Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
 
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         accum = accum << bits2Read
           | ((currentVal) >> (bitsLeft - bits2Read));
@@ -586,7 +586,7 @@ gt_bsStoreNonUniformUInt8Array(
               || (bitsLeft < sizeof (accum)*CHAR_BIT - bitsInAccum)))
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         GtUword mask = ~((~(GtUword)0) << bits2Read);
         accum = accum << bits2Read
@@ -675,7 +675,7 @@ gt_bsGetUniformUInt8ArrayAdd(constBitString str, BitOffset offset,
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -688,7 +688,7 @@ gt_bsGetUniformUInt8ArrayAdd(constBitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -734,7 +734,7 @@ gt_bsGetNonUniformUInt8ArrayAdd(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -747,7 +747,7 @@ gt_bsGetNonUniformUInt8ArrayAdd(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -801,7 +801,7 @@ gt_bsGetNonUniformInt8ArrayAdd(
   if (bitTop)
   {
     GtUword mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(GtUword)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -814,7 +814,7 @@ gt_bsGetNonUniformInt8ArrayAdd(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       GtUword mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(GtUword)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);

--- a/src/core/bitpackstringvectorreadop.gen
+++ b/src/core/bitpackstringvectorreadop.gen
@@ -42,7 +42,7 @@ gt_bsGetUniform@uTypeTag@Array@VecOpName@(constBitString str, BitOffset offset,
   if (bitTop)
   {
     @AccumType@ mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(@AccumType@)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -55,7 +55,7 @@ gt_bsGetUniform@uTypeTag@Array@VecOpName@(constBitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       @AccumType@ mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(@AccumType@)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -101,7 +101,7 @@ gt_bsGetNonUniform@uTypeTag@Array@VecOpName@(
   if (bitTop)
   {
     @AccumType@ mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(@AccumType@)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -114,7 +114,7 @@ gt_bsGetNonUniform@uTypeTag@Array@VecOpName@(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       @AccumType@ mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(@AccumType@)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);
@@ -168,7 +168,7 @@ gt_bsGetNonUniform@iTypeTag@Array@VecOpName@(
   if (bitTop)
   {
     @AccumType@ mask; /*< all of the bits we want to get from *p */
-    unsigned bits2Read = MIN(bitElemBits - bitTop, totalBitsLeft);
+    unsigned bits2Read = GT_MIN(bitElemBits - bitTop, totalBitsLeft);
     unsigned unreadRightBits = (bitElemBits - bitTop - bits2Read);
     mask = (~((~(@AccumType@)0) << bits2Read)) << unreadRightBits;
     accum = ((*p++) & mask) >> unreadRightBits;
@@ -181,7 +181,7 @@ gt_bsGetNonUniform@iTypeTag@Array@VecOpName@(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
       @AccumType@ mask;
-      bits2Read = MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
+      bits2Read = GT_MIN3(bitsFree, bitElemBits - bitsRead, totalBitsLeft);
       mask = (~((~(@AccumType@)0) << bits2Read));
       accum = accum << bits2Read | (((*p) >> (bitElemBits
                                               - bits2Read - bitsRead)) & mask);

--- a/src/core/bitpackstringvectorwriteop.gen
+++ b/src/core/bitpackstringvectorwriteop.gen
@@ -59,7 +59,7 @@ gt_bsStoreUniform@uTypeTag@Array(BitString str, BitOffset offset,
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
 
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         accum = accum << bits2Read
           | ((currentVal) >> (bitsLeft - bits2Read));
@@ -99,7 +99,7 @@ gt_bsStoreUniform@uTypeTag@Array(BitString str, BitOffset offset,
               || (bitsLeft < sizeof (accum)*CHAR_BIT - bitsInAccum)))
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         @AccumType@ mask = ~((~(@AccumType@)0) << bits2Read);
         accum = accum << bits2Read
@@ -187,7 +187,7 @@ gt_bsStoreNonUniform@uTypeTag@Array(
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
 
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         accum = accum << bits2Read
           | ((currentVal) >> (bitsLeft - bits2Read));
@@ -233,7 +233,7 @@ gt_bsStoreNonUniform@uTypeTag@Array(
               || (bitsLeft < sizeof (accum)*CHAR_BIT - bitsInAccum)))
     {
       unsigned bits2Read, bitsFree = sizeof (accum)*CHAR_BIT - bitsInAccum;
-      if ((bits2Read = MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
+      if ((bits2Read = GT_MIN(bitsFree, bitsLeft)) < sizeof (accum)*CHAR_BIT)
       {
         @AccumType@ mask = ~((~(@AccumType@)0) << bits2Read);
         accum = accum << bits2Read

--- a/src/core/chardef_api.h
+++ b/src/core/chardef_api.h
@@ -31,47 +31,47 @@
   separator symbol in multiple seq
 */
 
-#define SEPARATOR       UCHAR_MAX
+#define GT_SEPARATOR       UCHAR_MAX
 
 /*
   wildcard symbol in multiple seq
 */
 
-#define WILDCARD        (SEPARATOR-1)
+#define GT_WILDCARD        (GT_SEPARATOR-1)
 
 /*
   undefined character, only to be used in conjunction with symbol maps
 */
 
-#define UNDEFCHAR       (SEPARATOR-2)
+#define GT_UNDEFCHAR       (GT_SEPARATOR-2)
 
 /*
-  either WILDCARD or SEPARATOR
+  either GT_WILDCARD or GT_SEPARATOR
 */
 
-#define ISSPECIAL(C)    ((C) >= (GtUchar) WILDCARD)
+#define GT_ISSPECIAL(C)    ((C) >= (GtUchar) GT_WILDCARD)
 
 /*
-  neither WILDCARD nor SEPARATOR
+  neither GT_WILDCARD nor GT_SEPARATOR
 */
 
-#define ISNOTSPECIAL(C) ((C) < (GtUchar) WILDCARD)
+#define GT_ISNOTSPECIAL(C) ((C) < (GtUchar) GT_WILDCARD)
 
 /*
   undefined character, only to be used in conjunction with the Burrows-Wheeler
   transform
 */
 
-#define UNDEFBWTCHAR    WILDCARD
+#define GT_UNDEFBWTCHAR    GT_WILDCARD
 
 /*
-  Either special character or UNDEFBWTCHAR
+  Either special character or GT_UNDEFBWTCHAR
 */
 
-#define ISBWTSPECIAL(C) ((C) >= (GtUchar) UNDEFBWTCHAR)
+#define GT_ISBWTSPECIAL(C) ((C) >= (GtUchar) GT_UNDEFBWTCHAR)
 
 /*@unused@*/ static inline GtUword
-                            containsspecialbytestring(const GtUchar *seq,
+                            gt_containsspecialbytestring(const GtUchar *seq,
                                                       GtUword offset,
                                                       GtUword len)
 {
@@ -80,7 +80,7 @@
   gt_assert(offset < len);
   for (sptr=seq+offset; sptr < seq + len; sptr++)
   {
-    if (ISSPECIAL(*sptr))
+    if (GT_ISSPECIAL(*sptr))
     {
       return (GtUword) (sptr - seq);
     }

--- a/src/core/encseq.c
+++ b/src/core/encseq.c
@@ -4969,7 +4969,7 @@ GtUword gt_encseq_specialranges(const GtEncseq *encseq)
   if (encseq->hasmirror) {
     /* check whether central specialranges can be merged */
     if (gt_encseq_get_encoded_char(encseq, encseq->totallength-1,
-                                   GT_READMODE_FORWARD) == (GtUchar) GT_WILDCARD) {
+                               GT_READMODE_FORWARD) == (GtUchar) GT_WILDCARD) {
       return (encseq->specialcharinfo.specialranges*2)-1;
     } else {
       return (encseq->specialcharinfo.specialranges*2)+1;
@@ -5003,7 +5003,7 @@ GtUword gt_encseq_realspecialranges(const GtEncseq *encseq)
   if (encseq->hasmirror) {
     /* check whether central specialranges can be merged */
     if (gt_encseq_get_encoded_char(encseq, encseq->totallength-1,
-                                   GT_READMODE_FORWARD) == (GtUchar) GT_WILDCARD) {
+                               GT_READMODE_FORWARD) == (GtUchar) GT_WILDCARD) {
       return (encseq->specialcharinfo.realspecialranges*2)-1;
     } else {
       return (encseq->specialcharinfo.realspecialranges*2)+1;

--- a/src/core/encseq.c
+++ b/src/core/encseq.c
@@ -6051,7 +6051,7 @@ static GtUword fwdgetnexttwobitencodingstoppos(GtEncseqReader *esr)
       else {
         stopposssptab = esr->encseq->totallength;
       }
-      return MIN(stopposwildcard, stopposssptab);
+      return GT_MIN(stopposwildcard, stopposssptab);
     }
   }
   else {
@@ -6083,7 +6083,7 @@ static GtUword revgetnexttwobitencodingstoppos(GtEncseqReader *esr)
       else {
         stopposssptab = 0;
       }
-      return MAX(stopposwildcard, stopposssptab);
+      return GT_MAX(stopposwildcard, stopposssptab);
     }
   }
   else {
@@ -6871,7 +6871,7 @@ void gt_encseq_showatstartpos(FILE *fp,
   }
   fprintf(fp, "\nsequence=\"");
   if (fwd) {
-    endpos = MIN(startpos + GT_UNITSIN2BITENC - 1, encseq->totallength-1);
+    endpos = GT_MIN(startpos + GT_UNITSIN2BITENC - 1, encseq->totallength-1);
     gt_encseq_extract_encoded(encseq, buffer, startpos, endpos);
     for (pos=0; pos < endpos - startpos + 1; pos++) {
       showbufchar(fp, complement, buffer[pos]);
@@ -6906,10 +6906,10 @@ void gt_encseq_showatstartposwithdepth(FILE *fp,
   totallength = encseq->logicaltotallength;
   characters = gt_alphabet_characters(gt_encseq_alphabet(encseq));
   if (depth == 0) {
-    end = MIN(start + maxshow, totallength);
+    end = GT_MIN(start + maxshow, totallength);
   }
   else {
-    end = MIN(start + maxshow, MIN(totallength, start+depth));
+    end = GT_MIN(start + maxshow, GT_MIN(totallength, start+depth));
   }
   for (idx = start; idx <= end; idx++) {
     if (idx == totallength) {
@@ -6983,16 +6983,16 @@ static int gt_encseq_check_comparetwostrings(const GtEncseq *encseq,
   if (fwd) {
     gt_assert(pos1 < totallength);
     gt_assert(pos2 < totallength);
-    maxoffset = MIN(totallength - pos1, totallength - pos2);
+    maxoffset = GT_MIN(totallength - pos1, totallength - pos2);
   }
   else {
-    maxoffset = MIN(pos1+1, pos2+1);
+    maxoffset = GT_MIN(pos1+1, pos2+1);
   }
   if (*maxcommon > 0) {
-    maxoffset = MIN(*maxcommon, maxoffset);
+    maxoffset = GT_MIN(*maxcommon, maxoffset);
   }
   if (maxdepth > 0) {
-    maxoffset = MIN(maxoffset, maxdepth);
+    maxoffset = GT_MIN(maxoffset, maxdepth);
   }
   for (currentoffset = 0; currentoffset <= maxoffset; currentoffset++) {
     cc1 = derefcharboundaries(encseq, fwd, complement,

--- a/src/core/encseq.c
+++ b/src/core/encseq.c
@@ -262,7 +262,7 @@ GtUchar gt_encseq_get_encoded_char(const GtEncseq *encseq,
       gt_readmode_invert(readmode);
       pos = GT_REVERSEPOS(encseq->totallength, pos - encseq->totallength - 1);
     } else if (pos == encseq->totallength) {
-      return (GtUchar) SEPARATOR;
+      return (GtUchar) GT_SEPARATOR;
     }
   }
   gt_assert(pos < encseq->totallength);
@@ -279,10 +279,10 @@ GtUchar gt_encseq_get_encoded_char(const GtEncseq *encseq,
       }
       if (encseq->numofdbsequences > 1UL &&
           encseq->issinglepositionseparator(encseq, pos)) {
-        return (GtUchar) SEPARATOR;
+        return (GtUchar) GT_SEPARATOR;
       }
       if (encseq->issinglepositioninwildcardrange(encseq, pos))
-        return (GtUchar) WILDCARD;
+        return (GtUchar) GT_WILDCARD;
 
       return GT_ISDIRCOMPLEMENT(readmode)
                ? GT_COMPLEMENTBASE((GtUchar) twobits)
@@ -297,7 +297,7 @@ GtUchar gt_encseq_get_encoded_char(const GtEncseq *encseq,
                    ? GT_COMPLEMENTBASE((GtUchar) twobits)
                    : (GtUchar) twobits;
         }
-        return (GtUchar) SEPARATOR;
+        return (GtUchar) GT_SEPARATOR;
       }
       else {
         gt_assert(encseq->sat == GT_ACCESS_TYPE_BITACCESS);
@@ -309,8 +309,8 @@ GtUchar gt_encseq_get_encoded_char(const GtEncseq *encseq,
                    : (GtUchar) twobits;
         }
         return (twobits == (GtUword) GT_TWOBITS_FOR_SEPARATOR)
-                   ? (GtUchar) SEPARATOR
-                   : (GtUchar) WILDCARD;
+                   ? (GtUchar) GT_SEPARATOR
+                   : (GtUchar) GT_WILDCARD;
       }
     }
   }
@@ -323,7 +323,7 @@ GtUchar gt_encseq_get_encoded_char(const GtEncseq *encseq,
 
     gt_assert(encseq->sat == GT_ACCESS_TYPE_DIRECTACCESS);
     cc = encseq->plainseq[pos];
-    return (ISNOTSPECIAL(cc) && GT_ISDIRCOMPLEMENT(readmode))
+    return (GT_ISNOTSPECIAL(cc) && GT_ISDIRCOMPLEMENT(readmode))
            ? GT_COMPLEMENTBASE(cc)
            : cc;
   }
@@ -337,7 +337,7 @@ char gt_encseq_get_decoded_char(const GtEncseq *encseq, GtUword pos,
   gt_assert(encseq != NULL && encseq->alpha);
   gt_assert(pos < encseq->logicaltotallength);
   mycc = gt_encseq_get_encoded_char(encseq, pos, readmode);
-  if (mycc != (GtUchar) SEPARATOR) {
+  if (mycc != (GtUchar) GT_SEPARATOR) {
     if (GT_ISDIRREVERSE(readmode))
       pos = GT_REVERSEPOS(encseq->logicaltotallength, pos);
     if (encseq->has_exceptiontable) {
@@ -388,7 +388,7 @@ GtUchar gt_encseq_get_encoded_char_nospecial(const GtEncseq *encseq,
       gt_readmode_invert(readmode);
       pos = GT_REVERSEPOS(encseq->totallength, pos - encseq->totallength - 1);
     } else if (pos == encseq->totallength) {
-      return (GtUchar) SEPARATOR;
+      return (GtUchar) GT_SEPARATOR;
     }
   }
   gt_assert(pos < encseq->totallength);
@@ -408,7 +408,7 @@ GtUchar gt_encseq_get_encoded_char_nospecial(const GtEncseq *encseq,
     GtUchar cc;
     gt_assert(encseq->sat == GT_ACCESS_TYPE_DIRECTACCESS);
     cc = encseq->plainseq[pos];
-    gt_assert(ISNOTSPECIAL(cc));
+    gt_assert(GT_ISNOTSPECIAL(cc));
     return GT_ISDIRCOMPLEMENT(readmode)
            ? GT_COMPLEMENTBASE(cc)
            : cc;
@@ -548,7 +548,7 @@ GtUchar gt_encseq_reader_next_encoded_char(GtEncseqReader *esr)
         esr->currentpos--;
       }
     }
-    return (GtUchar) SEPARATOR;
+    return (GtUchar) GT_SEPARATOR;
   }
   gt_assert(esr && esr->currentpos < esr->encseq->totallength);
 
@@ -564,11 +564,11 @@ GtUchar gt_encseq_reader_next_encoded_char(GtEncseqReader *esr)
     case GT_READMODE_COMPL: /* only works with dna */
       cc = esr->encseq->seqdeliverchar(esr);
       esr->currentpos++;
-      return ISSPECIAL(cc) ? cc : GT_COMPLEMENTBASE(cc);
+      return GT_ISSPECIAL(cc) ? cc : GT_COMPLEMENTBASE(cc);
     case GT_READMODE_REVCOMPL: /* only works with dna */
       cc = esr->encseq->seqdeliverchar(esr);
       esr->currentpos--;
-      return ISSPECIAL(cc) ? cc : GT_COMPLEMENTBASE(cc);
+      return GT_ISSPECIAL(cc) ? cc : GT_COMPLEMENTBASE(cc);
     default:
       fprintf(stderr, "gt_encseq_get_encoded_char: "
                      "readmode %d not implemented\n", (int) esr->readmode);
@@ -583,7 +583,7 @@ char gt_encseq_reader_next_decoded_char(GtEncseqReader *esr)
   if (!esr->encseq->has_exceptiontable) {
     /* no lossless support available, we need to do simple decoding */
     GtUchar mycc = gt_encseq_reader_next_encoded_char(esr);
-    if (mycc != (GtUchar) SEPARATOR)
+    if (mycc != (GtUchar) GT_SEPARATOR)
       cc = gt_alphabet_decode(esr->encseq->alpha, mycc);
     else
       cc = (char) mycc;
@@ -623,12 +623,12 @@ char gt_encseq_reader_next_decoded_char(GtEncseqReader *esr)
           esr->currentpos--;
         }
       }
-      return (char) SEPARATOR;
+      return (char) GT_SEPARATOR;
     }
     gt_assert(esr && esr->currentpos < esr->encseq->totallength);
 
     ccc = esr->encseq->seqdeliverchar(esr);
-    if (ccc != (GtUchar) SEPARATOR) {
+    if (ccc != (GtUchar) GT_SEPARATOR) {
       GtUword mappos = GT_UNDEF_UWORD;
       if (esr->encseq->specialcharinfo.realexceptionranges > 0UL
             && esr->encseq->getexceptionmapping(esr->encseq,
@@ -648,7 +648,7 @@ char gt_encseq_reader_next_decoded_char(GtEncseqReader *esr)
       }
       gt_assert(cc != GT_UNDEF_CHAR);
     } else {
-      cc = (char) SEPARATOR;
+      cc = (char) GT_SEPARATOR;
     }
     switch (esr->readmode) {
       case GT_READMODE_FORWARD:
@@ -659,12 +659,12 @@ char gt_encseq_reader_next_decoded_char(GtEncseqReader *esr)
         return cc;
       case GT_READMODE_COMPL: /* only works with dna */
         esr->currentpos++;
-        if (cc != (char) SEPARATOR)
+        if (cc != (char) GT_SEPARATOR)
           (void) gt_complement(&cc, cc, NULL);
         return cc;
       case GT_READMODE_REVCOMPL: /* only works with dna */
         esr->currentpos--;
-        if (cc != (char) SEPARATOR)
+        if (cc != (char) GT_SEPARATOR)
           (void) gt_complement(&cc, cc, NULL);
         return cc;
       default:
@@ -2198,7 +2198,7 @@ static int fillViadirectaccess(GtEncseq *encseq,
   for (currentposition=0; /* Nothing */; currentposition++) {
     retval = gt_sequence_buffer_next_with_original(fb, &cc, &orig, err);
     if (retval == 1) {
-      if (encseq->has_exceptiontable && cc != (GtUchar) SEPARATOR) {
+      if (encseq->has_exceptiontable && cc != (GtUchar) GT_SEPARATOR) {
         if (orig == encseq->maxchars[cc]) {
           if (lastexceptionrangelength > 0) {
             exceptiontable->rangelengths[fillexceptionrangeidx-1]
@@ -2235,7 +2235,7 @@ static int fillViadirectaccess(GtEncseq *encseq,
         }
       }
       encseq->plainseq[currentposition] = cc;
-      if (cc == (GtUchar) SEPARATOR)
+      if (cc == (GtUchar) GT_SEPARATOR)
         ssptaboutinfo_processseppos(ssptaboutinfo, currentposition);
       ssptaboutinfo_processanyposition(ssptaboutinfo, currentposition);
     }
@@ -2288,7 +2288,7 @@ static bool containsspecialViadirectaccess(const GtEncseq *encseq,
   gt_assert(encseq != NULL);
   if (!GT_ISDIRREVERSE(readmode)) {
     for (pos = startpos; pos < startpos + len; pos++) {
-      if (ISSPECIAL(encseq->plainseq[pos]))
+      if (GT_ISSPECIAL(encseq->plainseq[pos]))
         return true;
     }
   }
@@ -2297,7 +2297,7 @@ static bool containsspecialViadirectaccess(const GtEncseq *encseq,
     startpos = GT_REVERSEPOS(encseq->totallength, startpos);
     gt_assert (startpos + 1 >= len);
     for (pos = startpos; /* Nothing */; pos--) {
-      if (ISSPECIAL(encseq->plainseq[pos]))
+      if (GT_ISSPECIAL(encseq->plainseq[pos]))
         return true;
       if (pos == startpos + 1 - len)
         break;
@@ -2310,13 +2310,13 @@ static bool issinglepositioninwildcardrangeViadirectaccess(
                                                    const GtEncseq *encseq,
                                                    GtUword pos)
 {
-  return (encseq->plainseq[pos] == (GtUchar) WILDCARD) ? true : false;
+  return (encseq->plainseq[pos] == (GtUchar) GT_WILDCARD) ? true : false;
 }
 
 static bool issinglepositionseparatorViadirectaccess(const GtEncseq *encseq,
                                                      GtUword pos)
 {
-  return (encseq->plainseq[pos] == (GtUchar) SEPARATOR) ? true : false;
+  return (encseq->plainseq[pos] == (GtUchar) GT_SEPARATOR) ? true : false;
 }
 
 /* GT_ACCESS_TYPE_BYTECOMPRESS */
@@ -2360,7 +2360,7 @@ static int fillViabytecompress(GtEncseq *encseq,
   for (currentposition=0; /* Nothing */; currentposition++) {
     retval = gt_sequence_buffer_next_with_original(fb, &cc, &orig, err);
     if (retval == 1) {
-      if (encseq->has_exceptiontable && cc != (GtUchar) SEPARATOR) {
+      if (encseq->has_exceptiontable && cc != (GtUchar) GT_SEPARATOR) {
         if (orig == encseq->maxchars[cc]) {
           if (lastexceptionrangelength > 0) {
             exceptiontable->rangelengths[fillexceptionrangeidx-1]
@@ -2395,8 +2395,8 @@ static int fillViabytecompress(GtEncseq *encseq,
           mapposition++;
         }
       }
-      if (ISSPECIAL(cc)) {
-        if (cc == (GtUchar) SEPARATOR) {
+      if (GT_ISSPECIAL(cc)) {
+        if (cc == (GtUchar) GT_SEPARATOR) {
           ssptaboutinfo_processseppos(ssptaboutinfo, currentposition);
           cc = (GtUchar) (numofchars+1);
         }
@@ -2455,9 +2455,9 @@ static GtUchar delivercharViabytecompress(const GtEncseq *encseq,
   if (cc < (uint32_t) encseq->numofchars)
     return (GtUchar) cc;
   if (cc == (uint32_t) encseq->numofchars)
-    return (GtUchar) WILDCARD;
+    return (GtUchar) GT_WILDCARD;
   if (cc == (uint32_t) (encseq->numofchars+1))
-    return (GtUchar) SEPARATOR;
+    return (GtUchar) GT_SEPARATOR;
   fprintf(stderr, "delivercharViabytecompress: cc="GT_WU" not possible\n",
                   (GtUword) cc);
   exit(GT_EXIT_PROGRAMMING_ERROR);
@@ -2480,7 +2480,7 @@ static bool containsspecialViabytecompress(const GtEncseq *encseq,
   if (!GT_ISDIRREVERSE(readmode)) {
     for (pos = startpos; pos < startpos + len; pos++) {
       cc = delivercharViabytecompress(encseq, pos);
-      if (ISSPECIAL(cc))
+      if (GT_ISSPECIAL(cc))
         return true;
     }
   }
@@ -2490,7 +2490,7 @@ static bool containsspecialViabytecompress(const GtEncseq *encseq,
     gt_assert (startpos + 1 >= len);
     for (pos = startpos; /* Nothing */; pos--) {
       cc = delivercharViabytecompress(encseq, pos);
-      if (ISSPECIAL(cc))
+      if (GT_ISSPECIAL(cc))
         return true;
       if (pos == startpos + 1 - len)
         break;
@@ -2503,7 +2503,7 @@ static bool issinglepositioninwildcardrangeViabytecompress(
                                                    const GtEncseq *encseq,
                                                    GtUword pos)
 {
-  return (delivercharViabytecompress(encseq, pos) == (GtUchar) WILDCARD)
+  return (delivercharViabytecompress(encseq, pos) == (GtUchar) GT_WILDCARD)
              ? true
              : false;
 }
@@ -2511,7 +2511,7 @@ static bool issinglepositioninwildcardrangeViabytecompress(
 static bool issinglepositionseparatorViabytecompress(const GtEncseq *encseq,
                                                      GtUword pos)
 {
-  return (delivercharViabytecompress(encseq, pos) == (GtUchar) SEPARATOR)
+  return (delivercharViabytecompress(encseq, pos) == (GtUchar) GT_SEPARATOR)
              ? true
              : false;
 }
@@ -2555,7 +2555,7 @@ static int fillViaequallength(GtEncseq *encseq,
   for (pos=0; /* Nothing */; pos++) {
     retval = gt_sequence_buffer_next_with_original(fb, &cc, &orig, err);
     if (retval == 1) {
-      if (encseq->has_exceptiontable && cc != (GtUchar) SEPARATOR) {
+      if (encseq->has_exceptiontable && cc != (GtUchar) GT_SEPARATOR) {
         if (orig == encseq->maxchars[cc]) {
           if (lastexceptionrangelength > 0) {
             exceptiontable->rangelengths[fillexceptionrangeidx-1]
@@ -2592,10 +2592,10 @@ static int fillViaequallength(GtEncseq *encseq,
         }
       }
       bitwise <<= 2;
-      if (ISNOTSPECIAL(cc))
+      if (GT_ISNOTSPECIAL(cc))
         bitwise |= (GtTwobitencoding) cc;
       else {
-        gt_assert(cc == (GtUchar) SEPARATOR);
+        gt_assert(cc == (GtUchar) GT_SEPARATOR);
         bitwise |= (GtTwobitencoding) encseq->leastprobablecharacter;
       }
       if (widthbuffer < (GtUword) (GT_UNITSIN2BITENC - 1))
@@ -2685,7 +2685,7 @@ static GtUchar seqdelivercharViaequallength(GtEncseqReader *esr)
   if (twobits != (GtUword) esr->encseq->leastprobablecharacter ||
       !issinglepositioninseparatorViaequallength(esr) || esr->currentpos == 0)
     return (GtUchar) twobits;
-  return (GtUchar) SEPARATOR;
+  return (GtUchar) GT_SEPARATOR;
 }
 
 static GtUword gt_encseq_seqnum_Viaequallength(const GtEncseq *encseq,
@@ -2777,7 +2777,7 @@ static int fillViabitaccess(GtEncseq *encseq,
   for (currentposition=0; /* Nothing */; currentposition++) {
     retval = gt_sequence_buffer_next_with_original(fb, &cc, &orig, err);
     if (retval == 1) {
-      if (encseq->has_exceptiontable && cc != (GtUchar) SEPARATOR) {
+      if (encseq->has_exceptiontable && cc != (GtUchar) GT_SEPARATOR) {
         if (orig == encseq->maxchars[cc]) {
           if (lastexceptionrangelength > 0) {
             exceptiontable->rangelengths[fillexceptionrangeidx-1]
@@ -2813,17 +2813,17 @@ static int fillViabitaccess(GtEncseq *encseq,
           mapposition++;
         }
       }
-      if (ISSPECIAL(cc)) {
+      if (GT_ISSPECIAL(cc)) {
         GT_SETIBIT(encseq->specialbits, currentposition);
-        if (cc == (GtUchar) SEPARATOR)
+        if (cc == (GtUchar) GT_SEPARATOR)
           ssptaboutinfo_processseppos(ssptaboutinfo, currentposition);
       }
       ssptaboutinfo_processanyposition(ssptaboutinfo, currentposition);
       bitwise <<= 2;
-      if (ISNOTSPECIAL(cc))
+      if (GT_ISNOTSPECIAL(cc))
         bitwise |= (GtTwobitencoding) cc;
       else {
-        if (cc == (GtUchar) SEPARATOR)
+        if (cc == (GtUchar) GT_SEPARATOR)
           bitwise |= (GtTwobitencoding) GT_TWOBITS_FOR_SEPARATOR;
       }
       if (widthbuffer < (GtUword) (GT_UNITSIN2BITENC - 1))
@@ -2871,8 +2871,8 @@ static GtUchar seqdelivercharViabitaccessSpecial(GtEncseqReader *esr)
   if (twobits > 1UL || !GT_ISIBITSET(esr->encseq->specialbits, esr->currentpos))
     return (GtUchar) twobits;
   return (twobits == (GtUword) GT_TWOBITS_FOR_SEPARATOR)
-           ? (GtUchar) SEPARATOR
-           : (GtUchar) WILDCARD;
+           ? (GtUchar) GT_SEPARATOR
+           : (GtUchar) GT_WILDCARD;
 }
 
 static bool containsspecialViabitaccess(const GtEncseq *encseq,
@@ -3406,7 +3406,7 @@ static bool gt_dabc_specialrangeiterator_next(bool directaccess,
       cc = sri->esr->encseq->plainseq[sri->jumppos];
     else
       cc = delivercharViabytecompress(sri->esr->encseq, sri->jumppos);
-    if (ISSPECIAL(cc))
+    if (GT_ISSPECIAL(cc))
       sri->lengthofspecialrange++;
     else {
       if (sri->lengthofspecialrange > 0) {
@@ -3824,8 +3824,8 @@ static void gt_addmarkpos(GtArrayGtUword *asp,
 
   for (pos=seqrange->start; pos<seqrange->end; pos++) {
     currentchar = gt_encseq_reader_next_encoded_char(esr);
-    gt_assert(ISSPECIAL(currentchar));
-    if (currentchar == (GtUchar) SEPARATOR) {
+    gt_assert(GT_ISSPECIAL(currentchar));
+    if (currentchar == (GtUchar) GT_SEPARATOR) {
       gt_assert(asp->nextfreeGtUword < asp->allocatedGtUword);
       asp->spaceGtUword[asp->nextfreeGtUword++] = pos;
     }
@@ -4027,7 +4027,7 @@ void gt_encseq_check_markpos(const GtEncseq *encseq)
 
     for (pos=0; pos<totallength; pos++) {
       currentchar = gt_encseq_reader_next_encoded_char(esr);
-      if (currentchar == (GtUchar) SEPARATOR)
+      if (currentchar == (GtUchar) GT_SEPARATOR)
         currentseqnum++;
       else {
         seqnum = gt_encseq_sep2seqnum(markpos, encseq->numofdbsequences,
@@ -4919,7 +4919,7 @@ void gt_encseq_check_startpositions(const GtEncseq *encseq, GtLogger *logger)
                 "sequential iteration of sequence of length "GT_WU" ...",
                 gt_encseq_total_length(encseq));
   for (i = 0; i < gt_encseq_total_length(encseq); i++) {
-    if (gt_encseq_reader_next_encoded_char(esr) == (GtUchar) SEPARATOR) {
+    if (gt_encseq_reader_next_encoded_char(esr) == (GtUchar) GT_SEPARATOR) {
       gt_assert(gt_encseq_position_is_separator(encseq, i,
                                                 GT_READMODE_FORWARD));
       startpostable[pos++] = i+1;
@@ -4969,7 +4969,7 @@ GtUword gt_encseq_specialranges(const GtEncseq *encseq)
   if (encseq->hasmirror) {
     /* check whether central specialranges can be merged */
     if (gt_encseq_get_encoded_char(encseq, encseq->totallength-1,
-                                   GT_READMODE_FORWARD) == (GtUchar) WILDCARD) {
+                                   GT_READMODE_FORWARD) == (GtUchar) GT_WILDCARD) {
       return (encseq->specialcharinfo.specialranges*2)-1;
     } else {
       return (encseq->specialcharinfo.specialranges*2)+1;
@@ -5003,7 +5003,7 @@ GtUword gt_encseq_realspecialranges(const GtEncseq *encseq)
   if (encseq->hasmirror) {
     /* check whether central specialranges can be merged */
     if (gt_encseq_get_encoded_char(encseq, encseq->totallength-1,
-                                   GT_READMODE_FORWARD) == (GtUchar) WILDCARD) {
+                                   GT_READMODE_FORWARD) == (GtUchar) GT_WILDCARD) {
       return (encseq->specialcharinfo.realspecialranges*2)-1;
     } else {
       return (encseq->specialcharinfo.realspecialranges*2)+1;
@@ -5282,7 +5282,7 @@ static void determine_original_subdist(const GtAlphabet *alpha,
                                        GtUword *originaldistribution)
 {
   GtUword i, *maxima, offset = 0, j;
-  unsigned char encodedchar = UNDEFCHAR;
+  unsigned char encodedchar = GT_UNDEFCHAR;
   GtStr **origchars;
   const char *classchars;
 
@@ -5294,15 +5294,15 @@ static void determine_original_subdist(const GtAlphabet *alpha,
     maxchars[i] = gt_alphabet_decode(alpha, (GtUchar) i);
     origchars[i] = gt_str_new();
   }
-  maxchars[WILDCARD] = gt_alphabet_decode(alpha, (GtUchar) WILDCARD);
-  origchars[WILDCARD] = gt_str_new();
+  maxchars[GT_WILDCARD] = gt_alphabet_decode(alpha, (GtUchar) GT_WILDCARD);
+  origchars[GT_WILDCARD] = gt_str_new();
 
   for (i = 1UL; i < 128UL /* printable characters */; i++) {
     if (originaldistribution[i] > 0UL) {
       gt_assert(gt_alphabet_valid_input(alpha, (char) i));
       encodedchar = (unsigned char) gt_alphabet_encode(alpha, (char) i);
-      gt_assert(encodedchar != UNDEFCHAR);
-      if (encodedchar != SEPARATOR) {
+      gt_assert(encodedchar != GT_UNDEFCHAR);
+      if (encodedchar != GT_SEPARATOR) {
         if (originaldistribution[i] > maxima[encodedchar]) {
           maxima[encodedchar] = originaldistribution[i];
           maxchars[encodedchar] = (char) i;
@@ -5333,7 +5333,7 @@ static void determine_original_subdist(const GtAlphabet *alpha,
     }
     gt_str_delete(origchars[i]);
   }
-  i = WILDCARD;
+  i = GT_WILDCARD;
   classchars = gt_str_get(origchars[i]);
   gt_log_log("encoding class "GT_WU": chars: %s, "
              "most frequent character %d(%c) ("GT_WU" occs)",
@@ -5386,7 +5386,7 @@ static int countnumberofexceptionranges(const GtAlphabet *alpha,
     for (currentpos = 0; /* Nothing */; currentpos++) {
       retval = gt_sequence_buffer_next_with_original(fb, &charcode, &cc, err);
       if (retval > 0) {
-        if (charcode != (GtUchar) SEPARATOR) {
+        if (charcode != (GtUchar) GT_SEPARATOR) {
           if (cc != maxchars[charcode]) {
             if (!in_range) {
               in_range = true;
@@ -6455,8 +6455,8 @@ int gt_encseq_compare_pairof_twobitencodings(bool fwd,
   GtTwobitencoding mask;
 
   if (ptbe1->unitsnotspecial < ptbe2->unitsnotspecial)
-      /* ISSPECIAL(seq1[ptbe1.unitsnotspecial]) &&
-         ISNOTSPECIAL(seq2[ptbe2.unitsnotspecial]) */ {
+      /* GT_ISSPECIAL(seq1[ptbe1.unitsnotspecial]) &&
+         GT_ISNOTSPECIAL(seq2[ptbe2.unitsnotspecial]) */ {
     GtTwobitencoding tbe1, tbe2;
 
     mask = GT_ENCSEQ_MASKEND(fwd, ptbe1->unitsnotspecial);
@@ -6475,8 +6475,8 @@ int gt_encseq_compare_pairof_twobitencodings(bool fwd,
                                                               tbe1, tbe2);
   }
   if (ptbe1->unitsnotspecial > ptbe2->unitsnotspecial)
-     /* ISSPECIAL(seq2[ptbe2->unitsnotspecial]) &&
-        ISNOTSPECIAL(seq1[ptbe2NOT->unitsnotspecial]) */ {
+     /* GT_ISSPECIAL(seq2[ptbe2->unitsnotspecial]) &&
+        GT_ISNOTSPECIAL(seq1[ptbe2NOT->unitsnotspecial]) */ {
     GtTwobitencoding tbe1, tbe2;
 
     mask = GT_ENCSEQ_MASKEND(fwd, ptbe2->unitsnotspecial);
@@ -6529,7 +6529,7 @@ int gt_encseq_compare_pairof_twobitencodings(bool fwd,
 
 #define GT_ENCSEQ_DEREF_STOPPOS(VAR, SPECIAL, TMPVAR, ENCSEQ, READMODE, POS)\
         TMPVAR = gt_encseq_get_encoded_char(ENCSEQ, POS, READMODE);\
-        if (ISNOTSPECIAL(TMPVAR)) {\
+        if (GT_ISNOTSPECIAL(TMPVAR)) {\
           VAR = (GtUword) TMPVAR;\
           SPECIAL = false;\
         }\
@@ -6761,7 +6761,7 @@ static void fwdextract2bitenc_bruteforce(GtEndofTwobitencoding *ptbe,
       return;
     }
     cc = gt_encseq_get_encoded_char(encseq, pos, GT_READMODE_FORWARD);
-    if (ISSPECIAL(cc)) {
+    if (GT_ISSPECIAL(cc)) {
       ptbe->unitsnotspecial = (unsigned int) (pos - startpos);
       ptbe->tbe <<= GT_MULT2(startpos + GT_UNITSIN2BITENC - pos);
       return;
@@ -6785,7 +6785,7 @@ static void revextract2bitenc_bruteforce(GtEndofTwobitencoding *ptbe,
        unit < (unsigned int) GT_UNITSIN2BITENC;
        unit++) {
     cc = gt_encseq_get_encoded_char(encseq, pos, GT_READMODE_FORWARD);
-    if (ISSPECIAL(cc)) {
+    if (GT_ISSPECIAL(cc)) {
       ptbe->unitsnotspecial = unit;
       return;
     }
@@ -6836,11 +6836,11 @@ static void extract2bitenc_bruteforce(bool fwd,
 
 static void showbufchar(FILE *fp, bool complement, GtUchar cc)
 {
-  if (cc == (GtUchar) WILDCARD) {
+  if (cc == (GtUchar) GT_WILDCARD) {
     fprintf(fp, "$");
   }
   else {
-    if (cc == (GtUchar) SEPARATOR) {
+    if (cc == (GtUchar) GT_SEPARATOR) {
       fprintf(fp, "#");
     }
     else {
@@ -6917,7 +6917,7 @@ void gt_encseq_showatstartposwithdepth(FILE *fp,
       break;
     }
     cc = gt_encseq_get_encoded_char(encseq, idx, readmode);
-    if (ISSPECIAL(cc)) {
+    if (GT_ISSPECIAL(cc)) {
       (void) putc('~', fp);
       break;
     }
@@ -6948,7 +6948,7 @@ static GtUword derefcharboundaries(const GtEncseq *encseq,
   if (currentoffset <= maxoffset) {
     GtUchar cc;
     cc = gt_encseq_get_encoded_char(encseq, start, GT_READMODE_FORWARD);
-    if (ISSPECIAL(cc)) {
+    if (GT_ISSPECIAL(cc)) {
       return start + GT_COMPAREOFFSET;
     }
     if (complement) {
@@ -7306,7 +7306,7 @@ GtCodetype gt_encseq_extractprefixcode(unsigned int *unitsnotspecial,
   *unitsnotspecial = 0;
   for (pos = frompos; pos < twobitencodingstoppos; pos++) {
     cc = gt_encseq_reader_next_encoded_char(esr);
-    if (ISNOTSPECIAL(cc)) {
+    if (GT_ISNOTSPECIAL(cc)) {
       code += multimappower[*unitsnotspecial][cc];
       (*unitsnotspecial)++;
     }
@@ -7416,8 +7416,8 @@ int gt_encseq_check_comparetwosuffixes(const GtEncseq *encseq,
     else {
       cc2 = gt_encseq_get_encoded_char(encseq, pos2, readmode);
     }
-    if (ISSPECIAL(cc1)) {
-      if (ISSPECIAL(cc2)) {
+    if (GT_ISSPECIAL(cc1)) {
+      if (GT_ISSPECIAL(cc2)) {
         if (specialsareequal || (pos1 == start1 && specialsareequalatdepth0)) {
           *maxlcp = pos1 - start1 + 1;
           retval = 0;
@@ -7442,7 +7442,7 @@ int gt_encseq_check_comparetwosuffixes(const GtEncseq *encseq,
       break;
     }
     else {
-      if (ISSPECIAL(cc2)) {
+      if (GT_ISSPECIAL(cc2)) {
         *maxlcp = pos1 - start1;
         retval = -1; /* a < b */
         break;
@@ -7538,7 +7538,7 @@ static GtEncseq* gt_encseq_new_from_files(GtTimer *sfxprogress,
   unsigned char subsymbolmap[UCHAR_MAX+1],
                 maxsubalphasize = 0;
   Definedunsignedlong equallength; /* is defined if all sequences are of equal
-                                      length and no WILDCARD appears in the
+                                      length and no GT_WILDCARD appears in the
                                       sequence */
   GtEncseqAccessType sat = GT_ACCESS_TYPE_UNDEFINED;
   char *allchars = NULL,
@@ -7779,7 +7779,7 @@ static void testseqnumextraction(const GtEncseq *encseq)
   for (pos=0; pos < totallength; pos++) {
     /* Random access */
     cc = gt_encseq_get_encoded_char(encseq, pos, GT_READMODE_FORWARD);
-    if (cc == (GtUchar) SEPARATOR) {
+    if (cc == (GtUchar) GT_SEPARATOR) {
       currentseqnum++;
       startofsequence = true;
     }
@@ -8894,7 +8894,7 @@ void gt_encseq_builder_add_cstr(GtEncseqBuilder *eb, const char *str,
   if (!eb->firstseq) {
     eb->plainseq = gt_dynalloc(eb->plainseq, &eb->allocated,
                                (eb->seqlen + strlen+1) * sizeof (GtUchar));
-    eb->plainseq[eb->seqlen] = (GtUchar) SEPARATOR;
+    eb->plainseq[eb->seqlen] = (GtUchar) GT_SEPARATOR;
     offset = eb->seqlen+1;
     eb->seqlen += strlen+1;
   } else {
@@ -8983,7 +8983,7 @@ static void gt_encseq_builder_add_encoded_generic(GtEncseqBuilder *eb,
     if (!eb->firstseq) {
       eb->plainseq = gt_dynalloc(eb->plainseq, &eb->allocated,
                                  (eb->seqlen + strlen+1) * sizeof (GtUchar));
-      eb->plainseq[eb->seqlen] = (GtUchar) SEPARATOR;
+      eb->plainseq[eb->seqlen] = (GtUchar) GT_SEPARATOR;
       offset = eb->seqlen+1;
       eb->seqlen += strlen+1;
     } else {
@@ -9023,7 +9023,7 @@ void gt_encseq_builder_add_encoded(GtEncseqBuilder *eb,
                                    GtUword strlen,
                                    const char *desc)
 {
-  gt_assert(memchr(str,(int) SEPARATOR,(size_t) strlen) == NULL);
+  gt_assert(memchr(str,(int) GT_SEPARATOR,(size_t) strlen) == NULL);
   gt_encseq_builder_add_encoded_generic(eb, str, strlen, desc, false);
 }
 
@@ -9032,7 +9032,7 @@ void gt_encseq_builder_add_encoded_own(GtEncseqBuilder *eb,
                                        GtUword strlen,
                                        const char *desc)
 {
-  gt_assert(memchr(str,(int) SEPARATOR,(size_t) strlen) == NULL);
+  gt_assert(memchr(str,(int) GT_SEPARATOR,(size_t) strlen) == NULL);
   gt_encseq_builder_add_encoded_generic(eb, str, strlen, desc, true);
 }
 
@@ -9044,7 +9044,7 @@ void gt_encseq_builder_add_multiple_encoded(GtEncseqBuilder *eb,
 
   for (idx = 0; idx < strlen; idx++)
   {
-    if (str[idx] == SEPARATOR)
+    if (str[idx] == GT_SEPARATOR)
     {
       gt_assert(laststart < idx);
       gt_encseq_builder_add_encoded(eb, str + laststart, idx - laststart, NULL);
@@ -9137,7 +9137,7 @@ GtEncseq* gt_encseq_builder_build(GtEncseqBuilder *eb, GT_UNUSED GtError *err)
     ssptaboutinfo = ssptaboutinfo_new(eb->seqlen,eb->nof_seqs, &encseq->ssptab);
     gt_assert(ssptaboutinfo != NULL);
     for (i = 0; i < eb->seqlen; i++) {
-      if (eb->plainseq[i] == (GtUchar) SEPARATOR)
+      if (eb->plainseq[i] == (GtUchar) GT_SEPARATOR)
         ssptaboutinfo_processseppos(ssptaboutinfo, i);
       ssptaboutinfo_processanyposition(ssptaboutinfo, i);
     }
@@ -9146,7 +9146,7 @@ GtEncseq* gt_encseq_builder_build(GtEncseqBuilder *eb, GT_UNUSED GtError *err)
     ssptaboutinfo_delete(ssptaboutinfo);
   }
   for (i = 0; i < eb->seqlen; i++) {
-    if (!ISSPECIAL(eb->plainseq[i])) {
+    if (!GT_ISSPECIAL(eb->plainseq[i])) {
       encseq->headerptr.characterdistribution[eb->plainseq[i]]++;
       lastnonspecialrangelength++;
     } else {

--- a/src/core/encseq.h
+++ b/src/core/encseq.h
@@ -75,7 +75,7 @@ typedef struct
 
 /* Stores the decoded version of the substring from 0-based position <frompos>
    to position <topos> of <encseq>. If the extracted region contains a separator
-   character, it will be represented by non-printable SEPARATOR constant.
+   character, it will be represented by non-printable GT_SEPARATOR constant.
    The caller is responsible to handle this case. The result of the extraction
    is written to the location pointed to by <buffer>, which must be sufficiently
    large to hold the result. The function is identical to
@@ -373,7 +373,7 @@ bool gt_encseq_contains_special(const GtEncseq *encseq,
                                 GtUword len);
 
 /* Returns the sequence number from the given <position> for an array of
-  SEPARATOR positions <recordseps>.  */
+  GT_SEPARATOR positions <recordseps>.  */
 GtUword gt_encseq_sep2seqnum(const GtUword *recordseps,
                                    GtUword numofrecords,
                                    GtUword totalwidth,

--- a/src/core/encseq_api.h
+++ b/src/core/encseq_api.h
@@ -125,7 +125,7 @@ void              gt_encseq_extract_encoded(const GtEncseq *encseq,
                                             GtUword topos);
 /* Stores the decoded version of the substring from 0-based position <frompos>
    to position <topos> of <encseq>. If the extracted region contains a separator
-   character, it will be represented by non-printable SEPARATOR constant.
+   character, it will be represented by non-printable GT_SEPARATOR constant.
    The caller is responsible to handle this case. The result of the extraction
    is written to the location pointed to by <buffer>, which must be sufficiently
    large to hold the result. */

--- a/src/core/encseq_charproc.gen
+++ b/src/core/encseq_charproc.gen
@@ -1,4 +1,4 @@
-          if (ISNOTSPECIAL(charcode))
+          if (GT_ISNOTSPECIAL(charcode))
           {
 #ifdef WITHEQUALLENGTH_DES_SSP
             lengthofcurrentsequence++;
@@ -46,7 +46,7 @@
               }
               lastnonspecialrangelength = 0;
             }
-            if (charcode == (GtUchar) WILDCARD)
+            if (charcode == (GtUchar) GT_WILDCARD)
             {
               if (wildcardprefix)
               {
@@ -71,7 +71,7 @@
 #endif
             } else
             {
-              gt_assert(charcode == (GtUchar) SEPARATOR);
+              gt_assert(charcode == (GtUchar) GT_SEPARATOR);
               if (wildcardprefix)
               {
                 wildcardprefix = false;

--- a/src/core/fa.c
+++ b/src/core/fa.c
@@ -324,7 +324,7 @@ FILE* gt_xtmpfp_generic_func(GtStr *template_arg, enum tmpfp_flags flags,
   FILE *fp;
   GtStr *template;
   gt_assert(fa);
-  if (flags & TMPFP_USETEMPLATE)
+  if (flags & GT_TMPFP_USETEMPLATE)
   {
     gt_assert(template_arg);
     template = template_arg;
@@ -358,11 +358,11 @@ FILE* gt_xtmpfp_generic_func(GtStr *template_arg, enum tmpfp_flags flags,
   }
   {
     int fd = gt_mkstemp(gt_str_get(template));
-    char mode[] = { 'w', '+', flags & TMPFP_OPENBINARY?'b':'\0', '\0' };
+    char mode[] = { 'w', '+', flags & GT_TMPFP_OPENBINARY?'b':'\0', '\0' };
     fp = gt_xfdopen(fd, mode);
   }
   gt_assert(fp);
-  if (flags & TMPFP_AUTOREMOVE)
+  if (flags & GT_TMPFP_AUTOREMOVE)
   {
     gt_xremove(gt_str_get(template));
   }

--- a/src/core/fa_api.h
+++ b/src/core/fa_api.h
@@ -98,15 +98,15 @@ void    gt_fa_xbzclose(BZFILE *stream);
 
 enum tmpfp_flags
 {
-  TMPFP_AUTOREMOVE    = 1 << 0, /**< otherwise template holds a valid
+  GT_TMPFP_AUTOREMOVE    = 1 << 0, /**< otherwise template holds a valid
                                  * path to (re-)open the temporary
                                  * file created */
-  TMPFP_USETEMPLATE   = 1 << 1, /**< if set use string template
+  GT_TMPFP_USETEMPLATE   = 1 << 1, /**< if set use string template
                                  * given, otherwise the value of
                                  * template is overwritten with an
                                  * interval default */
-  TMPFP_OPENBINARY    = 1 << 2, /**< use stdio mode "w+b", "w+" otherwise */
-  TMPFP_DEFAULT_FLAGS = 0,
+  GT_TMPFP_OPENBINARY    = 1 << 2, /**< use stdio mode "w+b", "w+" otherwise */
+  GT_TMPFP_DEFAULT_FLAGS = 0,
 };
 /* Create a temp file optionally using template analogous to mkstemp(3). */
 #define gt_xtmpfp_generic(template_code, flags) \
@@ -117,7 +117,7 @@ FILE*   gt_xtmpfp_generic_func(GtStr *template_code, enum tmpfp_flags flags,
 /* Create a temp file optionally using template analogous to mkstemp(3), with
    default flags. */
 #define gt_xtmpfp(template_code)\
-        gt_xtmpfp_generic(template_code, TMPFP_DEFAULT_FLAGS)
+        gt_xtmpfp_generic(template_code, GT_TMPFP_DEFAULT_FLAGS)
 
 #define gt_fa_heap_read(PATH,LENPTR,ERR)\
         gt_fa_heap_read_func(PATH,LENPTR,__FILE__,__LINE__,ERR)

--- a/src/core/interval_tree.c
+++ b/src/core/interval_tree.c
@@ -269,7 +269,7 @@ static void interval_tree_max_fixup(GtIntervalTree *it,
     else if (x->right == it->nil && x->left != it->nil)
       x->max = x->left->max;
     else if (x->right != it->nil && x->left != it->nil)
-      x->max = MAX(x->left->max, x->right->max);
+      x->max = GT_MAX(x->left->max, x->right->max);
     x = x->parent;
   }
 }

--- a/src/core/mathsupport.c
+++ b/src/core/mathsupport.c
@@ -86,7 +86,7 @@ GtUword gt_rand_max(GtUword maximal_value)
 {
   GtUword r;
   gt_assert(maximal_value);
-  r = ((double) random() / ((double) RAND_MAX + 1) * (maximal_value + 1));
+  r = ((double) random() / ((double) GT_RAND_MAX + 1) * (maximal_value + 1));
   gt_assert(r <= maximal_value);
   return r;
 }
@@ -95,7 +95,7 @@ double gt_rand_max_double(double maximal_value)
 {
   double r;
   gt_assert(maximal_value);
-  r = ((double) random() / RAND_MAX) * maximal_value; /* XXX */
+  r = ((double) random() / GT_RAND_MAX) * maximal_value; /* XXX */
   gt_assert(r >= 0.0 && r <= maximal_value);
   return r;
 }
@@ -103,7 +103,7 @@ double gt_rand_max_double(double maximal_value)
 double gt_rand_0_to_1(void)
 {
   double r;
-  r = (double) random() / RAND_MAX;
+  r = (double) random() / GT_RAND_MAX;
   gt_assert(r >= 0.0 && r <= 1.0);
   return r;
 }

--- a/src/core/minmax_api.h
+++ b/src/core/minmax_api.h
@@ -23,20 +23,20 @@
   if they are not already defined.
 */
 
-#ifndef MAX
-#define MAX(X,Y) (((X) > (Y)) ? (X) : (Y))
+#ifndef GT_MAX
+#define GT_MAX(X,Y) (((X) > (Y)) ? (X) : (Y))
 #endif
 
-#ifndef MIN
-#define MIN(X,Y) (((X) < (Y)) ? (X) : (Y))
+#ifndef GT_MIN
+#define GT_MIN(X,Y) (((X) < (Y)) ? (X) : (Y))
 #endif
 
-#ifndef MIN3
-#define MIN3(a, b, c) (((a)<(b))?((a)<(c)?(a):(c)):((b)<(c)?(b):(c)))
+#ifndef GT_MIN3
+#define GT_MIN3(a, b, c) (((a)<(b))?((a)<(c)?(a):(c)):((b)<(c)?(b):(c)))
 #endif
 
-#ifndef MAX3
-#define MAX3(a, b, c) (((a)>(b))?((a)>(c)?(a):(c)):((b)>(c)?(b):(c)))
+#ifndef GT_MAX3
+#define GT_MAX3(a, b, c) (((a)>(b))?((a)>(c)?(a):(c)):((b)>(c)?(b):(c)))
 #endif
 
 #define GT_UPDATE_MAX(MAXVAL,NEWVAL)\

--- a/src/core/qsort-direct.gen
+++ b/src/core/qsort-direct.gen
@@ -177,13 +177,13 @@ void QSORTNAME(gt_direct_qsort) (GtUword insertionsortthreshold,
     pn = current.startindex + current.len;
     gt_assert(pa >= current.startindex);
     gt_assert(pb >= pa);
-    s = MIN ((GtUword) (pa - current.startindex),
+    s = GT_MIN ((GtUword) (pa - current.startindex),
              (GtUword) (pb - pa));
     gt_assert(pb >= s);
     GT_QSORT_ARR_VECSWAP (arr, current.startindex, pb - s, s);
     gt_assert(pd >= pc);
     gt_assert(pn > pd);
-    s = MIN ((GtUword) (pd - pc), (GtUword) (pn - pd - 1));
+    s = GT_MIN ((GtUword) (pd - pc), (GtUword) (pn - pd - 1));
     gt_assert(pn > s);
     GT_QSORT_ARR_VECSWAP (arr, pb, pn - s, s);
     gt_assert(pb >= pa);

--- a/src/core/qsort_r.c
+++ b/src/core/qsort_r.c
@@ -160,9 +160,9 @@ gt_qsort_r(void *a, size_t n, size_t es, void *data, GtCompareWithData cmp)
     }
 
     pn = (char *)a + n * es;
-    r = MIN(pa - (char *)a, pb - pa);
+    r = GT_MIN(pa - (char *)a, pb - pa);
     vecswap(a, pb - r, r);
-    r = MIN(pd - pc, pn - pd - es);
+    r = GT_MIN(pd - pc, pn - pd - es);
     vecswap(pb, pn - r, r);
     if ((r = pb - pa) > es)
       gt_qsort_r(a, r / es, es, data, cmp);

--- a/src/core/radixsort-ip-flba.inc
+++ b/src/core/radixsort-ip-flba.inc
@@ -73,7 +73,7 @@ static void gt_radixsort_flba_cached_shuffle(GtRadixbuffer *rbuf,
   for (bufoffset = 0, binoffset = 0, binnum = 0; binnum <= UINT8_MAX;
        bufoffset += rbuf->buf_size, binoffset += count[binnum], binnum++)
   {
-    const GtUword elems2copy = MIN(rbuf->buf_size,(GtUword) count[binnum]);
+    const GtUword elems2copy = GT_MIN(rbuf->buf_size,(GtUword) count[binnum]);
 
     if (elems2copy > 0)
     {

--- a/src/core/radixsort-ip-uint64keypair.inc
+++ b/src/core/radixsort-ip-uint64keypair.inc
@@ -76,7 +76,7 @@ GT_RADIX_KEY(UINT8_MAX,rightshift,sourceptr->uint64_b)]++;
   for (bufoffset = 0, binoffset = 0, binnum = 0; binnum <= UINT8_MAX;
        bufoffset += rbuf->buf_size, binoffset += count[binnum], binnum++)
   {
-    const GtUword elems2copy = MIN(rbuf->buf_size,(GtUword) count[binnum]);
+    const GtUword elems2copy = GT_MIN(rbuf->buf_size,(GtUword) count[binnum]);
 
     if (elems2copy > 0)
     {

--- a/src/core/radixsort-ip-ulong.inc
+++ b/src/core/radixsort-ip-ulong.inc
@@ -73,7 +73,7 @@ static void gt_radixsort_ulong_cached_shuffle(GtRadixbuffer *rbuf,
   for (bufoffset = 0, binoffset = 0, binnum = 0; binnum <= UINT8_MAX;
        bufoffset += rbuf->buf_size, binoffset += count[binnum], binnum++)
   {
-    const GtUword elems2copy = MIN(rbuf->buf_size,(GtUword) count[binnum]);
+    const GtUword elems2copy = GT_MIN(rbuf->buf_size,(GtUword) count[binnum]);
 
     if (elems2copy > 0)
     {

--- a/src/core/radixsort-ip-ulongpair.inc
+++ b/src/core/radixsort-ip-ulongpair.inc
@@ -73,7 +73,7 @@ static void gt_radixsort_ulongpair_cached_shuffle(GtRadixbuffer *rbuf,
   for (bufoffset = 0, binoffset = 0, binnum = 0; binnum <= UINT8_MAX;
        bufoffset += rbuf->buf_size, binoffset += count[binnum], binnum++)
   {
-    const GtUword elems2copy = MIN(rbuf->buf_size,(GtUword) count[binnum]);
+    const GtUword elems2copy = GT_MIN(rbuf->buf_size,(GtUword) count[binnum]);
 
     if (elems2copy > 0)
     {

--- a/src/core/range.c
+++ b/src/core/range.c
@@ -43,10 +43,10 @@ int gt_range_compare_with_delta(const GtRange *range_a, const GtRange *range_b,
 
   gt_assert(range_a->start <= range_a->end && range_b->start <= range_b->end);
 
-  start_min = MIN(range_a->start, range_b->start);
-  start_max = MAX(range_a->start, range_b->start);
-  end_min   = MIN(range_a->end, range_b->end);
-  end_max   = MAX(range_a->end, range_b->end);
+  start_min = GT_MIN(range_a->start, range_b->start);
+  start_max = GT_MAX(range_a->start, range_b->start);
+  end_min   = GT_MIN(range_a->end, range_b->end);
+  end_max   = GT_MAX(range_a->end, range_b->end);
 
   if (start_max - start_min <= delta && end_max - end_min <= delta)
     return 0; /* range_a == range_b */

--- a/src/core/safearith.c
+++ b/src/core/safearith.c
@@ -184,31 +184,31 @@ int gt_safearith_unit_test(GtError *err)
   {
     /* This is not always true, e.g. on PPC and ARM!
        cf. http://www.network-theory.co.uk/docs/gccintro/gccintro_71.html
-    gt_ensure(__MIN(char) == -128);
-    gt_ensure(__MAX(char) == 127); */
-    gt_ensure(__MIN(unsigned char) == 0);
-    gt_ensure(__MAX(unsigned char) == 255);
+    gt_ensure(GT_SAFE_MIN(char) == -128);
+    gt_ensure(GT_SAFE_MAX(char) == 127); */
+    gt_ensure(GT_SAFE_MIN(unsigned char) == 0);
+    gt_ensure(GT_SAFE_MAX(unsigned char) == 255);
 
-    gt_ensure(__MIN(short) == SHRT_MIN);
-    gt_ensure(__MAX(short) == SHRT_MAX);
-    gt_ensure(__MIN(unsigned short) == 0);
-    gt_ensure(__MAX(unsigned short) == USHRT_MAX);
+    gt_ensure(GT_SAFE_MIN(short) == SHRT_MIN);
+    gt_ensure(GT_SAFE_MAX(short) == SHRT_MAX);
+    gt_ensure(GT_SAFE_MIN(unsigned short) == 0);
+    gt_ensure(GT_SAFE_MAX(unsigned short) == USHRT_MAX);
 
-    gt_ensure(__MIN(int) == INT_MIN);
-    gt_ensure(__MAX(int) == INT_MAX);
-    gt_ensure(__MIN(unsigned int) == 0);
-    gt_ensure(__MAX(unsigned int) == UINT_MAX);
+    gt_ensure(GT_SAFE_MIN(int) == INT_MIN);
+    gt_ensure(GT_SAFE_MAX(int) == INT_MAX);
+    gt_ensure(GT_SAFE_MIN(unsigned int) == 0);
+    gt_ensure(GT_SAFE_MAX(unsigned int) == UINT_MAX);
 
-    gt_ensure(__MIN(GtWord) == LONG_MIN);
-    gt_ensure(__MAX(GtWord) == LONG_MAX);
-    gt_ensure(__MIN(GtUword) == 0);
-    gt_ensure(__MAX(GtUword) == ULONG_MAX);
+    gt_ensure(GT_SAFE_MIN(GtWord) == LONG_MIN);
+    gt_ensure(GT_SAFE_MAX(GtWord) == LONG_MAX);
+    gt_ensure(GT_SAFE_MIN(GtUword) == 0);
+    gt_ensure(GT_SAFE_MAX(GtUword) == ULONG_MAX);
 
 #ifdef LLONG_MIN
-    gt_ensure(__MIN(GtInt64) == LLONG_MIN);
-    gt_ensure(__MAX(GtInt64) == LLONG_MAX);
-    gt_ensure(__MIN(GtUint64) == 0);
-    gt_ensure(__MAX(GtUint64) == ULLONG_MAX);
+    gt_ensure(GT_SAFE_MIN(GtInt64) == LLONG_MIN);
+    gt_ensure(GT_SAFE_MAX(GtInt64) == LLONG_MAX);
+    gt_ensure(GT_SAFE_MIN(GtUint64) == 0);
+    gt_ensure(GT_SAFE_MAX(GtUint64) == ULLONG_MAX);
 #endif
   }
 
@@ -217,64 +217,64 @@ int gt_safearith_unit_test(GtError *err)
     GtWord slong;
 
     slong = -1;
-    gt_ensure(assign(ulong, slong));
+    gt_ensure(gt_safearith_assign(ulong, slong));
 
     ulong = 0;
     slong = LONG_MAX;
-    gt_ensure(!assign(ulong, slong) && ulong == LONG_MAX);
+    gt_ensure(!gt_safearith_assign(ulong, slong) && ulong == LONG_MAX);
 
     ulong = ULONG_MAX;
-    gt_ensure(assign(slong, ulong));
+    gt_ensure(gt_safearith_assign(slong, ulong));
 
     slong = 0;
     ulong = LONG_MAX;
-    gt_ensure(!assign(slong, ulong) && slong == LONG_MAX);
+    gt_ensure(!gt_safearith_assign(slong, ulong) && slong == LONG_MAX);
   }
 
   {
     int x;
-    gt_ensure(add_of(x, INT_MAX, 1));
-    gt_ensure(add_of(x, INT_MAX, 256));
-    gt_ensure(add_of(x, INT_MAX, INT_MAX));
+    gt_ensure(gt_safearith_add_of(x, INT_MAX, 1));
+    gt_ensure(gt_safearith_add_of(x, INT_MAX, 256));
+    gt_ensure(gt_safearith_add_of(x, INT_MAX, INT_MAX));
 
-    x = 0; gt_ensure(!add_of(x, INT_MAX - 1, 1) && x == INT_MAX);
-    x = 0; gt_ensure(!add_of(x, INT_MAX - 256, 256) && x == INT_MAX);
-    x = 0; gt_ensure(!add_of(x, INT_MAX, 0) && x == INT_MAX);
+    x = 0; gt_ensure(!gt_safearith_add_of(x, INT_MAX - 1, 1) && x == INT_MAX);
+    x = 0; gt_ensure(!gt_safearith_add_of(x, INT_MAX - 256, 256) && x == INT_MAX);
+    x = 0; gt_ensure(!gt_safearith_add_of(x, INT_MAX, 0) && x == INT_MAX);
 
-    gt_ensure(add_of(x, 0x100000000ll, 0x100000000ll));
+    gt_ensure(gt_safearith_add_of(x, 0x100000000ll, 0x100000000ll));
     x = INT_MAX;
-    gt_ensure(!add_of(x, 0x100000000ll, -0x100000000ll) && x == 0);
+    gt_ensure(!gt_safearith_add_of(x, 0x100000000ll, -0x100000000ll) && x == 0);
 
-    gt_ensure(sub_of(x, INT_MIN, 1));
-    gt_ensure(sub_of(x, INT_MIN, 256));
-    gt_ensure(sub_of(x, INT_MIN, INT_MAX));
+    gt_ensure(gt_safearith_sub_of(x, INT_MIN, 1));
+    gt_ensure(gt_safearith_sub_of(x, INT_MIN, 256));
+    gt_ensure(gt_safearith_sub_of(x, INT_MIN, INT_MAX));
 
-    x = 0; gt_ensure(!sub_of(x, INT_MIN + 1, 1) && x == INT_MIN);
-    x = 0; gt_ensure(!sub_of(x, INT_MIN + 256, 256) && x == INT_MIN);
-    x = 0; gt_ensure(!sub_of(x, INT_MIN, 0) && x == INT_MIN);
+    x = 0; gt_ensure(!gt_safearith_sub_of(x, INT_MIN + 1, 1) && x == INT_MIN);
+    x = 0; gt_ensure(!gt_safearith_sub_of(x, INT_MIN + 256, 256) && x == INT_MIN);
+    x = 0; gt_ensure(!gt_safearith_sub_of(x, INT_MIN, 0) && x == INT_MIN);
   }
 
   {
     unsigned int x;
-    gt_ensure(add_of(x, UINT_MAX, 1));
-    gt_ensure(add_of(x, UINT_MAX, 256));
-    gt_ensure(add_of(x, UINT_MAX, UINT_MAX));
+    gt_ensure(gt_safearith_add_of(x, UINT_MAX, 1));
+    gt_ensure(gt_safearith_add_of(x, UINT_MAX, 256));
+    gt_ensure(gt_safearith_add_of(x, UINT_MAX, UINT_MAX));
 
-    x = 0; gt_ensure(!add_of(x, UINT_MAX - 1, 1) && x == UINT_MAX);
-    x = 0; gt_ensure(!add_of(x, UINT_MAX - 256, 256) && x == UINT_MAX);
-    x = 0; gt_ensure(!add_of(x, UINT_MAX, 0) && x == UINT_MAX);
+    x = 0; gt_ensure(!gt_safearith_add_of(x, UINT_MAX - 1, 1) && x == UINT_MAX);
+    x = 0; gt_ensure(!gt_safearith_add_of(x, UINT_MAX - 256, 256) && x == UINT_MAX);
+    x = 0; gt_ensure(!gt_safearith_add_of(x, UINT_MAX, 0) && x == UINT_MAX);
 
-    gt_ensure(add_of(x, 0x100000000ll, 0x100000000ll));
+    gt_ensure(gt_safearith_add_of(x, 0x100000000ll, 0x100000000ll));
     x = UINT_MAX;
-    gt_ensure(!add_of(x, 0x100000000ll, -0x100000000ll) && x == 0);
+    gt_ensure(!gt_safearith_add_of(x, 0x100000000ll, -0x100000000ll) && x == 0);
 
-    gt_ensure(sub_of(x, 0, 1));
-    gt_ensure(sub_of(x, 0, 256));
-    gt_ensure(sub_of(x, 0, UINT_MAX));
+    gt_ensure(gt_safearith_sub_of(x, 0, 1));
+    gt_ensure(gt_safearith_sub_of(x, 0, 256));
+    gt_ensure(gt_safearith_sub_of(x, 0, UINT_MAX));
 
-    x = 0; gt_ensure(!sub_of(x, 1, 1) && x == 0);
-    x = 0; gt_ensure(!sub_of(x, 256, 256) && x == 0);
-    x = 0; gt_ensure(!sub_of(x, 0, 0) && x == 0);
+    x = 0; gt_ensure(!gt_safearith_sub_of(x, 1, 1) && x == 0);
+    x = 0; gt_ensure(!gt_safearith_sub_of(x, 256, 256) && x == 0);
+    x = 0; gt_ensure(!gt_safearith_sub_of(x, 0, 0) && x == 0);
   }
 
   {

--- a/src/core/safearith.c
+++ b/src/core/safearith.c
@@ -238,19 +238,22 @@ int gt_safearith_unit_test(GtError *err)
     gt_ensure(gt_safearith_add_of(x, INT_MAX, INT_MAX));
 
     x = 0; gt_ensure(!gt_safearith_add_of(x, INT_MAX - 1, 1) && x == INT_MAX);
-    x = 0; gt_ensure(!gt_safearith_add_of(x, INT_MAX - 256, 256) && x == INT_MAX);
+    x = 0; gt_ensure(!gt_safearith_add_of(x,
+                                          INT_MAX - 256, 256) && x == INT_MAX);
     x = 0; gt_ensure(!gt_safearith_add_of(x, INT_MAX, 0) && x == INT_MAX);
 
     gt_ensure(gt_safearith_add_of(x, 0x100000000ll, 0x100000000ll));
     x = INT_MAX;
-    gt_ensure(!gt_safearith_add_of(x, 0x100000000ll, -0x100000000ll) && x == 0);
+    gt_ensure(!gt_safearith_add_of(x, 0x100000000ll,
+                                   -0x100000000ll) && x == 0);
 
     gt_ensure(gt_safearith_sub_of(x, INT_MIN, 1));
     gt_ensure(gt_safearith_sub_of(x, INT_MIN, 256));
     gt_ensure(gt_safearith_sub_of(x, INT_MIN, INT_MAX));
 
     x = 0; gt_ensure(!gt_safearith_sub_of(x, INT_MIN + 1, 1) && x == INT_MIN);
-    x = 0; gt_ensure(!gt_safearith_sub_of(x, INT_MIN + 256, 256) && x == INT_MIN);
+    x = 0; gt_ensure(!gt_safearith_sub_of(x, INT_MIN + 256,
+                                          256) && x == INT_MIN);
     x = 0; gt_ensure(!gt_safearith_sub_of(x, INT_MIN, 0) && x == INT_MIN);
   }
 
@@ -261,7 +264,8 @@ int gt_safearith_unit_test(GtError *err)
     gt_ensure(gt_safearith_add_of(x, UINT_MAX, UINT_MAX));
 
     x = 0; gt_ensure(!gt_safearith_add_of(x, UINT_MAX - 1, 1) && x == UINT_MAX);
-    x = 0; gt_ensure(!gt_safearith_add_of(x, UINT_MAX - 256, 256) && x == UINT_MAX);
+    x = 0; gt_ensure(!gt_safearith_add_of(x, UINT_MAX - 256,
+                                          256) && x == UINT_MAX);
     x = 0; gt_ensure(!gt_safearith_add_of(x, UINT_MAX, 0) && x == UINT_MAX);
 
     gt_ensure(gt_safearith_add_of(x, 0x100000000ll, 0x100000000ll));

--- a/src/core/safearith_api.h
+++ b/src/core/safearith_api.h
@@ -36,13 +36,14 @@
 */
 
 /* generic macros to determine the minimum and maximum value of given <type> */
-#define GT_SAFE_HALF_MAX_SIGNED(type)  ((type)1 << (type) (sizeof (type) * 8 - 2))
-#define GT_SAFE_MAX_SIGNED(type)       (GT_SAFE_HALF_MAX_SIGNED(type) - 1 +         \
+#define GT_SAFE_HALF_MAX_SIGNED(type)  ((type)1 << (type)                      \
+                                        (sizeof (type) * 8 - 2))
+#define GT_SAFE_MAX_SIGNED(type)       (GT_SAFE_HALF_MAX_SIGNED(type) - 1 +    \
                                         GT_SAFE_HALF_MAX_SIGNED(type))
 #define GT_SAFE_MIN_SIGNED(type)       ((type) -1 - GT_SAFE_MAX_SIGNED(type))
 
-#define GT_SAFE_MIN(type)              ((type) -1 < (type) 1                        \
-                                       ? GT_SAFE_MIN_SIGNED(type)                   \
+#define GT_SAFE_MIN(type)              ((type) -1 < (type) 1                   \
+                                       ? GT_SAFE_MIN_SIGNED(type)              \
                                        : (type)0)
 #define GT_SAFE_MAX(type)              ((type) ~GT_SAFE_MIN(type))
 
@@ -170,7 +171,7 @@ uint64_t      gt_safe_mult_u64_check_func(uint64_t, uint64_t, const char*, int,
 GtUword       gt_safe_mult_ulong_check_func(GtUword, GtUword,
                                             const char*, int,
                                             GtOverflowHandlerFunc, void*);
-/* Overflow-safe multiplication of two unsigned long integers. */
+/* Overflow-safe multiplication of two ulong integers. */
 #define       gt_safe_mult_ulong(i, j) \
               gt_safe_mult_ulong_check_func(i, j, __FILE__, __LINE__, \
                                           gt_safe_default_overflow_handler, \

--- a/src/core/score_matrix.c
+++ b/src/core/score_matrix.c
@@ -168,8 +168,8 @@ static int parse_score_line(GtScoreMatrix *sm, GtTokenizer *tz,
       idx2 = gt_alphabet_encode(sm->alphabet, *(char*)
                                 gt_array_get(index_to_alpha_char_mapping, i));
       gt_score_matrix_set_score(sm,
-                                idx1 == WILDCARD ? num_of_chars : idx1,
-                                idx2 == WILDCARD ? num_of_chars : idx2,
+                                idx1 == GT_WILDCARD ? num_of_chars : idx1,
+                                idx2 == GT_WILDCARD ? num_of_chars : idx2,
                                 score);
       i++;
       gt_str_delete(token);
@@ -267,8 +267,8 @@ int gt_score_matrix_get_score(const GtScoreMatrix *sm,
                               unsigned int idx1, unsigned int idx2)
 {
   gt_assert(sm);
-  idx1 = (idx1 == WILDCARD) ? sm->dimension - 1 : idx1;
-  idx2 = (idx2 == WILDCARD) ? sm->dimension - 1 : idx2;
+  idx1 = (idx1 == GT_WILDCARD) ? sm->dimension - 1 : idx1;
+  idx2 = (idx2 == GT_WILDCARD) ? sm->dimension - 1 : idx2;
   /* indices are valid */
   gt_assert(idx1 < sm->dimension && idx2 < sm->dimension);
   return sm->scores[idx1][idx2];
@@ -278,8 +278,8 @@ void gt_score_matrix_set_score(GtScoreMatrix *sm,
                                unsigned int idx1, unsigned int idx2, int score)
 {
   gt_assert(sm);
-  idx1 = (idx1 == WILDCARD) ? sm->dimension - 1 : idx1;
-  idx2 = (idx2 == WILDCARD) ? sm->dimension - 1 : idx2;
+  idx1 = (idx1 == GT_WILDCARD) ? sm->dimension - 1 : idx1;
+  idx2 = (idx2 == GT_WILDCARD) ? sm->dimension - 1 : idx2;
   /* indices are valid */
   gt_assert(idx1 < sm->dimension && idx2 < sm->dimension);
   sm->scores[idx1][idx2] = score;

--- a/src/core/seq_iterator_fastq.c
+++ b/src/core/seq_iterator_fastq.c
@@ -177,7 +177,7 @@ static int parse_fastq_sequence(GtSeqIteratorFastQ *seqit,
       for (idx = 0; !had_err && idx < str_len; idx++)
       {
         charcode = seqit->symbolmap[(unsigned int) input_str[idx]];
-        if (charcode == UNDEFCHAR) {
+        if (charcode == GT_UNDEFCHAR) {
           gt_error_set(err, "illegal character '%c': file \"%s\", line "GT_WU"",
                             input_str[idx],
                             gt_str_array_get(seqit->filenametab,
@@ -185,7 +185,7 @@ static int parse_fastq_sequence(GtSeqIteratorFastQ *seqit,
                             (GtUword) seqit->curline);
           had_err = -2;
         }
-        if (ISSPECIAL(charcode)) {
+        if (GT_ISSPECIAL(charcode)) {
           seqit->lastspeciallength++;
         } else {
           if (seqit->lastspeciallength > 0)

--- a/src/core/seq_iterator_sequence_buffer.c
+++ b/src/core/seq_iterator_sequence_buffer.c
@@ -158,7 +158,7 @@ static int gt_seq_iterator_sequence_buffer_next(GtSeqIterator *si,
     if (seqit->withsequence)
     {
       GT_STOREINARRAY(&seqit->sequencebuffer, GtUchar,
-                   MAX(1024UL, seqit->sequencebuffer.nextfreeGtUchar * 0.5),
+                   GT_MAX(1024UL, seqit->sequencebuffer.nextfreeGtUchar * 0.5),
                    charcode);
     } else
     {

--- a/src/core/seq_iterator_sequence_buffer.c
+++ b/src/core/seq_iterator_sequence_buffer.c
@@ -133,7 +133,7 @@ static int gt_seq_iterator_sequence_buffer_next(GtSeqIterator *si,
     {
       seqit->currentread++;
     }
-    if (charcode == (GtUchar) SEPARATOR)
+    if (charcode == (GtUchar) GT_SEPARATOR)
     {
       if (seqit->sequencebuffer.nextfreeGtUchar == 0 && seqit->withsequence)
       {

--- a/src/core/sequence_buffer.h
+++ b/src/core/sequence_buffer.h
@@ -28,7 +28,7 @@
    These files are parsed on-the-fly and the sequences and descriptions
    contained in them are made available.
    Sequences can be read character-wise using gt_sequence_buffer_next(), with
-   SEPARATOR symbols in between (see chardef.h).
+   GT_SEPARATOR symbols in between (see chardef.h).
    Note that the <GtSequenceBuffer> is a rather low-level tool for efficient
    sequence access. For simple access to whole sequences, use the
    <GtSeqIterator> class. */

--- a/src/core/sequence_buffer_embl.c
+++ b/src/core/sequence_buffer_embl.c
@@ -245,7 +245,7 @@ static int gt_sequence_buffer_embl_advance(GtSequenceBuffer *sb, GtError *err)
       return 0; /* buffer full, finished */
     }
     if (lc == TERMINATOR) {
-      pvt->outbuf[currentoutpos++] = (GtUchar) SEPARATOR;
+      pvt->outbuf[currentoutpos++] = (GtUchar) GT_SEPARATOR;
       currentfileadd++;
       pvt->lastspeciallength++;
       sbe->state = EMBL_UNDEFINED;
@@ -321,7 +321,7 @@ static int gt_sequence_buffer_embl_advance(GtSequenceBuffer *sb, GtError *err)
         /* all files exhausted */
         pvt->complete = true;
         /* remove last separator */
-        gt_assert(pvt->outbuf[currentoutpos-1] == SEPARATOR);
+        gt_assert(pvt->outbuf[currentoutpos-1] == GT_SEPARATOR);
         pvt->outbuf[--currentoutpos] = (GtUchar) '\0';
         if (pvt->filelengthtab) {
           pvt->filelengthtab[pvt->filenum].effectivelength--;

--- a/src/core/sequence_buffer_embl.c
+++ b/src/core/sequence_buffer_embl.c
@@ -241,7 +241,7 @@ static int gt_sequence_buffer_embl_advance(GtSequenceBuffer *sb, GtError *err)
         pvt->filelengthtab[pvt->filenum].effectivelength
           += (uint64_t) currentfileadd;
       }
-      pvt->nextfree = MIN(currentoutpos, OUTBUFSIZE);
+      pvt->nextfree = GT_MIN(currentoutpos, OUTBUFSIZE);
       return 0; /* buffer full, finished */
     }
     if (lc == TERMINATOR) {
@@ -331,7 +331,7 @@ static int gt_sequence_buffer_embl_advance(GtSequenceBuffer *sb, GtError *err)
       }
     }
   }
-  pvt->nextfree = MIN(currentoutpos, OUTBUFSIZE);
+  pvt->nextfree = GT_MIN(currentoutpos, OUTBUFSIZE);
   return had_err;
 }
 

--- a/src/core/sequence_buffer_fasta.c
+++ b/src/core/sequence_buffer_fasta.c
@@ -143,7 +143,7 @@ static int gt_sequence_buffer_fasta_advance(GtSequenceBuffer *sb, GtError *err)
                 {
                   currentfileadd++;
                 }
-                pvt->outbuf[currentoutpos++] = (unsigned char) SEPARATOR;
+                pvt->outbuf[currentoutpos++] = (unsigned char) GT_SEPARATOR;
                 pvt->lastspeciallength++;
               }
               sbf->indesc = true;

--- a/src/core/sequence_buffer_fastq.c
+++ b/src/core/sequence_buffer_fastq.c
@@ -98,7 +98,7 @@ static int gt_sequence_buffer_fastq_advance(GtSequenceBuffer *sb, GtError *err)
 
   /* we need more than one round to deal with the overflowed sequence */
   if (gt_str_length(sbfq->overflowbuffer) > 0) {
-    pvt->nextfree = MIN(currentoutpos, OUTBUFSIZE);
+    pvt->nextfree = GT_MIN(currentoutpos, OUTBUFSIZE);
     return had_err;
   }
 
@@ -173,7 +173,7 @@ static int gt_sequence_buffer_fastq_advance(GtSequenceBuffer *sb, GtError *err)
 
     /* if buffer is full, return it */
     if (currentoutpos >= (GtUword) OUTBUFSIZE) {
-      pvt->nextfree = MIN(currentoutpos, OUTBUFSIZE);
+      pvt->nextfree = GT_MIN(currentoutpos, OUTBUFSIZE);
       had_err = 0;
       break;
     }
@@ -186,7 +186,7 @@ static int gt_sequence_buffer_fastq_advance(GtSequenceBuffer *sb, GtError *err)
     pvt->filelengthtab[pvt->filenum].effectivelength
       += (uint64_t) currentfileadd;
   }
-  pvt->nextfree = MIN(currentoutpos, OUTBUFSIZE);
+  pvt->nextfree = GT_MIN(currentoutpos, OUTBUFSIZE);
   return had_err;
 }
 

--- a/src/core/sequence_buffer_fastq.c
+++ b/src/core/sequence_buffer_fastq.c
@@ -62,7 +62,7 @@ static int gt_sequence_buffer_fastq_advance(GtSequenceBuffer *sb, GtError *err)
   /* did the last buffer end with a sequence boundary?
      if so, we need to provide an additional separator! */
   if (sbfq->carryseparator) {
-    pvt->outbuf[currentoutpos++] = (GtUchar) SEPARATOR;
+    pvt->outbuf[currentoutpos++] = (GtUchar) GT_SEPARATOR;
     currentfileread++;
     pvt->lastspeciallength++;
     currentfileadd++;
@@ -88,7 +88,7 @@ static int gt_sequence_buffer_fastq_advance(GtSequenceBuffer *sb, GtError *err)
     if (*(overflowedstring) != '\0') {
       gt_str_set(sbfq->overflowbuffer, overflowedstring);
     } else {
-      pvt->outbuf[currentoutpos++] = (GtUchar) SEPARATOR;
+      pvt->outbuf[currentoutpos++] = (GtUchar) GT_SEPARATOR;
       currentfileread++;
       pvt->lastspeciallength++;
       gt_str_reset(sbfq->overflowbuffer);
@@ -152,7 +152,7 @@ static int gt_sequence_buffer_fastq_advance(GtSequenceBuffer *sb, GtError *err)
       if (currentoutpos >= (GtUword) OUTBUFSIZE)
         sbfq->carryseparator = true;
       else {
-        pvt->outbuf[currentoutpos++] = (GtUchar) SEPARATOR;
+        pvt->outbuf[currentoutpos++] = (GtUchar) GT_SEPARATOR;
         pvt->lastspeciallength++;
         currentfileadd++;
       }

--- a/src/core/sequence_buffer_gb.c
+++ b/src/core/sequence_buffer_gb.c
@@ -265,7 +265,7 @@ static int gt_sequence_buffer_gb_advance(GtSequenceBuffer *sb, GtError *err)
     /* terminators may occur in any line */
     if (!had_err && strcmp(gt_str_get(sbe->keywordbuffer),
                            GB_ENTRY_TERMINATOR) == 0) {
-      pvt->outbuf[currentoutpos++] = (GtUchar) SEPARATOR;
+      pvt->outbuf[currentoutpos++] = (GtUchar) GT_SEPARATOR;
       currentfileadd++;
       pvt->lastspeciallength++;
       if (!sbe->description_set && pvt->descptr)

--- a/src/core/sequence_buffer_gb.c
+++ b/src/core/sequence_buffer_gb.c
@@ -423,7 +423,7 @@ static int gt_sequence_buffer_gb_advance(GtSequenceBuffer *sb, GtError *err)
     }
     pvt->linenum++;
   }
-  pvt->nextfree = MIN(currentoutpos, OUTBUFSIZE);
+  pvt->nextfree = GT_MIN(currentoutpos, OUTBUFSIZE);
   return had_err;
 }
 

--- a/src/core/sequence_buffer_inline.h
+++ b/src/core/sequence_buffer_inline.h
@@ -33,7 +33,7 @@
   pvt = sb->pvt;
   if (pvt->symbolmap != NULL) {
     charcode = pvt->symbolmap[(unsigned int) cc];
-    if (charcode == UNDEFCHAR) {
+    if (charcode == GT_UNDEFCHAR) {
       gt_error_set(err, "illegal character '%c': file \"%s\", line "GT_LLU"",
                         cc,
                         gt_str_array_get(pvt->filenametab,
@@ -41,7 +41,7 @@
                         (GtUint64) pvt->linenum);
       return -2;
     }
-    if (ISSPECIAL((GtUchar) charcode)) {
+    if (GT_ISSPECIAL((GtUchar) charcode)) {
       pvt->lastspeciallength++;
     } else {
       if (pvt->lastspeciallength > 0)

--- a/src/core/yarandom_api.h
+++ b/src/core/yarandom_api.h
@@ -31,11 +31,11 @@ unsigned int gt_ya_rand_init(unsigned int);
 void         gt_ya_rand_clean(void);
 
 /* Maximum random number (2147483647) */
-#define RAND_MAX \
+#define GT_RAND_MAX \
         0x7FFFFFFF
 /* Return random number up to RAND_MAX. */
 #define random() \
-        ((GtWord) (gt_ya_random() & RAND_MAX))
+        ((GtWord) (gt_ya_random() & GT_RAND_MAX))
 
 /*#define srandom(i) ya_rand_init(0)*/
 
@@ -50,7 +50,7 @@ void         gt_ya_rand_clean(void);
 #if defined (__GNUC__) && (__GNUC__ >= 2)
  /* Implement frand using GCC's statement-expression extension. */
 
-# define frand(f)                                                       \
+# define gt_frand(f)                                                    \
   __extension__                                                         \
   ({ double tmp = ((((double) random()) * ((double) (f))) /             \
                    ((double) ((unsigned int)~0)));                      \
@@ -59,7 +59,7 @@ void         gt_ya_rand_clean(void);
 #else /* not GCC2 - implement frand using a global variable.*/
 
 /*@unused@*/ static double _frand_tmp_;
-# define frand(f)                                                       \
+# define gt_frand(f)                                                    \
   (_frand_tmp_ = ((((double) random()) * ((double) (f))) /              \
                   ((double) ((unsigned int)~0))),                       \
    _frand_tmp_ < 0 ? (-_frand_tmp_) : _frand_tmp_)

--- a/src/extended/affinealign.c
+++ b/src/extended/affinealign.c
@@ -82,7 +82,7 @@ static void affinealign_fill_table(GtAffinealignDPentry **dptable,
           Rvalue = add_safe_max(dptable[i-1][j-1].Rvalue, rcost);
           Dvalue = add_safe_max(dptable[i-1][j-1].Dvalue, rcost);
           Ivalue = add_safe_max(dptable[i-1][j-1].Ivalue, rcost);
-          minvalue = MIN3(Rvalue, Dvalue, Ivalue);
+          minvalue = GT_MIN3(Rvalue, Dvalue, Ivalue);
           gt_assert(minvalue != LONG_MAX);
           dptable[i][j].Rvalue = minvalue;
           /* set backtracing edge */
@@ -102,7 +102,7 @@ static void affinealign_fill_table(GtAffinealignDPentry **dptable,
           Dvalue = add_safe_max(dptable[i-1][j].Dvalue, gap_extension);
           Ivalue = add_safe_max(dptable[i-1][j].Ivalue,
                                 gap_opening + gap_extension);
-          minvalue = MIN3(Rvalue, Dvalue, Ivalue);
+          minvalue = GT_MIN3(Rvalue, Dvalue, Ivalue);
           gt_assert(minvalue != ULONG_MAX);
           dptable[i][j].Dvalue = minvalue;
           /* set backtracing edge */
@@ -122,7 +122,7 @@ static void affinealign_fill_table(GtAffinealignDPentry **dptable,
           Dvalue = add_safe_max(dptable[i][j-1].Dvalue,
                                 gap_opening + gap_extension);
           Ivalue = add_safe_max(dptable[i][j-1].Ivalue, gap_extension);
-          minvalue = MIN3(Rvalue, Dvalue, Ivalue);
+          minvalue = GT_MIN3(Rvalue, Dvalue, Ivalue);
           gt_assert(minvalue != LONG_MAX);
           dptable[i][j].Ivalue = minvalue;
           /* set backtracing edge */
@@ -146,7 +146,7 @@ GtWord gt_affinealign_traceback(GtAlignment *align,
   GtAffineAlignEdge edge;
   gt_assert(align && dptable);
   /* determine min{A_affine(m,n,x) | x in {R,D,I}} */
-  minvalue = MIN3(dptable[i][j].Rvalue, dptable[i][j].Dvalue,
+  minvalue = GT_MIN3(dptable[i][j].Rvalue, dptable[i][j].Dvalue,
                   dptable[i][j].Ivalue);
   if (dptable[i][j].Rvalue == minvalue)
     edge = Affine_R;
@@ -351,7 +351,7 @@ static GtWord affinealign_fill_table_local(GtAffinealignDPentry **Atabcolumn,
     Atabcolumn[0][j].Rvalue = GT_WORD_MIN;
     Atabcolumn[0][j].Dvalue = GT_WORD_MIN;
     Atabcolumn[0][j].Ivalue = gap_opening + gap_extension;
-    temp = MAX3(Atabcolumn[0][j].Rvalue,
+    temp = GT_MAX3(Atabcolumn[0][j].Rvalue,
                 Atabcolumn[0][j].Dvalue,
                 Atabcolumn[0][j].Ivalue);
     Atabcolumn[0][j].totalvalue = ((temp > 0)? temp : 0);
@@ -385,7 +385,7 @@ static GtWord affinealign_fill_table_local(GtAffinealignDPentry **Atabcolumn,
       Dvalue = add_safe_min(Atabcolumn[i-1][j-1].Dvalue, replacement);
       Ivalue = add_safe_min(Atabcolumn[i-1][j-1].Ivalue, replacement);
       totalvalue = add_safe_min(Atabcolumn[i-1][j-1].totalvalue, replacement);
-      Atabcolumn[i][j].Rvalue = MAX(MAX(Rvalue, Dvalue),MAX(Ivalue,totalvalue));
+      Atabcolumn[i][j].Rvalue = GT_MAX(GT_MAX(Rvalue, Dvalue),GT_MAX(Ivalue,totalvalue));
       /* set backtracing edge */
       if (Rvalue == Atabcolumn[i][j].Rvalue)
         Atabcolumn[i][j].Redge = Affine_R;
@@ -404,7 +404,7 @@ static GtWord affinealign_fill_table_local(GtAffinealignDPentry **Atabcolumn,
                             gap_opening + gap_extension);
       totalvalue = add_safe_min(Atabcolumn[i-1][j].totalvalue,
                                 gap_opening + gap_extension);
-      Atabcolumn[i][j].Dvalue = MAX(MAX(Rvalue, Dvalue),MAX(Ivalue,totalvalue));
+      Atabcolumn[i][j].Dvalue = GT_MAX(GT_MAX(Rvalue, Dvalue),GT_MAX(Ivalue,totalvalue));
       /* set backtracing edge */
       if (Rvalue == Atabcolumn[i][j].Dvalue)
         Atabcolumn[i][j].Dedge = Affine_R;
@@ -423,7 +423,7 @@ static GtWord affinealign_fill_table_local(GtAffinealignDPentry **Atabcolumn,
       Ivalue = add_safe_min(Atabcolumn[i][j-1].Ivalue,gap_extension);
       totalvalue = add_safe_min(Atabcolumn[i][j-1].totalvalue,
                                 gap_extension + gap_opening);
-      Atabcolumn[i][j].Ivalue = MAX(MAX(Rvalue, Dvalue),MAX(Ivalue,totalvalue));
+      Atabcolumn[i][j].Ivalue = GT_MAX(GT_MAX(Rvalue, Dvalue),GT_MAX(Ivalue,totalvalue));
       /* set backtracing edge */
       if (Rvalue == Atabcolumn[i][j].Ivalue)
         Atabcolumn[i][j].Iedge = Affine_R;
@@ -435,7 +435,7 @@ static GtWord affinealign_fill_table_local(GtAffinealignDPentry **Atabcolumn,
         Atabcolumn[i][j].Iedge = Affine_X;
 
       /*calculate totalvalue*/
-      temp = MAX3(Atabcolumn[i][j].Rvalue,
+      temp = GT_MAX3(Atabcolumn[i][j].Rvalue,
                   Atabcolumn[i][j].Dvalue,
                   Atabcolumn[i][j].Ivalue);
       Atabcolumn[i][j].totalvalue = temp > 0 ? temp : 0;
@@ -467,8 +467,8 @@ static void affinealign_traceback_local(GtAlignment *align,
   i = max_end.a;
   j = max_end.b;
 
-  maxvalue = MAX(MAX(dptable[i][j].Rvalue, dptable[i][j].Dvalue),
-                  MAX(dptable[i][j].Ivalue,dptable[i][j].totalvalue));
+  maxvalue = GT_MAX(GT_MAX(dptable[i][j].Rvalue, dptable[i][j].Dvalue),
+                  GT_MAX(dptable[i][j].Ivalue,dptable[i][j].totalvalue));
   gt_assert(gt_maxcoordvalue_get_value(max) == maxvalue);
 
   if (dptable[i][j].Rvalue == maxvalue)

--- a/src/extended/affinealign.c
+++ b/src/extended/affinealign.c
@@ -385,7 +385,8 @@ static GtWord affinealign_fill_table_local(GtAffinealignDPentry **Atabcolumn,
       Dvalue = add_safe_min(Atabcolumn[i-1][j-1].Dvalue, replacement);
       Ivalue = add_safe_min(Atabcolumn[i-1][j-1].Ivalue, replacement);
       totalvalue = add_safe_min(Atabcolumn[i-1][j-1].totalvalue, replacement);
-      Atabcolumn[i][j].Rvalue = GT_MAX(GT_MAX(Rvalue, Dvalue),GT_MAX(Ivalue,totalvalue));
+      Atabcolumn[i][j].Rvalue = GT_MAX(GT_MAX(Rvalue, Dvalue),
+                                       GT_MAX(Ivalue,totalvalue));
       /* set backtracing edge */
       if (Rvalue == Atabcolumn[i][j].Rvalue)
         Atabcolumn[i][j].Redge = Affine_R;
@@ -404,7 +405,8 @@ static GtWord affinealign_fill_table_local(GtAffinealignDPentry **Atabcolumn,
                             gap_opening + gap_extension);
       totalvalue = add_safe_min(Atabcolumn[i-1][j].totalvalue,
                                 gap_opening + gap_extension);
-      Atabcolumn[i][j].Dvalue = GT_MAX(GT_MAX(Rvalue, Dvalue),GT_MAX(Ivalue,totalvalue));
+      Atabcolumn[i][j].Dvalue = GT_MAX(GT_MAX(Rvalue, Dvalue),
+                                       GT_MAX(Ivalue,totalvalue));
       /* set backtracing edge */
       if (Rvalue == Atabcolumn[i][j].Dvalue)
         Atabcolumn[i][j].Dedge = Affine_R;
@@ -423,7 +425,8 @@ static GtWord affinealign_fill_table_local(GtAffinealignDPentry **Atabcolumn,
       Ivalue = add_safe_min(Atabcolumn[i][j-1].Ivalue,gap_extension);
       totalvalue = add_safe_min(Atabcolumn[i][j-1].totalvalue,
                                 gap_extension + gap_opening);
-      Atabcolumn[i][j].Ivalue = GT_MAX(GT_MAX(Rvalue, Dvalue),GT_MAX(Ivalue,totalvalue));
+      Atabcolumn[i][j].Ivalue = GT_MAX(GT_MAX(Rvalue, Dvalue),
+                                       GT_MAX(Ivalue,totalvalue));
       /* set backtracing edge */
       if (Rvalue == Atabcolumn[i][j].Ivalue)
         Atabcolumn[i][j].Iedge = Affine_R;

--- a/src/extended/alignment.c
+++ b/src/extended/alignment.c
@@ -223,7 +223,7 @@ GtUword gt_alignment_eval_generic(bool mapped,bool downcase,
                   b = alignment->v[idx_v];
           if (mapped)
           {
-            if (ISSPECIAL(a) || ISSPECIAL(b) || a != b)
+            if (GT_ISSPECIAL(a) || GT_ISSPECIAL(b) || a != b)
             {
               sumcost++;
             }
@@ -300,7 +300,7 @@ static GtWord gt_alignment_eval_generic_with_score(bool mapped,
               sumscore += gt_score_matrix_get_score(scorematrix, a, b);
             } else
             {
-              sumscore += (ISSPECIAL(a) || ISSPECIAL(b) ||
+              sumscore += (GT_ISSPECIAL(a) || GT_ISSPECIAL(b) ||
                            characters[a] != characters[b]) ? mismatchscore
                                                            : matchscore;
             }
@@ -409,7 +409,7 @@ static GtWord gt_alignment_eval_generic_with_affine_score(
               sumscore += gt_score_matrix_get_score(scorematrix, a, b);
             } else
             {
-              if (ISSPECIAL(a) || ISSPECIAL(b) ||
+              if (GT_ISSPECIAL(a) || GT_ISSPECIAL(b) ||
                   characters[a] != characters[b])
               {
                 sumscore += mismatchscore;
@@ -566,9 +566,9 @@ void gt_alignment_show_generic(GtUchar *buffer,
 
           if (characters != NULL)
           {
-            topbuf[pos] = ISSPECIAL(a) ? wildcardshow : characters[a];
-            is_match = (a == b && !ISSPECIAL(a)) ? true : false;
-            lowbuf[pos] = ISSPECIAL(b) ? wildcardshow : characters[b];
+            topbuf[pos] = GT_ISSPECIAL(a) ? wildcardshow : characters[a];
+            is_match = (a == b && !GT_ISSPECIAL(a)) ? true : false;
+            lowbuf[pos] = GT_ISSPECIAL(b) ? wildcardshow : characters[b];
           } else
           {
             topbuf[pos] = a;
@@ -595,7 +595,7 @@ void gt_alignment_show_generic(GtUchar *buffer,
 
           if (characters != NULL)
           {
-            topbuf[pos] = ISSPECIAL(a) ? wildcardshow : characters[a];
+            topbuf[pos] = GT_ISSPECIAL(a) ? wildcardshow : characters[a];
           } else
           {
             topbuf[pos] = a;
@@ -614,7 +614,7 @@ void gt_alignment_show_generic(GtUchar *buffer,
           midbuf[pos] = (GtUchar) MISMATCHSYMBOL;
           if (characters != NULL)
           {
-            lowbuf[pos] = ISSPECIAL(b) ? wildcardshow : characters[b];
+            lowbuf[pos] = GT_ISSPECIAL(b) ? wildcardshow : characters[b];
           } else
           {
             lowbuf[pos] = b;
@@ -717,7 +717,7 @@ static int gt_alignment_check_match(const GtAlignment *alignment,GtError *err)
   {
     GtUchar cc_u = alignment->u[idx];
     GtUchar cc_v = alignment->v[idx];
-    if (ISSPECIAL(cc_u) || ISSPECIAL(cc_v) || cc_u != cc_v)
+    if (GT_ISSPECIAL(cc_u) || GT_ISSPECIAL(cc_v) || cc_u != cc_v)
     {
       if (err == NULL)
       {

--- a/src/extended/condenseq.c
+++ b/src/extended/condenseq.c
@@ -793,7 +793,7 @@ const GtUchar *gt_condenseq_extract_encoded_range(GtCondenseq *condenseq,
               unique != NULL ||
               link != NULL);
     if (nextsep != 0 && nextsep == range.start + buffoffset) {
-      buf[buffoffset++] = SEPARATOR;
+      buf[buffoffset++] = GT_SEPARATOR;
       nextsep = condenseq_next_sep(condenseq, range.start + buffoffset);
     }
     else if (unique != NULL &&
@@ -859,7 +859,7 @@ const char *gt_condenseq_extract_decoded_range(GtCondenseq *condenseq,
   }
   buf = condenseq->buffer;
   for (idx = 0; idx < length; ++idx) {
-    if (ubuf[idx] == SEPARATOR) {
+    if (ubuf[idx] == GT_SEPARATOR) {
       buf[idx] = separator;
     }
     else {

--- a/src/extended/condenseq.h
+++ b/src/extended/condenseq.h
@@ -87,7 +87,7 @@ const GtUchar*     gt_condenseq_extract_encoded(GtCondenseq *condenseq,
 /* Returns the encoded representation of the substring defined by (inclusive)
    range <range> of <condenseq>.
    If the positions include a sequence separator this will be set to the non
-   printable SEPARATOR (core/chardef_api.h). */
+   printable GT_SEPARATOR (core/chardef_api.h). */
 const GtUchar*     gt_condenseq_extract_encoded_range(GtCondenseq *condenseq,
                                                       GtRange range);
 /* Returns the decoded representation of the <id>s sequence of

--- a/src/extended/consensus_sa.c
+++ b/src/extended/consensus_sa.c
@@ -27,17 +27,17 @@ typedef struct {
   const void *set_of_sas;
   GtUword number_of_sas;
   size_t size_of_sa;
-  GetGenomicRangeFunc get_genomic_range;
-  GetStrandFunc get_strand;
-  GetExonsFunc get_exons;
-  ProcessSpliceFormFunc process_splice_form;
+  GtGetGenomicRangeFunc get_genomic_range;
+  GtGetStrandFunc get_strand;
+  GtGetExonsFunc get_exons;
+  GtProcessSpliceFormFunc process_splice_form;
   void *userdata;
 } ConsensusSA;
 
 #ifndef NDEBUG
 static bool set_of_sas_is_sorted(const void *set_of_sas,
                                  GtUword number_of_sas,
-                                 size_t size_of_sa, GetGenomicRangeFunc
+                                 size_t size_of_sa, GtGetGenomicRangeFunc
                                  get_genomic_range)
 {
   GtRange gt_range_a, gt_range_b;
@@ -564,9 +564,10 @@ static void compute_csas(ConsensusSA *csa)
 }
 
 void gt_consensus_sa(const void *set_of_sas, GtUword number_of_sas,
-                     size_t size_of_sa, GetGenomicRangeFunc get_genomic_range,
-                     GetStrandFunc get_strand, GetExonsFunc get_exons,
-                     ProcessSpliceFormFunc process_splice_form, void *userdata)
+                     size_t size_of_sa, GtGetGenomicRangeFunc get_genomic_range,
+                     GtGetStrandFunc get_strand, GtGetExonsFunc get_exons,
+                     GtProcessSpliceFormFunc process_splice_form,
+                     void *userdata)
 {
   ConsensusSA csa;
   gt_assert(set_of_sas && number_of_sas && size_of_sa);

--- a/src/extended/consensus_sa_api.h
+++ b/src/extended/consensus_sa_api.h
@@ -24,14 +24,14 @@
 /* ConsensusSplicedAlignment module */
 
 /* Function to obtain the genomic range from spliced alignment <sa>. */
-typedef GtRange  (*GetGenomicRangeFunc)(const void *sa);
+typedef GtRange  (*GtGetGenomicRangeFunc)(const void *sa);
 /* Function to obtain the strand from spliced alignment <sa>. */
-typedef GtStrand (*GetStrandFunc)(const void *sa);
+typedef GtStrand (*GtGetStrandFunc)(const void *sa);
 /* Function to obtain exon ranges from spliced alignment <sa>. */
-typedef void   (*GetExonsFunc)(GtArray *exon_ranges, const void *sa);
+typedef void   (*GtGetExonsFunc)(GtArray *exon_ranges, const void *sa);
 /* Function to process the generated from the consensus spliced alignment
    process. */
-typedef void   (*ProcessSpliceFormFunc)(GtArray *spliced_alignments_in_form,
+typedef void   (*GtProcessSpliceFormFunc)(GtArray *spliced_alignments_in_form,
                                         const void *set_of_sas,
                                         GtUword number_of_sas,
                                         size_t size_of_sa,
@@ -52,7 +52,7 @@ typedef void   (*ProcessSpliceFormFunc)(GtArray *spliced_alignments_in_form,
   Technology, 47(15):965-978, 2005.
 */
 void gt_consensus_sa(const void *set_of_sas, GtUword number_of_sas,
-                     size_t size_of_sa, GetGenomicRangeFunc, GetStrandFunc,
-                     GetExonsFunc, ProcessSpliceFormFunc, void *userdata);
+                     size_t size_of_sa, GtGetGenomicRangeFunc, GtGetStrandFunc,
+                     GtGetExonsFunc, GtProcessSpliceFormFunc, void *userdata);
 
 #endif

--- a/src/extended/csa_splice_form.c
+++ b/src/extended/csa_splice_form.c
@@ -21,13 +21,13 @@
 
 struct GtCSASpliceForm {
   GtArray *spliced_alignments;
-  GetGenomicRangeFunc get_genomic_range;
-  GetStrandFunc get_strand;
+  GtGetGenomicRangeFunc get_genomic_range;
+  GtGetStrandFunc get_strand;
 };
 
 GtCSASpliceForm* gt_csa_splice_form_new(void *spliced_alignment,
-                                   GetGenomicRangeFunc get_genomic_range,
-                                   GetStrandFunc get_strand)
+                                   GtGetGenomicRangeFunc get_genomic_range,
+                                   GtGetStrandFunc get_strand)
 {
   GtCSASpliceForm *splice_form;
   gt_assert(spliced_alignment && get_strand);

--- a/src/extended/csa_splice_form.h
+++ b/src/extended/csa_splice_form.h
@@ -24,7 +24,7 @@
 typedef struct GtCSASpliceForm GtCSASpliceForm;
 
 GtCSASpliceForm* gt_csa_splice_form_new(void *spliced_alignment,
-                                        GetGenomicRangeFunc, GetStrandFunc);
+                                        GtGetGenomicRangeFunc, GtGetStrandFunc);
 void             gt_csa_splice_form_delete(GtCSASpliceForm*);
 void             gt_csa_splice_form_add_sa(GtCSASpliceForm*,
                                            void *spliced_alignment);

--- a/src/extended/csa_variable_strands.c
+++ b/src/extended/csa_variable_strands.c
@@ -22,8 +22,8 @@
 
 typedef struct {
   GtArray *splice_forms;
-  GetGenomicRangeFunc get_genomic_range;
-  GetStrandFunc get_strand;
+  GtGetGenomicRangeFunc get_genomic_range;
+  GtGetStrandFunc get_strand;
 } StoreSpliceFormInfo;
 
 static void store_splice_form(GtArray *spliced_alignments_in_form,
@@ -98,9 +98,9 @@ static void process_splice_forms(GtArray *genes, GtArray *splice_forms)
 GtArray* gt_csa_variable_strands(const void *set_of_sas,
                                  GtUword number_of_sas,
                                  size_t size_of_sa,
-                                 GetGenomicRangeFunc get_genomic_range,
-                                 GetStrandFunc get_strand,
-                                 GetExonsFunc get_exons)
+                                 GtGetGenomicRangeFunc get_genomic_range,
+                                 GtGetStrandFunc get_strand,
+                                 GtGetExonsFunc get_exons)
 {
   StoreSpliceFormInfo info;
   GtArray *genes;

--- a/src/extended/csa_variable_strands.h
+++ b/src/extended/csa_variable_strands.h
@@ -33,7 +33,7 @@
 /* Returns an array of GtCSAGenes. */
 GtArray* gt_csa_variable_strands(const void *set_of_sas,
                                  GtUword number_of_sas,
-                                 size_t size_of_sa, GetGenomicRangeFunc,
-                                 GetStrandFunc, GetExonsFunc);
+                                 size_t size_of_sa, GtGetGenomicRangeFunc,
+                                 GtGetStrandFunc, GtGetExonsFunc);
 
 #endif

--- a/src/extended/diagonalbandalign.c
+++ b/src/extended/diagonalbandalign.c
@@ -122,8 +122,8 @@ static GtUword diagonalband_squarespace_distance_only(const GtUchar *useq,
   GtUword **EDtabcolumn, distance = GT_UWORD_MAX;
   GtScoreHandler *scorehandler;
 
-   if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+   if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     gt_assert(false);
   }
@@ -160,8 +160,8 @@ GtUword gt_diagonalbandalignment_in_square_space_generic(GtLinspaceManagement
 
   gt_assert(align && scorehandler);
 
-  if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+  if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     gt_assert(false);
   }
@@ -301,8 +301,8 @@ GT_UNUSED  static void dtab_in_square_space(GtLinspaceManagement *spacemanager,
   GtUword **EDtabcolumn;
   gt_assert(Dtab && scorehandler && spacemanager);
 
-  if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+  if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     gt_assert(false);
   }
@@ -338,8 +338,8 @@ static GtUword diagonalband_linear_distance_only(const GtUchar *useq,
 
   distance = GT_UWORD_MAX;
 
-  if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+  if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     return GT_UWORD_MAX;
   }
@@ -509,8 +509,8 @@ static GtUword evaluateallDBtabcolumns(GtLinspaceManagement *spacemanager,
   GtWord diag;
   bool last_row = false;
 
-  if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+  if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     gt_assert(false);
   }
@@ -735,7 +735,7 @@ static void evaluateDBcrosspoints(GtLinspaceManagement *spacemanager,
     if (diag + ((GtWord)ulen-(GtWord)vlen) > 0)
     {
       dtemp = Diagcolumn[cpoint];
-      new_left = MAX((GtWord)left_dist-diag+1,
+      new_left = GT_MAX((GtWord)left_dist-diag+1,
                     -((GtWord)ulen-((GtWord)Diagcolumn[cpoint].currentrowindex+1
                     -(GtWord)rowoffset)));
       new_right = 0;
@@ -752,7 +752,7 @@ static void evaluateDBcrosspoints(GtLinspaceManagement *spacemanager,
     else
     {
       new_left = -1;
-      new_right =  MIN((GtWord)right_dist-((GtWord)diag)-1,
+      new_right =  GT_MIN((GtWord)right_dist-((GtWord)diag)-1,
                       ((GtWord)vlen-(GtWord)cpoint-1));
       new_ulen = ulen - (Diagcolumn[cpoint].currentrowindex-rowoffset);
       evaluateDBcrosspoints(spacemanager,Diagcolumn+cpoint+1,scorehandler,
@@ -783,7 +783,7 @@ static void evaluateDBcrosspoints(GtLinspaceManagement *spacemanager,
     else if (Diagcolumn[prevcpoint].last_type == Linear_D)
     {
       new_left = -1;
-      new_right = MIN(right_dist-((GtWord)diag)-1,
+      new_right = GT_MIN(right_dist-((GtWord)diag)-1,
                      (GtWord)prevcpoint-(GtWord)cpoint-1);
       new_ulen = Diagcolumn[prevcpoint].currentrowindex-
                  Diagcolumn[cpoint].currentrowindex-1;
@@ -799,7 +799,7 @@ static void evaluateDBcrosspoints(GtLinspaceManagement *spacemanager,
       dtemp = Diagcolumn[cpoint];
       new_ulen = Diagcolumn[prevcpoint].currentrowindex-
                  Diagcolumn[cpoint].currentrowindex-1;
-      new_left = MAX(left_dist-diag+1,-new_ulen);
+      new_left = GT_MAX(left_dist-diag+1,-new_ulen);
       new_right = 0;
 
       evaluateDBcrosspoints(spacemanager,Diagcolumn+cpoint,scorehandler,
@@ -824,8 +824,8 @@ static void evaluateDBcrosspoints(GtLinspaceManagement *spacemanager,
     if (Diagcolumn[cpoint].last_type == Linear_D)
     {
       new_ulen = Diagcolumn[cpoint].currentrowindex-ustart-1;
-      new_left =  MAX(diag, -new_ulen);
-      new_right = MIN(right_dist, (GtWord)cpoint);
+      new_left =  GT_MAX(diag, -new_ulen);
+      new_right = GT_MIN(right_dist, (GtWord)cpoint);
 
       evaluateDBcrosspoints(spacemanager, Diagcolumn, scorehandler,
                             edge, rowoffset, coloffset,
@@ -836,9 +836,9 @@ static void evaluateDBcrosspoints(GtLinspaceManagement *spacemanager,
     }
     else if (Diagcolumn[cpoint].last_type == Linear_I)
     {
-      new_left = MAX(left_dist,
+      new_left = GT_MAX(left_dist,
                  -((GtWord)Diagcolumn[cpoint].currentrowindex-(GtWord)ustart));
-      new_right = MIN((GtWord)cpoint-1, diag);
+      new_right = GT_MIN((GtWord)cpoint-1, diag);
       evaluateDBcrosspoints(spacemanager, Diagcolumn, scorehandler,
                             edge, rowoffset, coloffset, useq, ustart,
                             Diagcolumn[cpoint].currentrowindex-ustart,
@@ -870,8 +870,8 @@ static void gt_calc_diagonalbandalign(GtLinspaceManagement *spacemanager,
 
   gt_assert(align && spacemanager && scorehandler);
 
-  if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+  if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     gt_assert(false); /* no global alignment */
   }
@@ -901,7 +901,7 @@ static void gt_calc_diagonalbandalign(GtLinspaceManagement *spacemanager,
     return;
   }
 
-  gt_linspace_management_check(spacemanager, MIN(right_dist-left_dist,ulen),
+  gt_linspace_management_check(spacemanager, GT_MIN(right_dist-left_dist,ulen),
                                vlen,
                                sizeof (*EDtabcolumn),
                                sizeof (*Rtabcolumn),
@@ -937,8 +937,8 @@ void gt_diagonalbandalign_compute_generic(GtLinspaceManagement *spacemanager,
   gt_assert(useq && vseq && align && spacemanager && scorehandler);
 
   /* set new bounds, if left_dist or right_dist is out of sequence */
-  left_dist = MAX(-(GtWord) ulen, left_dist);
-  right_dist = MIN((GtWord) vlen, right_dist);
+  left_dist = GT_MAX(-(GtWord) ulen, left_dist);
+  right_dist = GT_MIN((GtWord) vlen, right_dist);
 
   gt_alignment_set_seqs(align,useq+ustart, ulen, vseq+vstart, vlen);
   gt_calc_diagonalbandalign(spacemanager, scorehandler, align,

--- a/src/extended/diagonalbandalign_affinegapcost.c
+++ b/src/extended/diagonalbandalign_affinegapcost.c
@@ -48,8 +48,8 @@ static void diagonalband_fillDPtab_affine(GtAffinealignDPentry **Atabcolumn,
   GtWord rcost, r_dist, d_dist, i_dist, minvalue;
 
   gt_assert(Atabcolumn && scorehandler);
-  if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+  if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     gt_assert(false);
   }
@@ -93,7 +93,7 @@ static void diagonalband_fillDPtab_affine(GtAffinealignDPentry **Atabcolumn,
     d_dist = add_safe_max(Atabcolumn[i-1][0].Dvalue, gap_extension);
     i_dist = add_safe_max(Atabcolumn[i-1][0].Ivalue,
                          gap_opening + gap_extension);
-    Atabcolumn[i][0].Dvalue = MIN3(r_dist, d_dist, i_dist);
+    Atabcolumn[i][0].Dvalue = GT_MIN3(r_dist, d_dist, i_dist);
     Atabcolumn[i][0].Ivalue = GT_WORD_MAX;
 
     Atabcolumn[i][0].Redge = Affine_X;
@@ -126,7 +126,7 @@ static void diagonalband_fillDPtab_affine(GtAffinealignDPentry **Atabcolumn,
                                gap_extension + gap_opening);
         i_dist = add_safe_max(Atabcolumn[i][j-1].Ivalue,gap_extension);
 
-        minvalue = MIN3(r_dist, d_dist, i_dist);
+        minvalue = GT_MIN3(r_dist, d_dist, i_dist);
         Atabcolumn[i][j].Ivalue = minvalue;
         Atabcolumn[i][j].Rvalue = GT_WORD_MAX;
         Atabcolumn[i][j].Dvalue = GT_WORD_MAX;
@@ -154,7 +154,7 @@ static void diagonalband_fillDPtab_affine(GtAffinealignDPentry **Atabcolumn,
       r_dist=add_safe_max(Atabcolumn[i][j-1].Rvalue,gap_extension+gap_opening);
       d_dist=add_safe_max(Atabcolumn[i][j-1].Dvalue,gap_extension+gap_opening);
       i_dist=add_safe_max(Atabcolumn[i][j-1].Ivalue,gap_extension);
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
       Atabcolumn[i][j].Ivalue = minvalue;
       Atabcolumn[i][j].Iedge = gt_linearalign_affinegapcost_set_edge(
                                                         r_dist, d_dist, i_dist);
@@ -165,7 +165,7 @@ static void diagonalband_fillDPtab_affine(GtAffinealignDPentry **Atabcolumn,
       r_dist = add_safe_max(Atabcolumn[i-1][j-1].Rvalue, rcost);
       d_dist = add_safe_max(Atabcolumn[i-1][j-1].Dvalue, rcost);
       i_dist = add_safe_max(Atabcolumn[i-1][j-1].Ivalue, rcost);
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
       Atabcolumn[i][j].Rvalue = minvalue;
       Atabcolumn[i][j].Redge = gt_linearalign_affinegapcost_set_edge(
                                                         r_dist, d_dist, i_dist);
@@ -176,7 +176,7 @@ static void diagonalband_fillDPtab_affine(GtAffinealignDPentry **Atabcolumn,
       d_dist = add_safe_max(Atabcolumn[i-1][j].Dvalue,gap_extension);
       i_dist = add_safe_max(Atabcolumn[i-1][j].Ivalue,
                           gap_extension+gap_opening);
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
       Atabcolumn[i][j].Dvalue = minvalue;
       Atabcolumn[i][j].Dedge = gt_linearalign_affinegapcost_set_edge(
                                                         r_dist, d_dist, i_dist);
@@ -232,7 +232,7 @@ GtWord gt_diagonalbandalign_affinegapcost_in_square_space_generic(
                                 vlen, left_dist, right_dist,
                                 Affine_X, Affine_X, scorehandler);
 
-  distance = MIN3(Atabcolumn[ulen][vlen].Rvalue,
+  distance = GT_MIN3(Atabcolumn[ulen][vlen].Rvalue,
                   Atabcolumn[ulen][vlen].Dvalue,
                   Atabcolumn[ulen][vlen].Ivalue);
 
@@ -294,8 +294,8 @@ GtWord gt_diagonalbandalign_affinegapcost_square_space_distance_only(
   GtAffinealignDPentry **Atabcolumn;
   gt_assert(scorehandler);
 
-   if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+   if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     return GT_WORD_MAX;
   }
@@ -305,7 +305,7 @@ GtWord gt_diagonalbandalign_affinegapcost_square_space_distance_only(
                                 vlen, left_dist, right_dist,
                                 Affine_X, Affine_X, scorehandler);
 
-  distance = MIN3(Atabcolumn[ulen][vlen].Rvalue,
+  distance = GT_MIN3(Atabcolumn[ulen][vlen].Rvalue,
                   Atabcolumn[ulen][vlen].Dvalue,
                   Atabcolumn[ulen][vlen].Ivalue);
 
@@ -457,8 +457,8 @@ static GtWord diagonalband_linear_affine(const GtUchar *useq,
   bool last_row = false;
   distance = GT_WORD_MAX;
 
-  if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+  if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     gt_assert(false);
   }
@@ -511,7 +511,7 @@ static GtWord diagonalband_linear_affine(const GtUchar *useq,
     d_dist = add_safe_max(westAffinealignDPentry.Dvalue,
                           gap_extension+gap_opening);
     i_dist = add_safe_max(westAffinealignDPentry.Ivalue,gap_extension);
-    minvalue = MIN3(r_dist, d_dist, i_dist);
+    minvalue = GT_MIN3(r_dist, d_dist, i_dist);
     Atabcolumn[0].Ivalue = minvalue;
     Atabcolumn[0].Rvalue = GT_WORD_MAX;
     Atabcolumn[0].Dvalue = GT_WORD_MAX;
@@ -524,7 +524,7 @@ static GtWord diagonalband_linear_affine(const GtUchar *useq,
       r_dist = add_safe_max(northwestAffinealignDPentry.Rvalue, rcost);
       d_dist = add_safe_max(northwestAffinealignDPentry.Dvalue, rcost);
       i_dist = add_safe_max(northwestAffinealignDPentry.Ivalue, rcost);
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
       Atabcolumn[0].Rvalue = minvalue;
     }
     for (rowindex = low_row + 1; rowindex <= high_row; rowindex++)
@@ -550,7 +550,7 @@ static GtWord diagonalband_linear_affine(const GtUchar *useq,
                             gap_extension+gap_opening);
       i_dist = add_safe_max(westAffinealignDPentry.Ivalue,gap_extension);
 
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
       Atabcolumn[rowindex-low_row].Ivalue = minvalue;
 
       rcost = gt_scorehandler_get_replacement(scorehandler,
@@ -560,7 +560,7 @@ static GtWord diagonalband_linear_affine(const GtUchar *useq,
       d_dist = add_safe_max(northwestAffinealignDPentry.Dvalue, rcost);
       i_dist = add_safe_max(northwestAffinealignDPentry.Ivalue, rcost);
 
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
       Atabcolumn[rowindex-low_row].Rvalue = minvalue;
 
       r_dist = add_safe_max(Atabcolumn[rowindex-low_row-1].Rvalue,
@@ -570,12 +570,12 @@ static GtWord diagonalband_linear_affine(const GtUchar *useq,
       i_dist = add_safe_max(Atabcolumn[rowindex-low_row-1].Ivalue,
                            gap_extension+gap_opening);
 
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
       Atabcolumn[rowindex-low_row].Dvalue = minvalue;
     }
   }
 
-  distance = MIN3(Atabcolumn[high_row-low_row].Rvalue,
+  distance = GT_MIN3(Atabcolumn[high_row-low_row].Rvalue,
                   Atabcolumn[high_row-low_row].Dvalue,
                   Atabcolumn[high_row-low_row].Ivalue);
   gt_free(Atabcolumn);
@@ -776,8 +776,8 @@ static GtAffineAlignRnode evaluateallaffineDBcolumns(
   GtAffineAlignRtabentry *Rtabcolumn, northwestRtabentry, westRtabentry = {{0}};
   GtAffineAlignRnode lastcpoint = {GT_UWORD_MAX, Affine_X};
 
-  if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+  if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     gt_assert(false);
   }
@@ -834,7 +834,7 @@ static GtAffineAlignRnode evaluateallaffineDBcolumns(
                           gap_extension + gap_opening);
     i_dist = add_safe_max(westAffinealignDPentry.Ivalue, gap_extension);
 
-    minvalue = MIN3(r_dist, d_dist, i_dist);
+    minvalue = GT_MIN3(r_dist, d_dist, i_dist);
     Atabcolumn[0].Ivalue = minvalue;
     Atabcolumn[0].Rvalue = GT_WORD_MAX;
     Atabcolumn[0].Dvalue = GT_WORD_MAX;
@@ -869,7 +869,7 @@ static GtAffineAlignRnode evaluateallaffineDBcolumns(
       d_dist = add_safe_max(northwestAffinealignDPentry.Dvalue, rcost);
       i_dist = add_safe_max(northwestAffinealignDPentry.Ivalue, rcost);
 
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
       Atabcolumn[0].Rvalue = minvalue;
 
       if (diag == (GtWord)colindex - (GtWord)low_row)
@@ -919,7 +919,7 @@ static GtAffineAlignRnode evaluateallaffineDBcolumns(
                             gap_extension+gap_opening);
       i_dist = add_safe_max(westAffinealignDPentry.Ivalue,gap_extension);
 
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
       Atabcolumn[rowindex-low_row].Ivalue = minvalue;
       if (diag == (GtWord)colindex - (GtWord)rowindex)
       {
@@ -942,7 +942,7 @@ static GtAffineAlignRnode evaluateallaffineDBcolumns(
       r_dist = add_safe_max(northwestAffinealignDPentry.Rvalue, rcost);
       d_dist = add_safe_max(northwestAffinealignDPentry.Dvalue, rcost);
       i_dist = add_safe_max(northwestAffinealignDPentry.Ivalue, rcost);
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
 
       Atabcolumn[rowindex-low_row].Rvalue = minvalue;
       if (diag == (GtWord)colindex - (GtWord)rowindex)
@@ -967,7 +967,7 @@ static GtAffineAlignRnode evaluateallaffineDBcolumns(
       i_dist = add_safe_max(Atabcolumn[rowindex-low_row-1].Ivalue,
                            gap_extension+gap_opening);
 
-      minvalue = MIN3(r_dist, d_dist, i_dist);
+      minvalue = GT_MIN3(r_dist, d_dist, i_dist);
       Atabcolumn[rowindex-low_row].Dvalue = minvalue;
 
       if (diag == (GtWord)colindex - (GtWord)rowindex)
@@ -1007,7 +1007,7 @@ static GtAffineAlignRnode evaluateallaffineDBcolumns(
       break;
   }
 
-  minvalue = MIN3(r_dist, d_dist, i_dist);
+  minvalue = GT_MIN3(r_dist, d_dist, i_dist);
   if (minvalue == r_dist)
     lastcpoint = Rtabcolumn[high_row-low_row].val_R;
   else if (minvalue == i_dist)
@@ -1190,7 +1190,7 @@ static GtAffineAlignRnode evaluateaffineDBcrosspoints(
     {
       new_ulen = ulen - (row_start+1-rowoffset);
       new_vlen = vlen-col_start;
-      new_left = MAX((GtWord)left_dist-diag+1,
+      new_left = GT_MAX((GtWord)left_dist-diag+1,
                     -(GtWord)new_ulen);
       new_right = 0;
       temp_entry = Diagcolumn[col_start];
@@ -1212,7 +1212,7 @@ static GtAffineAlignRnode evaluateaffineDBcrosspoints(
       new_ulen = ulen - (row_start - rowoffset);
       new_vlen = vlen-col_start-1;
       new_left = -1;
-      new_right = MIN((GtWord)right_dist-((GtWord)diag)-1,new_vlen);
+      new_right = GT_MIN((GtWord)right_dist-((GtWord)diag)-1,new_vlen);
 
       lastrpoint = evaluateaffineDBcrosspoints(spacemanager,
                             Diagcolumn+col_start+1,scorehandler, Affine_I,
@@ -1259,7 +1259,7 @@ static GtAffineAlignRnode evaluateaffineDBcrosspoints(
       new_ulen = row_end - row_start - 1;
       new_vlen = col_end-col_start-1;
       new_left = -1;
-      new_right = MIN(right_dist-diag-1,new_vlen);
+      new_right = GT_MIN(right_dist-diag-1,new_vlen);
 
       temprpoint = evaluateaffineDBcrosspoints(spacemanager,
                            Diagcolumn+col_start+1, scorehandler,
@@ -1283,7 +1283,7 @@ static GtAffineAlignRnode evaluateaffineDBcrosspoints(
     else if (prevcp_type == Affine_I)
     {
       new_ulen = row_end - row_start-1;
-      new_left = MAX(left_dist-diag+1,
+      new_left = GT_MAX(left_dist-diag+1,
                         -(GtWord)new_ulen);
       new_right = 0;
       temp_entry = Diagcolumn[col_start];
@@ -1316,8 +1316,8 @@ static GtAffineAlignRnode evaluateaffineDBcrosspoints(
       if (row_end == ustart-1)
          gt_assert(false);
        new_ulen = row_end-ustart-1;
-       new_left =  MAX(-new_ulen, diag);
-       new_right = MIN(right_dist, (GtWord)col_end);
+       new_left =  GT_MAX(-new_ulen, diag);
+       new_right = GT_MIN(right_dist, (GtWord)col_end);
 
        rpoint = evaluateaffineDBcrosspoints(spacemanager, Diagcolumn,
                                         scorehandler, edge, from_edge,Affine_D,
@@ -1336,10 +1336,10 @@ static GtAffineAlignRnode evaluateaffineDBcrosspoints(
      case Affine_I:
        new_ulen = row_end-ustart;
        new_vlen = col_end-1;
-       new_left = MAX(left_dist,
+       new_left = GT_MAX(left_dist,
                  -(GtWord)new_ulen);
 
-       new_right = MIN(diag,new_vlen);
+       new_right = GT_MIN(diag,new_vlen);
        rpoint = evaluateaffineDBcrosspoints(spacemanager, Diagcolumn,
                                scorehandler,edge, from_edge, Affine_I,rowoffset,
                                coloffset, useq, ustart, new_ulen, vseq, vstart,
@@ -1381,8 +1381,8 @@ static void gt_calc_diagonalbandaffinealign(GtLinspaceManagement *spacemanager,
   GtUword idx, gap_extension;
   gt_assert(align && scorehandler);
 
-  if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-      (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+  if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+      (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
   {
     gt_assert(false); /* no global alignment */
   }
@@ -1415,7 +1415,7 @@ static void gt_calc_diagonalbandaffinealign(GtLinspaceManagement *spacemanager,
                                                          left_dist, right_dist);
     return;
   }
-  gt_linspace_management_check(spacemanager, MIN(right_dist-left_dist,ulen),
+  gt_linspace_management_check(spacemanager, GT_MIN(right_dist-left_dist,ulen),
                                vlen, sizeof (*Atabcolumn), sizeof (*Rtabcolumn),
                                sizeof (*Diagcolumn));
   Diagcolumn = gt_linspace_management_get_crosspointTabspace(spacemanager);
@@ -1458,8 +1458,8 @@ void gt_diagonalbandalign_affinegapcost_compute_generic(GtLinspaceManagement
   gt_assert(useq  && vseq && spacemanager && scorehandler && align);
 
   /* set new bounds, if left_dist or right_dist is out of sequence */
-  left_dist = MAX(-(GtWord) ulen,left_dist);
-  right_dist = MIN((GtWord) vlen,right_dist);
+  left_dist = GT_MAX(-(GtWord) ulen,left_dist);
+  right_dist = GT_MIN((GtWord) vlen,right_dist);
   gt_alignment_set_seqs(align, useq+ustart, ulen, vseq+vstart, vlen);
   gt_calc_diagonalbandaffinealign(spacemanager, scorehandler, align,
                                              useq, ustart, ulen,

--- a/src/extended/editscript.c
+++ b/src/extended/editscript.c
@@ -586,7 +586,7 @@ GtUword gt_editscript_get_sub_sequence_u(const GtEditscript *editscript,
               (mismatch_or_deletion && uidx == ufrompos)) {
             (*buffer)[bufidx++] =
               (elem == (GtBitsequence) editscript->del - 1) ?
-              (GtUchar) WILDCARD :
+              (GtUchar) GT_WILDCARD :
               (GtUchar) elem;
             if (bufidx == *bufsize) {
               *bufsize += GT_MULT2(start + utopos - uidx);
@@ -660,7 +660,7 @@ GtUword gt_editscript_get_sub_sequence_v(const GtEditscript *editscript,
           if (vidx >= vfrompos) {
             buffer[bufidx++] =
               (elem == (GtBitsequence) editscript->del - 1) ?
-              (GtUchar) WILDCARD :
+              (GtUchar) GT_WILDCARD :
               (GtUchar) elem;
           }
           vidx++;
@@ -795,7 +795,7 @@ void gt_editscript_show(const GtEditscript *editscript, GtAlphabet *alphabet)
             break;
           }
           elem = (elem == (GtBitsequence) editscript->del - 1) ?
-            (GtBitsequence) WILDCARD :
+            (GtBitsequence) GT_WILDCARD :
             elem;
           printf("%c|", (int) gt_alphabet_pretty_symbol(alphabet,
                                                         (uint32_t) elem));
@@ -817,7 +817,7 @@ void gt_editscript_show(const GtEditscript *editscript, GtAlphabet *alphabet)
           }
           if (elem < (GtBitsequence) editscript->del) {
             elem = (elem == (GtBitsequence) editscript->del - 1) ?
-              (GtBitsequence) WILDCARD :
+              (GtBitsequence) GT_WILDCARD :
               elem;
             printf("%c|", (int) gt_alphabet_pretty_symbol(alphabet,
                                                           (uint32_t) elem));
@@ -881,8 +881,8 @@ void gt_editscript_builder_add_mismatch(GtEditscriptBuilder *es_builder,
   GtEditscript *es;
   gt_assert(es_builder != NULL);
   es = es_builder->es;
-  gt_assert(c <= (GtUchar) es->del || c == (GtUchar) WILDCARD);
-  if (c == (GtUchar) WILDCARD) {
+  gt_assert(c <= (GtUchar) es->del || c == (GtUchar) GT_WILDCARD);
+  if (c == (GtUchar) GT_WILDCARD) {
     c = (GtUchar) es->del - 1;
   }
   if (es_builder->last_op != (uint8_t) GT_EDITSCRIPT_MISDEL_SYM(es)) {
@@ -904,8 +904,8 @@ void gt_editscript_builder_add_insertion(GtEditscriptBuilder *es_builder,
   gt_assert(es_builder);
   es = es_builder->es;
 
-  gt_assert(c < (GtUchar) es->del || c == (GtUchar) WILDCARD);
-  if (c == (GtUchar) WILDCARD) {
+  gt_assert(c < (GtUchar) es->del || c == (GtUchar) GT_WILDCARD);
+  if (c == (GtUchar) GT_WILDCARD) {
     c = (GtUchar) es->del - 1;
   }
   if (es_builder->last_op != (uint8_t) GT_EDITSCRIPT_INS_SYM(es)) {

--- a/src/extended/feature_index_memory.c
+++ b/src/extended/feature_index_memory.c
@@ -129,8 +129,8 @@ int gt_feature_index_memory_add_feature_node(GtFeatureIndex *gfi,
   new_node = gt_interval_tree_node_new(gn, node_range.start, node_range.end);
   gt_interval_tree_insert(info->features, new_node);
   /* update dynamic range */
-  info->dyn_range.start = MIN(info->dyn_range.start, node_range.start);
-  info->dyn_range.end = MAX(info->dyn_range.end, node_range.end);
+  info->dyn_range.start = GT_MIN(info->dyn_range.start, node_range.start);
+  info->dyn_range.end = GT_MAX(info->dyn_range.end, node_range.end);
   return 0;
 }
 

--- a/src/extended/gff3_linesorted_out_stream.c
+++ b/src/extended/gff3_linesorted_out_stream.c
@@ -70,9 +70,9 @@ static inline void gt_linesorted_gff3_next_token_pair(const char **s1,
   gt_assert(tokend1 && tokend1 > *s1);
   tokend2 = strchr(*s2, sep);
   gt_assert(tokend2 && tokend2 > *s2);
-  idlength1 = MIN((tokend1 - *s1), len1 - 1);
+  idlength1 = GT_MIN((tokend1 - *s1), len1 - 1);
   gt_assert(idlength1 > 0);
-  idlength2 = MIN((tokend2 - *s2), len2 - 1);
+  idlength2 = GT_MIN((tokend2 - *s2), len2 - 1);
   gt_assert(idlength2 > 0);
   (void) strncpy(buf1, *s1, idlength1);
   (void) strncpy(buf2, *s2, idlength2);

--- a/src/extended/hcr.c
+++ b/src/extended/hcr.c
@@ -207,7 +207,7 @@ static GtBaseQualDistr* hcr_base_qual_distr_new_from_file(FILE *fp,
     read = gt_xfread_one(&cur_freq, fp);
     gt_assert(read == one);
     cur_char_code = gt_alphabet_encode(alpha, read_char_code);
-    if (cur_char_code == (GtUchar) WILDCARD)
+    if (cur_char_code == (GtUchar) GT_WILDCARD)
       gt_safe_assign(cur_char_code, bqd->wildcard_indx);
     bqd->distr[cur_qual][cur_char_code] = cur_freq;
     if ((unsigned) cur_qual > max_qual)
@@ -264,7 +264,7 @@ static int hcr_base_qual_distr_add(GtBaseQualDistr *bqd, const GtUchar *qual,
       if (cur_qual >= bqd->qrange_end)
         cur_qual = bqd->qrange_end;
     }
-    if (cur_char_code == WILDCARD)
+    if (cur_char_code == GT_WILDCARD)
       bqd->distr[cur_qual][bqd->wildcard_indx]++;
     else
       bqd->distr[cur_qual][cur_char_code]++;
@@ -317,7 +317,7 @@ static GtUword hcr_write_seq(GtHcrSeqEncoder *seq_encoder,
   for (i = 0; i < len; i++) {
     cur_char_code = (unsigned) seq[i];
 
-    if (cur_char_code == WILDCARD)
+    if (cur_char_code == GT_WILDCARD)
       cur_char_code = gt_alphabet_size(seq_encoder->alpha) - 1;
 
     cur_qual = (unsigned) qual[i];
@@ -476,7 +476,7 @@ static int hcr_huffman_write_base_qual_freq(GtUword symbol,
 
   gt_safe_assign(base, (symbol % gt_alphabet_size(info->alpha)));
   if (base == (GtUchar) gt_alphabet_size(info->alpha) - 1)
-    base = (GtUchar) WILDCARD;
+    base = (GtUchar) GT_WILDCARD;
   gt_safe_assign(base, (toupper(gt_alphabet_decode(info->alpha, base))));
 
   gt_xfwrite_one(&base, info->output);
@@ -872,7 +872,7 @@ static unsigned char get_base_from_symbol(GtHcrSeqDecoder *seq_dec,
 {
   unsigned char base = (unsigned char) symbol % seq_dec->alphabet_size;
   if (base == (unsigned char) seq_dec->alphabet_size)
-    return (unsigned char) WILDCARD;
+    return (unsigned char) GT_WILDCARD;
   return base;
 }
 

--- a/src/extended/hmm.c
+++ b/src/extended/hmm.c
@@ -172,7 +172,8 @@ void gt_hmm_set_emission_probability(GtHMM *hmm,
   gt_assert(hmm);
   gt_assert(probability >= 0.0 && probability <= 1.0);
   gt_assert(state_num < hmm->num_of_states);
-  symbol_num = (symbol_num == GT_WILDCARD) ? hmm->num_of_symbols - 1 : symbol_num;
+  symbol_num = (symbol_num == GT_WILDCARD) ? hmm->num_of_symbols - 1
+                                           : symbol_num;
   gt_assert(symbol_num < hmm->num_of_symbols);
   if (probability == 0.0)
     hmm->emission_prob[state_num][symbol_num] = MINUSINFINITY;
@@ -186,7 +187,8 @@ double gt_hmm_get_emission_probability(const GtHMM *hmm,
 {
   gt_assert(hmm);
   gt_assert(state_num < hmm->num_of_states);
-  symbol_num = (symbol_num == GT_WILDCARD) ? hmm->num_of_symbols - 1 : symbol_num;
+  symbol_num = (symbol_num == GT_WILDCARD) ? hmm->num_of_symbols - 1
+                                           : symbol_num;
   gt_assert(symbol_num < hmm->num_of_symbols);
   if (hmm->emission_prob[state_num][symbol_num] == MINUSINFINITY)
     return 0.0;

--- a/src/extended/hmm.c
+++ b/src/extended/hmm.c
@@ -172,7 +172,7 @@ void gt_hmm_set_emission_probability(GtHMM *hmm,
   gt_assert(hmm);
   gt_assert(probability >= 0.0 && probability <= 1.0);
   gt_assert(state_num < hmm->num_of_states);
-  symbol_num = (symbol_num == WILDCARD) ? hmm->num_of_symbols - 1 : symbol_num;
+  symbol_num = (symbol_num == GT_WILDCARD) ? hmm->num_of_symbols - 1 : symbol_num;
   gt_assert(symbol_num < hmm->num_of_symbols);
   if (probability == 0.0)
     hmm->emission_prob[state_num][symbol_num] = MINUSINFINITY;
@@ -186,7 +186,7 @@ double gt_hmm_get_emission_probability(const GtHMM *hmm,
 {
   gt_assert(hmm);
   gt_assert(state_num < hmm->num_of_states);
-  symbol_num = (symbol_num == WILDCARD) ? hmm->num_of_symbols - 1 : symbol_num;
+  symbol_num = (symbol_num == GT_WILDCARD) ? hmm->num_of_symbols - 1 : symbol_num;
   gt_assert(symbol_num < hmm->num_of_symbols);
   if (hmm->emission_prob[state_num][symbol_num] == MINUSINFINITY)
     return 0.0;
@@ -319,7 +319,7 @@ void gt_hmm_decode(const GtHMM *hmm,
 
   /* fill DP table */
   for (row = 0; row < num_of_rows; row++) { /* first column */
-    if (emissions[0] == WILDCARD)
+    if (emissions[0] == GT_WILDCARD)
       emission = hmm->num_of_symbols - 1;
     else
       emission = emissions[0];
@@ -330,7 +330,7 @@ void gt_hmm_decode(const GtHMM *hmm,
   }
 
   for (column = 1; column < num_of_columns; column++) { /* other columns */
-    if (emissions[column] == WILDCARD)
+    if (emissions[column] == GT_WILDCARD)
       emission = hmm->num_of_symbols - 1;
     else
       emission = emissions[column];

--- a/src/extended/hpol_processor.c
+++ b/src/extended/hpol_processor.c
@@ -682,12 +682,12 @@ static bool gt_hpol_processor_adjust_hlen_of_a_segment(GtAlignedSegment *as,
         if (output_stats)
         {
           gt_hpol_processor_output_stats(as, r_hstart, coverage, r_hlen, r_supp,
-              s_hlen, a_hlen, a_supp, c, q_ave, MIN(s_free, hlen_diff),
+              s_hlen, a_hlen, a_supp, c, q_ave, GT_MIN(s_free, hlen_diff),
               outfp_stats);
         }
         gt_aligned_segment_seq_set_edited(as);
         gt_hpol_processor_enlarge_hpol(s, q, left, right,
-            MIN(s_free, hlen_diff), c, (char)(q_sum / s_hlen));
+            GT_MIN(s_free, hlen_diff), c, (char)(q_sum / s_hlen));
         edited = true;
       }
     }
@@ -784,7 +784,7 @@ static void gt_hpol_processor_determine_alternative_consensus(
     s = gt_aligned_segment_seq(as);
     s_hlen = gt_hpol_processor_determine_hlen_forwards(s, NULL, left, right, c,
         NULL, NULL);
-    occ[MIN(s_hlen, s_hlen_max)]++;
+    occ[GT_MIN(s_hlen, s_hlen_max)]++;
   }
   *r_hlen_support = occ[r_hlen];
   *c_s_hlen = 0;

--- a/src/extended/linearalign.c
+++ b/src/extended/linearalign.c
@@ -518,11 +518,11 @@ static GtUword gt_calc_linearedist(bool downcase,
 
   printf("%s(%*.*s,%*.*s)\n",__func__,(int) ulen,(int) ulen,(char *) useq,
                              (int) vlen,(int) vlen,(char *) vseq);
-  dpcolumn = gt_malloc(sizeof *dpcolumn * (MIN(ulen,vlen) + 1));
+  dpcolumn = gt_malloc(sizeof *dpcolumn * (GT_MIN(ulen,vlen) + 1));
   fillDPtable_unitcost(downcase,dpcolumn,
-                       ulen <= vlen ? useq : vseq, MIN(ulen,vlen),
-                       ulen <= vlen ? vseq : useq, MAX(ulen,vlen));
-  edist = dpcolumn[MIN(ulen,vlen)];
+                       ulen <= vlen ? useq : vseq, GT_MIN(ulen,vlen),
+                       ulen <= vlen ? vseq : useq, GT_MAX(ulen,vlen));
+  edist = dpcolumn[GT_MIN(ulen,vlen)];
   gt_free(dpcolumn);
   return edist;
 }

--- a/src/extended/linearalign_affinegapcost.c
+++ b/src/extended/linearalign_affinegapcost.c
@@ -42,7 +42,7 @@ GtAffineAlignEdge gt_linearalign_affinegapcost_set_edge(GtWord Rdist,
                                                         GtWord Ddist,
                                                         GtWord Idist)
 {
-  GtUword minvalue = MIN3(Rdist, Ddist, Idist);
+  GtUword minvalue = GT_MIN3(Rdist, Ddist, Idist);
 
   if (Rdist == minvalue)
     return Affine_R;
@@ -127,7 +127,7 @@ static void firstAtabRtabcolumn(GtAffinealignDPentry *Atabcolumn,
     ddist = add_safe_max(Atabcolumn[rowindex-1].Dvalue, gap_extension);
     idist = add_safe_max(Atabcolumn[rowindex-1].Dvalue,
                          gap_opening + gap_extension);
-    Atabcolumn[rowindex].Dvalue = MIN3(rdist, ddist, idist);
+    Atabcolumn[rowindex].Dvalue = GT_MIN3(rdist, ddist, idist);
     Atabcolumn[rowindex].Ivalue = GT_WORD_MAX;
 
     Atabcolumn[rowindex].Redge = Affine_X;
@@ -171,7 +171,7 @@ static void nextAtabRtabcolumn(GtAffinealignDPentry *Atabcolumn,
   ddist = add_safe_max(Atabcolumn[0].Dvalue, gap_extension + gap_opening);
   idist = add_safe_max(Atabcolumn[0].Ivalue, gap_extension);
 
-  minvalue = MIN3(rdist, ddist, idist);
+  minvalue = GT_MIN3(rdist, ddist, idist);
   Atabcolumn[0].Ivalue = minvalue;
   Atabcolumn[0].Rvalue = GT_WORD_MAX;
   Atabcolumn[0].Dvalue = GT_WORD_MAX;
@@ -204,7 +204,7 @@ static void nextAtabRtabcolumn(GtAffinealignDPentry *Atabcolumn,
     ddist = add_safe_max(northwestAffinealignDPentry.Dvalue, rcost);
     idist = add_safe_max(northwestAffinealignDPentry.Ivalue, rcost);
 
-    minvalue = MIN3(rdist, ddist, idist);
+    minvalue = GT_MIN3(rdist, ddist, idist);
     Atabcolumn[rowindex].Rvalue = minvalue;
     Atabcolumn[rowindex].Redge = gt_linearalign_affinegapcost_set_edge(rdist,
                                                                        ddist,
@@ -216,7 +216,7 @@ static void nextAtabRtabcolumn(GtAffinealignDPentry *Atabcolumn,
     idist = add_safe_max(Atabcolumn[rowindex-1].Ivalue,
                          gap_extension + gap_opening);
 
-    minvalue = MIN3(rdist, ddist, idist);
+    minvalue = GT_MIN3(rdist, ddist, idist);
     Atabcolumn[rowindex].Dvalue = minvalue;
     Atabcolumn[rowindex].Dedge = gt_linearalign_affinegapcost_set_edge(rdist,
                                                                        ddist,
@@ -228,7 +228,7 @@ static void nextAtabRtabcolumn(GtAffinealignDPentry *Atabcolumn,
                          gap_extension + gap_opening);
     idist = add_safe_max(westAffinealignDPentry.Ivalue, gap_extension);
 
-    minvalue = MIN3(rdist, ddist, idist);
+    minvalue = GT_MIN3(rdist, ddist, idist);
     Atabcolumn[rowindex].Ivalue = minvalue;
     Atabcolumn[rowindex].Iedge = gt_linearalign_affinegapcost_set_edge(rdist,
                                                                        ddist,
@@ -279,7 +279,7 @@ static GtUword evaluateallAtabRtabcolumns(GtAffinealignDPentry *Atabcolumn,
                        colindex);
   }
 
-  return MIN3(Atabcolumn[ulen].Rvalue,
+  return GT_MIN3(Atabcolumn[ulen].Rvalue,
               Atabcolumn[ulen].Dvalue,
               Atabcolumn[ulen].Ivalue);
 }
@@ -848,7 +848,7 @@ static void nextAStabcolumn(GtAffinealignDPentry *Atabcolumn,
   Atabcolumn[0].Rvalue = GT_WORD_MIN;
   Atabcolumn[0].Dvalue = GT_WORD_MIN;
   Atabcolumn[0].Ivalue = (gap_opening + gap_extension);
-  temp = MAX3(Atabcolumn[0].Rvalue,
+  temp = GT_MAX3(Atabcolumn[0].Rvalue,
               Atabcolumn[0].Dvalue,
               Atabcolumn[0].Ivalue);
   Atabcolumn[0].totalvalue = ((temp > 0)? temp : 0);
@@ -893,7 +893,7 @@ static void nextAStabcolumn(GtAffinealignDPentry *Atabcolumn,
     val1 = add_safe_min(Atabcolumn[rowindex-1].Dvalue, gap_extension);
     val2 = add_safe_min(Atabcolumn[rowindex-1].totalvalue,
                        (gap_opening+gap_extension));
-    Atabcolumn[rowindex].Dvalue = MAX(val1,val2);
+    Atabcolumn[rowindex].Dvalue = GT_MAX(val1,val2);
     Starttabcolumn[rowindex].Dstart =
     setStarttabentry(Atabcolumn[rowindex].Dvalue, &Atabcolumn[rowindex-1],
                      &Starttabcolumn[rowindex-1], replacement, gap_opening,
@@ -903,13 +903,13 @@ static void nextAStabcolumn(GtAffinealignDPentry *Atabcolumn,
     val1=(add_safe_min(westAffinealignDPentry.Ivalue,gap_extension));
     val2=(add_safe_min(westAffinealignDPentry.totalvalue,
                               gap_opening+gap_extension));
-    Atabcolumn[rowindex].Ivalue = MAX(val1,val2);
+    Atabcolumn[rowindex].Ivalue = GT_MAX(val1,val2);
     Starttabcolumn[rowindex].Istart =
     setStarttabentry(Atabcolumn[rowindex].Ivalue, &westAffinealignDPentry, &Swe,
                      replacement, gap_opening, gap_extension, Affine_I);
 
     /*calculate totalvalue*/
-    temp = MAX3(Atabcolumn[rowindex].Rvalue,
+    temp = GT_MAX3(Atabcolumn[rowindex].Rvalue,
                 Atabcolumn[rowindex].Dvalue,
                 Atabcolumn[rowindex].Ivalue);
     Atabcolumn[rowindex].totalvalue = temp > 0 ? temp : 0;

--- a/src/extended/rcr.c
+++ b/src/extended/rcr.c
@@ -187,7 +187,7 @@ static inline GtUchar rcr_bambase2gtbase(uint8_t base, GtAlphabet *alpha)
 {
   switch (base) {
     case BAMBASEN:
-      return (GtUchar) WILDCARD;
+      return (GtUchar) GT_WILDCARD;
     default:
       return gt_alphabet_encode(alpha, rcr_bambase2char(base));
   }
@@ -201,7 +201,7 @@ static GtBitsequence rcr_transencode(GtUchar ref, GtUchar base,
           code_g = gt_alphabet_encode(alpha, 'G'),
           code_t = gt_alphabet_encode(alpha, 'T');
 
-  if (base == (GtUchar) WILDCARD)
+  if (base == (GtUchar) GT_WILDCARD)
     return (GtBitsequence) 3;
 
   if (ref == code_a) {
@@ -236,7 +236,7 @@ static GtBitsequence rcr_transencode(GtUchar ref, GtUchar base,
     if (base == code_g)
       return (GtBitsequence) 2;
   }
-  if (ref == (GtUchar) WILDCARD) {
+  if (ref == (GtUchar) GT_WILDCARD) {
     if (base == code_a)
       return (GtBitsequence) 0;
     if (base == code_c)
@@ -257,7 +257,7 @@ static GtUchar rcr_transdecode(GtUchar ref, GtBitsequence transcode,
           code_g = gt_alphabet_encode(alpha, 'G'),
           code_t = gt_alphabet_encode(alpha, 'T');
 
-  if (ref == (GtUchar) WILDCARD) {
+  if (ref == (GtUchar) GT_WILDCARD) {
     switch (transcode) {
        case 0:
          return code_a;
@@ -270,7 +270,7 @@ static GtUchar rcr_transdecode(GtUchar ref, GtBitsequence transcode,
     }
   }
   else if (transcode == (GtBitsequence) 3)
-    return (GtUchar) WILDCARD;
+    return (GtUchar) GT_WILDCARD;
   else {
     if (ref == code_a) {
       switch (transcode) {
@@ -615,7 +615,7 @@ static int rcr_write_read_encoding(const bam1_t *alignment,
             /* use alphabet_size - 1 as wildcard symbol */
             /* TODO DW change this, it doesn't matter if wildcard is in a
                continuous range with the rest */
-            if (base == (GtUchar) WILDCARD)
+            if (base == (GtUchar) GT_WILDCARD)
               base = (GtUchar) (alpha_size - 1);
 
             rcr_huff_encode_write(rcr_enc, rcr_enc->bases_huff,
@@ -1696,7 +1696,7 @@ static int rcr_decode_insert_var(GtRcrDecoder *rcr_dec,
   had_err = rcr_huff_read(info->base_hbwd, bitstream, &symbol, err);
   while (!had_err && symbol != info->alpha_size) {
     if (symbol == (info->alpha_size - 1)) {
-      base = (GtUchar) WILDCARD;
+      base = (GtUchar) GT_WILDCARD;
     }
     else
       base = (GtUchar) symbol;

--- a/src/extended/rdb_mysql.c
+++ b/src/extended/rdb_mysql.c
@@ -191,7 +191,7 @@ static GtCstrTable* gt_rdb_mysql_get_tables(GtRDB *rdb, GtError *err)
     GtUword *lengths;
     memset(buf, 0, BUFSIZ);
     lengths = mysql_fetch_lengths(res);
-    (void) snprintf(buf, MIN(BUFSIZ, lengths[0])*sizeof (char), "%s",
+    (void) snprintf(buf, GT_MIN(BUFSIZ, lengths[0])*sizeof (char), "%s",
                     (char*) row[0] ? (char*) row[0] : "NULL");
     gt_cstr_table_add(tab, buf);
   }

--- a/src/extended/regioncov_visitor.c
+++ b/src/extended/regioncov_visitor.c
@@ -62,7 +62,7 @@ static int gt_regioncov_visitor_feature_node(GtNodeVisitor *nv,
     old_range = *old_range_ptr;
     old_range.end += regioncov_visitor->max_feature_dist;
     if (gt_range_overlap(&old_range, &new_range)) {
-      old_range_ptr->end = MAX(old_range_ptr->end, new_range.end);
+      old_range_ptr->end = GT_MAX(old_range_ptr->end, new_range.end);
     }
     else
       gt_array_add(ranges, new_range);

--- a/src/extended/scorehandler.c
+++ b/src/extended/scorehandler.c
@@ -134,9 +134,9 @@ GtScoreHandler *gt_scorehandler2costhandler(const GtScoreHandler *scorehandler)
   if (scorehandler->scorematrix == NULL)
   {
     GtWord matchscore, mismatchscore, gap_extension, gap_opening,
-           maxscore = MAX(MAX(GT_DIV2(scorehandler->matchscore+1),
+           maxscore = GT_MAX(GT_MAX(GT_DIV2(scorehandler->matchscore+1),
                          GT_DIV2(scorehandler->mismatchscore+1)),
-                     MAX(1 + scorehandler->gap_extension,0));
+                     GT_MAX(1 + scorehandler->gap_extension,0));
 
     matchscore = 2 * maxscore - scorehandler->matchscore;
     mismatchscore = 2 * maxscore - scorehandler->mismatchscore;
@@ -171,7 +171,7 @@ GtScoreHandler *gt_scorehandler2costhandler(const GtScoreHandler *scorehandler)
         }
       }
     }
-    maxscore = MAX(GT_DIV2(maxscore+1), 1 + scorehandler->gap_extension);
+    maxscore = GT_MAX(GT_DIV2(maxscore+1), 1 + scorehandler->gap_extension);
     for (i = 0; i < dim; i++)
     {
       for (j = 0; j < dim; j++)

--- a/src/extended/scorehandler.c
+++ b/src/extended/scorehandler.c
@@ -110,7 +110,7 @@ GtWord gt_scorehandler_get_replacement(const GtScoreHandler *scorehandler,
   {
     if (scorehandler->mappedsequence)
     {
-      return ISSPECIAL(a) || ISSPECIAL(b) || a != b
+      return GT_ISSPECIAL(a) || GT_ISSPECIAL(b) || a != b
                ? scorehandler->mismatchscore
                : scorehandler->matchscore;
     }

--- a/src/extended/select_visitor.c
+++ b/src/extended/select_visitor.c
@@ -302,8 +302,8 @@ static int select_visitor_region_node(GtNodeVisitor *nv, GtRegionNode *rn,
       GtRange range = gt_genome_node_get_range((GtGenomeNode*) rn);
       if (gt_range_overlap(&range, &select_visitor->contain_range)) {
         /* an overlapping contain range was defined -> update range  */
-        range.start = MAX(range.start, select_visitor->contain_range.start);
-        range.end = MIN(range.end, select_visitor->contain_range.end);
+        range.start = GT_MAX(range.start, select_visitor->contain_range.start);
+        range.end = GT_MIN(range.end, select_visitor->contain_range.end);
         gt_genome_node_set_range((GtGenomeNode*) rn, &range);
         gt_queue_add(select_visitor->node_buffer, rn);
       }

--- a/src/extended/squarealign.c
+++ b/src/extended/squarealign.c
@@ -278,7 +278,7 @@ static GtWord fillDPtab_in_square_space_local(GtWord **Ltabcolumn,
         {
           Ltabcolumn[i][j] = val;
         }
-        Ltabcolumn[i][j] = MAX(Ltabcolumn[i][j],0);
+        Ltabcolumn[i][j] = GT_MAX(Ltabcolumn[i][j],0);
         maxscore = Ltabcolumn[i][j];
 
         if (maxscore > (GtWord) overall_maxscore)

--- a/src/extended/swalign.c
+++ b/src/extended/swalign.c
@@ -51,8 +51,8 @@ static void swalign_fill_table(DPentry **dptable,
   for (j = 1; j <= vlen; j++) {
     for (i = 1; i <= ulen; i++) {
       int uval, vval;
-      uval = (int) ((u[i-1] == WILDCARD) ? u_alpha_size - 1 : u[i-1]);
-      vval = (int) ((v[j-1] == WILDCARD) ? v_alpha_size - 1 : v[j-1]);
+      uval = (int) ((u[i-1] == GT_WILDCARD) ? u_alpha_size - 1 : u[i-1]);
+      vval = (int) ((v[j-1] == GT_WILDCARD) ? v_alpha_size - 1 : v[j-1]);
       repscore = dptable[i-1][j-1].score + scores[uval][vval];
       delscore = dptable[i-1][j].score + deletion_score;
       insscore = dptable[i][j-1].score + insertion_score;

--- a/src/extended/swalign.c
+++ b/src/extended/swalign.c
@@ -56,7 +56,7 @@ static void swalign_fill_table(DPentry **dptable,
       repscore = dptable[i-1][j-1].score + scores[uval][vval];
       delscore = dptable[i-1][j].score + deletion_score;
       insscore = dptable[i][j-1].score + insertion_score;
-      maxscore = MAX(MAX(MAX(repscore, delscore), insscore), 0);
+      maxscore = GT_MAX(GT_MAX(GT_MAX(repscore, delscore), insscore), 0);
       dptable[i][j].score = maxscore;
       dptable[i][j].max_replacement = (maxscore == repscore) ? true : false;
       dptable[i][j].max_deletion    = (maxscore == delscore) ? true : false;

--- a/src/extended/tir_stream.c
+++ b/src/extended/tir_stream.c
@@ -241,7 +241,7 @@ static void gt_tir_remove_overlaps(GtArrayTIRPair *arrayTIRPair,
       /* due to sortedness of the array, the left border shouldn't change... */
       gt_assert(refrng.start <= boundaries->left_tir_start);
       /* ...so only update the right border */
-      refrng.end = MAX(boundaries->right_transformed_end, refrng.end);
+      refrng.end = GT_MAX(boundaries->right_transformed_end, refrng.end);
       if (nooverlapallowed) {
         oldboundaries->skip = true;
         boundaries->skip = true;
@@ -507,7 +507,7 @@ static int gt_tir_searchforTIRs(GtTIRStream *tir_stream,
 
       } else
       {
-        GtUword maxleft = MIN(seedptr->pos1 - seqstart1,
+        GtUword maxleft = GT_MIN(seedptr->pos1 - seqstart1,
                                     seedptr->pos2 - seqstart2);
         gt_seqabstract_reinit_encseq(false,GT_READMODE_FORWARD,
                                      sa_useq, encseq, maxleft,
@@ -545,7 +545,7 @@ static int gt_tir_searchforTIRs(GtTIRStream *tir_stream,
                                      seedptr->pos2 + seedptr->len);
       } else
       {
-        GtUword maxright = MIN(seqend1 - (seedptr->pos1 + seedptr->len),
+        GtUword maxright = GT_MIN(seqend1 - (seedptr->pos1 + seedptr->len),
                                      seqend2 - (seedptr->pos2 + seedptr->len));
         gt_seqabstract_reinit_encseq(true,GT_READMODE_FORWARD,
                                      sa_useq, encseq, maxright,
@@ -614,7 +614,7 @@ static int gt_tir_searchforTIRs(GtTIRStream *tir_stream,
                                    sa_vseq, encseq, vlen,
                                    pair->right_tir_start);
       edist = greedyunitedist(frontresource, sa_useq, sa_vseq);
-      pair->similarity = 100.0 * (1.0 - (double) edist/MAX(ulen, vlen));
+      pair->similarity = 100.0 * (1.0 - (double) edist/GT_MAX(ulen, vlen));
       /* gt_log_log("edist "GT_WU", sim %f", edist, pair->similarity); */
       if (gt_double_smaller_double(pair->similarity,
                                    tir_stream->similarity_threshold)) {

--- a/src/extended/wtree_encseq.c
+++ b/src/extended/wtree_encseq.c
@@ -309,16 +309,16 @@ static void gt_wtree_encseq_delete(GT_UNUSED GtWtree *wtree)
 static inline GtWtreeSymbol gt_wtree_encseq_map(GtWtreeEncseq *wtree_encseq,
                                                 GtUchar symbol)
 {
-  if (ISNOTSPECIAL(symbol))
+  if (GT_ISNOTSPECIAL(symbol))
     return (GtWtreeSymbol) symbol;
   else {
-    if (symbol == (GtUchar) SEPARATOR) {
+    if (symbol == (GtUchar) GT_SEPARATOR) {
       return (GtWtreeSymbol) wtree_encseq->alpha_size - 1;
     }
-    if (symbol == (GtUchar) WILDCARD)
+    if (symbol == (GtUchar) GT_WILDCARD)
       return (GtWtreeSymbol) wtree_encseq->alpha_size - 2;
   }
-  gt_assert(symbol == (GtUchar) UNDEFCHAR);
+  gt_assert(symbol == (GtUchar) GT_UNDEFCHAR);
   return (GtWtreeSymbol) wtree_encseq->alpha_size - 3;
 }
 
@@ -332,11 +332,11 @@ char gt_wtree_encseq_unmap_decoded(GtWtree *wtree,
   wtree_encseq = gt_wtree_encseq_cast(wtree);
   switch (wtree_encseq->alpha_size - encseq_sym) {
     case 1:
-      return (char) SEPARATOR;
+      return (char) GT_SEPARATOR;
     case 2:
-      return gt_alphabet_decode(wtree_encseq->alpha, (GtUchar) WILDCARD);
+      return gt_alphabet_decode(wtree_encseq->alpha, (GtUchar) GT_WILDCARD);
     case 3:
-      return (char) UNDEFCHAR;
+      return (char) GT_UNDEFCHAR;
     default:
       return gt_alphabet_decode(wtree_encseq->alpha, encseq_sym);
   }
@@ -467,7 +467,7 @@ GtWtree* gt_wtree_encseq_new(GtEncseq *encseq)
   wtree_encseq->encseq = gt_encseq_ref(encseq);
   wtree_encseq->alpha = gt_alphabet_ref(gt_encseq_alphabet(encseq));
   /* encoded chars + WC given by gt_alphabet_size,
-     we have to encode UNDEFCHAR and SEPARATOR too */
+     we have to encode GT_UNDEFCHAR and GT_SEPARATOR too */
   wtree_encseq->alpha_size = gt_alphabet_size(wtree_encseq->alpha) + 2;
   wtree->members->num_of_symbols = (GtUword) wtree_encseq->alpha_size;
   /* levels in tree: \lceil log_2(\sigma)\rceil */

--- a/src/ltr/ltr_four_char_motif.c
+++ b/src/ltr/ltr_four_char_motif.c
@@ -28,25 +28,25 @@ int gt_ltr_four_char_motif_encode (GtLTRFourCharMotif *motif,
   unsigned int i;
 
   symbolmap = gt_alphabet_symbolmap(gt_encseq_alphabet(encseq));
-  if ( symbolmap[(unsigned int)motif->firstleft] == (GtUchar) UNDEFCHAR)
+  if ( symbolmap[(unsigned int)motif->firstleft] == (GtUchar) GT_UNDEFCHAR)
   {
     gt_error_set(err,"Illegal nucleotide character %c "
                       "as argument to option -motif", motif->firstleft);
     return -1;
   }
-  if ( symbolmap[(unsigned int)motif->secondleft] == (GtUchar) UNDEFCHAR )
+  if ( symbolmap[(unsigned int)motif->secondleft] == (GtUchar) GT_UNDEFCHAR )
   {
     gt_error_set(err,"Illegal nucleotide character %c "
                       "as argument to option -motif", motif->secondleft);
     return -1;
   }
-  if ( symbolmap[(unsigned int)motif->firstright] == (GtUchar) UNDEFCHAR )
+  if ( symbolmap[(unsigned int)motif->firstright] == (GtUchar) GT_UNDEFCHAR )
   {
     gt_error_set(err,"Illegal nucleotide character %c "
                       "as argument to option -motif", motif->firstright);
     return -1;
   }
-  if ( symbolmap[(unsigned int)motif->secondright] == (GtUchar) UNDEFCHAR )
+  if ( symbolmap[(unsigned int)motif->secondright] == (GtUchar) GT_UNDEFCHAR )
   {
     gt_error_set(err,"Illegal nucleotide character %c "
                       "as argument to option -motif", motif->secondright);
@@ -55,7 +55,7 @@ int gt_ltr_four_char_motif_encode (GtLTRFourCharMotif *motif,
 
   for (i=0; i<=(unsigned int) UCHAR_MAX; i++)
   {
-    c_tab[i] = (GtUchar) UNDEFCHAR;
+    c_tab[i] = (GtUchar) GT_UNDEFCHAR;
   }
   /* define complementary symbols */
   c_tab[symbolmap['a']] = symbolmap['t'];

--- a/src/ltr/ltrdigest_file_out_stream.c
+++ b/src/ltr/ltrdigest_file_out_stream.c
@@ -114,7 +114,8 @@ static int gt_ltrelement_format_description(GtLTRElement *e,
   char tmpstr[BUFSIZ];
   gt_assert(buf && e);
 
-  (void) snprintf(tmpstr, GT_MIN(BUFSIZ, (size_t) seqnamelen+1), "%s", e->seqid);
+  (void) snprintf(tmpstr, GT_MIN(BUFSIZ, (size_t) seqnamelen+1), "%s",
+                  e->seqid);
   tmpstr[seqnamelen+1] = '\0';
   gt_cstr_rep(tmpstr, ' ', '_');
   ret = snprintf(buf, buflen, "%s_"GT_WU"_"GT_WU"", tmpstr, e->leftLTR_5+1,

--- a/src/ltr/ltrdigest_file_out_stream.c
+++ b/src/ltr/ltrdigest_file_out_stream.c
@@ -114,7 +114,7 @@ static int gt_ltrelement_format_description(GtLTRElement *e,
   char tmpstr[BUFSIZ];
   gt_assert(buf && e);
 
-  (void) snprintf(tmpstr, MIN(BUFSIZ, (size_t) seqnamelen+1), "%s", e->seqid);
+  (void) snprintf(tmpstr, GT_MIN(BUFSIZ, (size_t) seqnamelen+1), "%s", e->seqid);
   tmpstr[seqnamelen+1] = '\0';
   gt_cstr_rep(tmpstr, ' ', '_');
   ret = snprintf(buf, buflen, "%s_"GT_WU"_"GT_WU"", tmpstr, e->leftLTR_5+1,
@@ -417,7 +417,7 @@ int gt_ltrfileout_stream_next(GtNodeStream *ns, GtGenomeNode **gn, GtError *err)
       GtRange rng;
       ls->element.seqid = gt_calloc((size_t) ls->seqnamelen+1, sizeof (char));
       (void) snprintf(ls->element.seqid,
-                      MIN((size_t) gt_str_length(sdesc),
+                      GT_MIN((size_t) gt_str_length(sdesc),
                           (size_t) ls->seqnamelen)+1,
                       "%s", gt_str_get(sdesc));
       gt_cstr_rep(ls->element.seqid, ' ', '_');

--- a/src/ltr/ltrdigest_ppt_visitor.c
+++ b/src/ltr/ltrdigest_ppt_visitor.c
@@ -400,7 +400,7 @@ static GtPPTResults* gt_ppt_find(GtLTRdigestPPTVisitor *v,
      -------------------------------- */
   ltrlen = gt_range_length(&rightltrrng);
   /* make sure that we do not cross the LTR boundary */
-  radius = MIN((GtUword) v->radius, ltrlen-1);
+  radius = GT_MIN((GtUword) v->radius, ltrlen-1);
   /* encode sequence */
   encoded_seq = gt_malloc(sizeof (unsigned int) * seqlen);
   for (i = 0; i < seqlen; i++) {
@@ -421,7 +421,7 @@ static GtPPTResults* gt_ppt_find(GtLTRdigestPPTVisitor *v,
      -------------------------------- */
   ltrlen = gt_range_length(&leftltrrng);
   /* make sure that we do not cross the LTR boundary */
-  radius = MIN((GtUword) v->radius, ltrlen - 1);
+  radius = GT_MIN((GtUword) v->radius, ltrlen - 1);
   /* encode sequence */
   for (i = 0; i < seqlen; i++) {
     encoded_seq[i] = (unsigned int) gt_alphabet_encode(v->alpha, rev_seq[i]);

--- a/src/ltr/ltrharvest_stream.c
+++ b/src/ltr/ltrharvest_stream.c
@@ -372,12 +372,12 @@ static void searchforbestTSDandormotifatborders(const SubRepeatInfo
               /* store TSD length */
               boundaries->lenleftTSD = boundaries->lenrightTSD = tsd_len;
 
-              max = MAX(oldleftLTR_5, boundaries->leftLTR_5);
-              min = MIN(oldleftLTR_5, boundaries->leftLTR_5);
+              max = GT_MAX(oldleftLTR_5, boundaries->leftLTR_5);
+              min = GT_MIN(oldleftLTR_5, boundaries->leftLTR_5);
               difffromoldboundary1 = max - min;
 
-              max = MAX(oldrightLTR_3, boundaries->rightLTR_3);
-              min = MIN(oldrightLTR_3, boundaries->rightLTR_3);
+              max = GT_MAX(oldrightLTR_3, boundaries->rightLTR_3);
+              min = GT_MIN(oldrightLTR_3, boundaries->rightLTR_3);
               difffromoldboundary2 = max - min;
 
               hitcounter++;
@@ -387,11 +387,11 @@ static void searchforbestTSDandormotifatborders(const SubRepeatInfo
                    difffromnewboundary2;
 
               /* test if hit is nearer to old boundaries than previous hit */
-              max = MAX(oldleftLTR_5, motifpos1 - back);
-              min = MIN(oldleftLTR_5, motifpos1 - back);
+              max = GT_MAX(oldleftLTR_5, motifpos1 - back);
+              min = GT_MIN(oldleftLTR_5, motifpos1 - back);
               difffromnewboundary1 = max - min;
-              max = MAX(oldrightLTR_3, motifpos2 + 1 + forward);
-              min = MIN(oldrightLTR_3, motifpos2 + 1 + forward);
+              max = GT_MAX(oldrightLTR_3, motifpos2 + 1 + forward);
+              min = GT_MIN(oldrightLTR_3, motifpos2 + 1 + forward);
               difffromnewboundary2 = max - min;
 
               if (difffromnewboundary1 + difffromnewboundary2 <
@@ -462,16 +462,16 @@ static void searchformotifonlyborders(const GtLTRharvestStream *lo,
          motifmismatches_frombestmatch = tmp_mm.left;
          boundaries->leftLTR_5 = idx;
          motif1 = true;
-         max = MAX(oldleftLTR_5, boundaries->leftLTR_5);
-         min = MIN(oldleftLTR_5, boundaries->leftLTR_5);
+         max = GT_MAX(oldleftLTR_5, boundaries->leftLTR_5);
+         min = GT_MIN(oldleftLTR_5, boundaries->leftLTR_5);
          difffromoldboundary = max - min;
        } else /* next hit */
        {
          GtUword maxval, minval, difffromnewboundary;
 
          /* test if hit is nearer to old boundaries than previous hit */
-         maxval = MAX(oldleftLTR_5, idx);
-         minval = MIN(oldleftLTR_5, idx);
+         maxval = GT_MAX(oldleftLTR_5, idx);
+         minval = GT_MIN(oldleftLTR_5, idx);
          difffromnewboundary = maxval - minval;
 
          if (difffromnewboundary < difffromoldboundary)
@@ -509,16 +509,16 @@ static void searchformotifonlyborders(const GtLTRharvestStream *lo,
          motifmismatches_frombestmatch = tmp_mm.right;
          boundaries->rightLTR_3 = idx;
          motif2 = true;
-         max = MAX(oldrightLTR_3, boundaries->rightLTR_3);
-         min = MIN(oldrightLTR_3, boundaries->rightLTR_3);
+         max = GT_MAX(oldrightLTR_3, boundaries->rightLTR_3);
+         min = GT_MIN(oldrightLTR_3, boundaries->rightLTR_3);
          difffromoldboundary = max - min;
        } else /* next hit */
        {
          GtUword maxval, minval, difffromnewboundary;
 
          /* test if hit is nearer to old boundaries than previous hit */
-         maxval = MAX(oldrightLTR_3, idx);
-         minval = MIN(oldrightLTR_3, idx);
+         maxval = GT_MAX(oldrightLTR_3, idx);
+         minval = GT_MIN(oldrightLTR_3, idx);
          difffromnewboundary = maxval - minval;
          if (difffromnewboundary < difffromoldboundary)
          {
@@ -615,16 +615,16 @@ static void searchformotifonlyinside(const GtLTRharvestStream *lo,
          motifmismatches_frombestmatch = tmp_mm.left;
          boundaries->leftLTR_3 = idx;
          motif1 = true;
-         maxval = MAX(oldleftLTR_3, boundaries->leftLTR_3);
-         minval = MIN(oldleftLTR_3, boundaries->leftLTR_3);
+         maxval = GT_MAX(oldleftLTR_3, boundaries->leftLTR_3);
+         minval = GT_MIN(oldleftLTR_3, boundaries->leftLTR_3);
          difffromoldboundary = maxval - minval;
        } else /* next hit */
        {
          GtUword maxval, minval, difffromnewboundary;
 
          /* test if hit is nearer to old boundaries than previous hit */
-         maxval = MAX(oldleftLTR_3, idx);
-         minval = MIN(oldleftLTR_3, idx);
+         maxval = GT_MAX(oldleftLTR_3, idx);
+         minval = GT_MIN(oldleftLTR_3, idx);
          difffromnewboundary = maxval - minval;
 
          if (difffromnewboundary < difffromoldboundary)
@@ -663,16 +663,16 @@ static void searchformotifonlyinside(const GtLTRharvestStream *lo,
          motifmismatches_frombestmatch = tmp_mm.right;
          boundaries->rightLTR_5 = idx;
          motif2 = true;
-         maxval = MAX(oldrightLTR_5, boundaries->rightLTR_5);
-         minval = MIN(oldrightLTR_5, boundaries->rightLTR_5);
+         maxval = GT_MAX(oldrightLTR_5, boundaries->rightLTR_5);
+         minval = GT_MIN(oldrightLTR_5, boundaries->rightLTR_5);
          difffromoldboundary = maxval - minval;
        } else /* next hit */
        {
          GtUword maxval, minval, difffromnewboundary;
 
          /* test if hit is nearer to old boundaries than previous hit */
-         maxval = MAX(oldrightLTR_5, idx);
-         minval = MIN(oldrightLTR_5, idx);
+         maxval = GT_MAX(oldrightLTR_5, idx);
+         minval = GT_MIN(oldrightLTR_5, idx);
          difffromnewboundary = maxval - minval;
 
          if (difffromnewboundary < difffromoldboundary)
@@ -1124,7 +1124,7 @@ static int gt_searchforLTRs(GtLTRharvestStream *lo,
     edist = greedyunitedist(frontresource,sa_useq,sa_vseq);
 
     /* determine similarity */
-    boundaries.similarity = 100.0 * (1.0 - (double) edist/MAX(ulen,vlen));
+    boundaries.similarity = 100.0 * (1.0 - (double) edist/GT_MAX(ulen,vlen));
 
     if (!gt_double_smaller_double(boundaries.similarity,
                                   lo->similaritythreshold))
@@ -1221,7 +1221,7 @@ static void gt_removeoverlapswithlowersimilarity(GtArrayLTRboundaries
       /* due to sortedness of the array, the left border shouldn't change... */
       gt_assert(refrng.start <= boundaries->leftLTR_5);
       /* ...so only update the right border */
-      refrng.end = MAX(boundaries->rightLTR_3, refrng.end);
+      refrng.end = GT_MAX(boundaries->rightLTR_3, refrng.end);
       if (nooverlapallowed) {
         oldboundaries->skipped = true;
         boundaries->skipped = true;
@@ -1760,7 +1760,7 @@ GtNodeStream* gt_ltrharvest_stream_new(GtStr *str_indexname,
                "results may be duplicated");
   }
   max_contiglength = gt_encseq_max_seq_length(ltrh_stream->encseq);
-  ltrh_stream->repeatinfo.dmax = MIN(maxdistance,max_contiglength);
+  ltrh_stream->repeatinfo.dmax = GT_MIN(maxdistance,max_contiglength);
   ltrh_stream->repeatinfo.dmin = mindistance;
   ltrh_stream->repeatinfo.lmin = minltrlength;
   ltrh_stream->repeatinfo.lmax = maxltrlength;

--- a/src/match/apmeoveridx.c
+++ b/src/match/apmeoveridx.c
@@ -279,8 +279,8 @@ static void apme_nextLimdfsstate(const Limdfsconstinfo *mt,
 
   gt_assert(incol->maxleqk != UNDEFMAXLEQK);
   gt_assert(mti->maxintervalwidth > 0 || incol->maxleqk != SUCCESSMAXLEQK);
-  gt_assert(currentchar != (GtUchar) SEPARATOR);
-  if (currentchar != (GtUchar) WILDCARD)
+  gt_assert(currentchar != (GtUchar) GT_SEPARATOR);
+  if (currentchar != (GtUchar) GT_WILDCARD)
   {
     Eq = mti->eqsvector[(GtUword) currentchar];
   }
@@ -361,7 +361,7 @@ static void apme_inplacenextLimdfsstate(const Limdfsconstinfo *mt,
 
   gt_assert(col->maxleqk != UNDEFMAXLEQK);
   gt_assert(mti->maxintervalwidth > 0 || col->maxleqk != SUCCESSMAXLEQK);
-  if (currentchar != (GtUchar) WILDCARD)
+  if (currentchar != (GtUchar) GT_WILDCARD)
   {
     Eq = mti->eqsvector[(GtUword) currentchar];
   }

--- a/src/match/bare-encseq.c
+++ b/src/match/bare-encseq.c
@@ -67,7 +67,7 @@ GtBareEncseq *gt_bare_encseq_new(GtUchar *sequence,GtUword len,
   for (readptr = sequence; readptr < sequence + len; readptr++)
   {
     GtUchar cc = *readptr;
-    if (ISSPECIAL(cc))
+    if (GT_ISSPECIAL(cc))
     {
       if (lastspecialrange_length == 0)
       {
@@ -130,7 +130,7 @@ GtBareEncseq *gt_bare_encseq_parse_new(GtUchar *filecontents,size_t numofbytes,
           srptr->start = (GtUword) (writeptr - filecontents);
         }
         lastspecialrange_length++;
-        *writeptr++ = SEPARATOR;
+        *writeptr++ = GT_SEPARATOR;
         bare_encseq->specialcharacters++;
       } else
       {
@@ -148,13 +148,13 @@ GtBareEncseq *gt_bare_encseq_parse_new(GtUchar *filecontents,size_t numofbytes,
         if (!isspace(*readptr))
         {
           GtUchar cc = smap[*readptr];
-          if (cc == UNDEFCHAR)
+          if (cc == GT_UNDEFCHAR)
           {
             gt_error_set(err,"illegal input characters %c\n",*readptr);
             haserr = true;
             break;
           }
-          if (ISSPECIAL(cc))
+          if (GT_ISSPECIAL(cc))
           {
             if (lastspecialrange_length == 0)
             {
@@ -310,7 +310,7 @@ void bare_encseq_convert(GtBareEncseq *bare_encseq,bool forward,bool direct)
          leftptr < bare_encseq->sequence + bare_encseq->totallength;
          leftptr++)
     {
-      if (ISNOTSPECIAL(*leftptr))
+      if (GT_ISNOTSPECIAL(*leftptr))
       {
         *leftptr = GT_COMPLEMENTBASE(*leftptr);
       }
@@ -334,9 +334,9 @@ void bare_encseq_convert(GtBareEncseq *bare_encseq,bool forward,bool direct)
            leftptr <= rightptr; leftptr++, rightptr--)
       {
         GtUchar tmp = *leftptr;
-        *leftptr = ISSPECIAL(*rightptr) ? *rightptr
+        *leftptr = GT_ISSPECIAL(*rightptr) ? *rightptr
                                         : GT_COMPLEMENTBASE(*rightptr);
-        *rightptr = ISSPECIAL(tmp) ? tmp
+        *rightptr = GT_ISSPECIAL(tmp) ? tmp
                                    : GT_COMPLEMENTBASE(tmp);
       }
     }

--- a/src/match/bcktab.c
+++ b/src/match/bcktab.c
@@ -1311,7 +1311,7 @@ size_t gt_bcktab_sizeforlcpvalues(const GtBcktab *bcktab)
                     bcktab->maxbucketinfo.specialsmaxbucketsize;
   sizelcps
     = sizeof (GtUword) * gt_bcktab_nonspecialsmaxsize(bcktab);
-  return MAX(sizelcps,sizespeciallcps);
+  return GT_MAX(sizelcps,sizespeciallcps);
 }
 
 GtUword gt_bcktab_maxbucketsize(const GtBcktab *bcktab)

--- a/src/match/bcktab.c
+++ b/src/match/bcktab.c
@@ -1403,7 +1403,7 @@ void gt_bcktab_consistencyofsuffix(int line,
     }
     cc = gt_encseq_get_encoded_char(encseq,suffix->startpos + idx,
                                            readmode);
-    if (ISSPECIAL(cc))
+    if (GT_ISSPECIAL(cc))
     {
       firstspecial = idx;
       break;

--- a/src/match/cgr_spacedseed.c
+++ b/src/match/cgr_spacedseed.c
@@ -118,7 +118,7 @@ static void singlequerymatchspacedseed(Limdfsresources *limdfsresources,
   offset = 0;
   while (qptr <= query + querylen - spse->seedwidth)
   {
-    skipvalue = containsspecialbytestring(qptr,offset,spse->seedwidth);
+    skipvalue = gt_containsspecialbytestring(qptr,offset,spse->seedwidth);
     if (skipvalue == spse->seedwidth)
     {
       offset = spse->seedwidth-1;

--- a/src/match/chain2dim.c
+++ b/src/match/chain2dim.c
@@ -366,10 +366,10 @@ static GtChain2Dimscoretype gapcostCc(const GtChain2Dimmatchtable *matchtable,
              - GT_CHAIN2DIM_GETSTOREDENDPOINT(0,i) - 1,
   value2 = GT_CHAIN2DIM_GETSTOREDSTARTPOINT(1,j)
              - GT_CHAIN2DIM_GETSTOREDENDPOINT(1,i) - 1;
-  return (GtChain2Dimscoretype) MAX(value1,value2);
+  return (GtChain2Dimscoretype) GT_MAX(value1,value2);
 }
 
-#define GT_MINARRAYSPACE(A,TYPE,MINLEN)\
+#define MINARRAYSPACE(A,TYPE,MINLEN)\
         do {\
           if ((MINLEN) >= (A)->allocated##TYPE)\
           {\
@@ -420,7 +420,7 @@ static void gt_chain2dim_retrace_previousinchain(GtChain2Dim *chain,
     /* Use previousinchain */
     matchnum = matchtable->matches[matchnum].previousinchain;
   }
-  GT_MINARRAYSPACE(&chain->chainedmatches,GtChain2Dimref,lengthofchain);
+  MINARRAYSPACE(&chain->chainedmatches,GtChain2Dimref,lengthofchain);
   chain->chainedmatches.nextfreeGtChain2Dimref = lengthofchain;
   for (matchnum = retracestart;
        matchnum != GT_CHAIN2DIM_UNDEFPREVIOUS;
@@ -458,7 +458,7 @@ static void gt_chain2dim_nd_retrace_allprevious(
   }
   gt_assert(stack->nextfreeGtChain2DimEdgelevel == 0);
   chain->storedinreverseorder = true;
-  GT_MINARRAYSPACE(&chain->chainedmatches,GtChain2Dimref,32UL);
+  MINARRAYSPACE(&chain->chainedmatches,GtChain2Dimref,32UL);
   chain->chainedmatches.spaceGtChain2Dimref[0] = retracestart;
   chain->chainedmatches.nextfreeGtChain2Dimref = 1UL;
   for (idx = matchtable->previousbound[retracestart];
@@ -476,7 +476,7 @@ static void gt_chain2dim_nd_retrace_allprevious(
   {
     GtChain2DimEdgelevel father
       = stack->spaceGtChain2DimEdgelevel[--stack->nextfreeGtChain2DimEdgelevel];
-    GT_MINARRAYSPACE(&chain->chainedmatches,GtChain2Dimref,father.level + 1);
+    MINARRAYSPACE(&chain->chainedmatches,GtChain2Dimref,father.level + 1);
     chain->chainedmatches.spaceGtChain2Dimref[father.level] = father.son;
     chain->chainedmatches.nextfreeGtChain2Dimref = father.level + 1;
     if (matchtable->previouscount[father.son] == 0)

--- a/src/match/cutendpfx.c
+++ b/src/match/cutendpfx.c
@@ -49,7 +49,7 @@ static inline unsigned int prefixqgram2code(GtCodetype *code,
   for (i = (int) (qvalueprefix-1); i>=0; i--)
   {
     a = qgram[i];
-    if (ISSPECIAL(a))
+    if (GT_ISSPECIAL(a))
     {
       return (unsigned int) i;
     }

--- a/src/match/dataalign.h
+++ b/src/match/dataalign.h
@@ -39,8 +39,8 @@ roundUp(GtUint64 v, GtUword multipleOf)
 static inline size_t
 offsetAlign(size_t offset, size_t sizeOfVal2Align)
 {
-  size_t alignBase = MAX(MIN_ALIGN_REQUREMENT,
-                         MIN(sizeOfVal2Align, MAX_ALIGN_REQUIREMENT));
+  size_t alignBase = GT_MAX(MIN_ALIGN_REQUREMENT,
+                         GT_MIN(sizeOfVal2Align, MAX_ALIGN_REQUIREMENT));
   return roundUp(offset, alignBase);
 }
 

--- a/src/match/diagband-struct.c
+++ b/src/match/diagband-struct.c
@@ -149,7 +149,7 @@ static GtUword gt_diagband_struct_dband_coverage(
                                     GtUword diagband_idx)
 {
   gt_assert(diagband_struct != NULL);
-  return (GtUword) MAX(diagband_struct->score[diagband_idx + 1],
+  return (GtUword) GT_MAX(diagband_struct->score[diagband_idx + 1],
                        diagband_struct->score[diagband_idx - 1])
          + (GtUword) diagband_struct->score[diagband_idx];
 }

--- a/src/match/diagbandseed.c
+++ b/src/match/diagbandseed.c
@@ -390,11 +390,11 @@ static GtUword gt_seed_extend_numofkmers(const GtEncseq *encseq,
   gt_assert(lastpos >= firstpos);
   numofpos = lastpos - firstpos;
 
-  subtract = MIN(seedlength - 1, gt_encseq_min_seq_length(encseq)) + 1;
+  subtract = GT_MIN(seedlength - 1, gt_encseq_min_seq_length(encseq)) + 1;
   gt_assert(numofpos + 1 >= numofseq * subtract);
-  ratioofspecial = MIN(totalnumofspecial * numofpos / totalnumofpos, numofpos);
+  ratioofspecial = GT_MIN(totalnumofspecial * numofpos / totalnumofpos, numofpos);
   gt_assert(numofpos >= ratioofspecial);
-  return numofpos - MAX(numofseq * subtract - 1, ratioofspecial);
+  return numofpos - GT_MAX(numofseq * subtract - 1, ratioofspecial);
 }
 
 static GtKmerPosList *gt_kmerpos_list_new(GtUword init_size,
@@ -1232,7 +1232,7 @@ static GtUword gt_diagbandseed_processhistogram(GtUword *histogram,
     } else if (frequency == maxgram + 1) {
       frequency = GT_UWORD_MAX;
     }
-    maxfreq = MIN(maxfreq, frequency);
+    maxfreq = GT_MIN(maxfreq, frequency);
   }
 
   /* determine minimum required memory for error message */
@@ -1991,12 +1991,12 @@ static void gt_diagbandseed_merge(GtSeedpairlist *seedpairlist,
         blist = gt_diagbandseed_kmer_iter_next(biter);
       } else
       {
-        GtUword frequency = MAX(alen, blen);
+        GtUword frequency = GT_MAX(alen, blen);
 
         if (frequency <= maxfreq)
         {
           /* add all equal k-mers */
-          frequency = MIN(maxgram, frequency);
+          frequency = GT_MIN(maxgram, frequency);
           gt_assert(frequency > 0);
           if (count_cartesian)
           {
@@ -2149,7 +2149,7 @@ static int gt_diagbandseed_get_mlistlen_maxfreq(GtUword *mlistlen,
                                             FILE *stream,
                                             GtError *err)
 {
-  const GtUword maxgram = MIN(*maxfreq, 8190) + 1; /* Cap on k-mer count */
+  const GtUword maxgram = GT_MIN(*maxfreq, 8190) + 1; /* Cap on k-mer count */
   GtUword *histogram = NULL;
   GtTimer *timer = NULL;
   int had_err = 0;
@@ -4272,7 +4272,7 @@ static int gt_diagbandseed_algorithm(const GtDiagbandseedInfo *arg,
     if (extp->extendgreedy) {
       GtGreedyextendmatchinfo *grextinfo = NULL;
       const double weak_errorperc = (double)(extp->weakends
-                                             ? MAX(extp->errorpercentage, 20)
+                                             ? GT_MAX(extp->errorpercentage, 20)
                                              : extp->errorpercentage);
 
       pol_info = polishing_info_new_with_bias(weak_errorperc,
@@ -4903,7 +4903,7 @@ int gt_diagbandseed_run(const GtDiagbandseedInfo *arg,
         GtThread *thread;
         GtUword idx;
         bidx += num_runs_per_thread;
-        const GtUword end = MIN(bidx + num_runs_per_thread, bnumseqranges);
+        const GtUword end = GT_MIN(bidx + num_runs_per_thread, bnumseqranges);
 
         for (idx = bidx; idx < end; idx++) {
           GtUwordPair comb = {aidx, idx};
@@ -4934,7 +4934,7 @@ int gt_diagbandseed_run(const GtDiagbandseedInfo *arg,
         GtUword idx;
         bidx = self ? aidx : 0;
         for (idx = bidx;
-             idx < MIN(bidx + num_runs_per_thread, bnumseqranges);
+             idx < GT_MIN(bidx + num_runs_per_thread, bnumseqranges);
              ++idx) {
           if (!bpick || pick->b == idx) {
             GtUwordPair comb = {aidx, idx};

--- a/src/match/diagbandseed.c
+++ b/src/match/diagbandseed.c
@@ -4706,7 +4706,7 @@ int gt_diagbandseed_run(const GtDiagbandseedInfo *arg,
   stream_tab[0] = stdout;
   for (tidx = 1; !had_err && tidx < gt_jobs; tidx++) {
     stream_tab[tidx]
-      = gt_xtmpfp_generic(NULL, TMPFP_OPENBINARY | TMPFP_AUTOREMOVE);
+      = gt_xtmpfp_generic(NULL, GT_TMPFP_OPENBINARY | GT_TMPFP_AUTOREMOVE);
   }
 #endif
   if (arg->verbose || gt_querymatch_gfa2_display(arg->extp->out_display_flag))

--- a/src/match/diagbandseed.c
+++ b/src/match/diagbandseed.c
@@ -392,7 +392,8 @@ static GtUword gt_seed_extend_numofkmers(const GtEncseq *encseq,
 
   subtract = GT_MIN(seedlength - 1, gt_encseq_min_seq_length(encseq)) + 1;
   gt_assert(numofpos + 1 >= numofseq * subtract);
-  ratioofspecial = GT_MIN(totalnumofspecial * numofpos / totalnumofpos, numofpos);
+  ratioofspecial = GT_MIN(totalnumofspecial * numofpos / totalnumofpos,
+                          numofpos);
   gt_assert(numofpos >= ratioofspecial);
   return numofpos - GT_MAX(numofseq * subtract - 1, ratioofspecial);
 }

--- a/src/match/dist-short.c
+++ b/src/match/dist-short.c
@@ -36,8 +36,8 @@
                       distval = ulen
 
 #define COMPUTENEWDIST(CC)\
-        gt_assert((CC) != (GtUchar) SEPARATOR);\
-        if ((CC) != (GtUchar) WILDCARD)\
+        gt_assert((CC) != (GtUchar) GT_SEPARATOR);\
+        if ((CC) != (GtUchar) GT_WILDCARD)\
         {\
           Eq = eqsvector[(GtUword) (CC)];\
         } else\
@@ -152,7 +152,7 @@ Definedunsignedlong gt_forwardprefixmatch(const GtEncseq *encseq,
   {
     gt_assert(pos - startpos <= (GtUword) (ulen + maxdistance));
     cc = gt_encseq_get_encoded_char(encseq,pos,GT_READMODE_FORWARD);
-    if (nowildcards && cc == (GtUchar) WILDCARD)
+    if (nowildcards && cc == (GtUchar) GT_WILDCARD)
     {
       result.defined = false;
       result.valueunsignedlong = 0;

--- a/src/match/echoseq.c
+++ b/src/match/echoseq.c
@@ -43,7 +43,7 @@ void gt_symbolstring2fasta(FILE *fpout,
   for (i = 0, j = 0; ; i++)
   {
     currentchar = w[i];
-    if (currentchar == (GtUchar) SEPARATOR)
+    if (currentchar == (GtUchar) GT_SEPARATOR)
     {
       fprintf(fpout,"\n>\n");
       j = 0;
@@ -56,7 +56,7 @@ void gt_symbolstring2fasta(FILE *fpout,
       fprintf(fpout,"\n");
       break;
     }
-    if (currentchar != (GtUchar) SEPARATOR)
+    if (currentchar != (GtUchar) GT_SEPARATOR)
     {
       j++;
       if (j >= width)
@@ -87,7 +87,7 @@ void gt_encseq2symbolstring(FILE *fpout,
   for (idx = start, j = 0; /* Nothing */ ; idx++)
   {
     currentchar = gt_encseq_reader_next_encoded_char(esr);
-    if (currentchar == (GtUchar) SEPARATOR)
+    if (currentchar == (GtUchar) GT_SEPARATOR)
     {
       fprintf(fpout,"\n>\n");
       j = 0;
@@ -100,7 +100,7 @@ void gt_encseq2symbolstring(FILE *fpout,
       fprintf(fpout,"\n");
       break;
     }
-    if (currentchar != (GtUchar) SEPARATOR)
+    if (currentchar != (GtUchar) GT_SEPARATOR)
     {
       j++;
       if (j >= width)
@@ -128,7 +128,7 @@ void gt_fprintfencseq(FILE *fpout,
     currentchar = gt_encseq_get_encoded_char(encseq,
                                                     idx,
                                                     GT_READMODE_FORWARD);
-    gt_assert(ISNOTSPECIAL(currentchar));
+    gt_assert(GT_ISNOTSPECIAL(currentchar));
     gt_alphabet_echo_pretty_symbol(alpha,fpout,currentchar);
   }
 }

--- a/src/match/eis-bwtseq-context-param.h
+++ b/src/match/eis-bwtseq-context-param.h
@@ -40,7 +40,7 @@ ctxMapILogIsValid(GtUword seqLen, short mapIntervalLog2)
           || mapIntervalLog2 == CTX_MAP_ILOG_AUTOSIZE
           || (mapIntervalLog2 >= 0
               && mapIntervalLog2
-              < MIN(requiredUlongBits(seqLen),
+              < GT_MIN(requiredUlongBits(seqLen),
                     sizeof (GtUword) * CHAR_BIT)));
 }
 

--- a/src/match/eis-bwtseq-context.c
+++ b/src/match/eis-bwtseq-context.c
@@ -141,7 +141,7 @@ gt_BWTSCRFReadAdvance(BWTSeqContextRetrieverFactory *factory,
   gt_assert(factory);
   while (sfxIdxLeft)
   {
-    GtUword len = MIN(BLOCK_IO_SIZE, sfxIdxLeft);
+    GtUword len = GT_MIN(BLOCK_IO_SIZE, sfxIdxLeft);
     if (SDRRead(readSfxIdx, buf, len)
         != len)
     {

--- a/src/match/eis-bwtseq-context.c
+++ b/src/match/eis-bwtseq-context.c
@@ -75,7 +75,7 @@ initBWTSeqContextRetrieverFactory(BWTSeqContextRetrieverFactory *newFactory,
   newFactory->mapTableDBSPath = gt_str_new();
   fp = newFactory->mapTableDiskBackingStore
     = gt_xtmpfp_generic(newFactory->mapTableDBSPath,
-                        TMPFP_AUTOREMOVE | TMPFP_OPENBINARY);
+                        GT_TMPFP_AUTOREMOVE | GT_TMPFP_OPENBINARY);
   {
     off_t backingStoreSize = numMapEntries(seqLen, mapIntervalLog2), i;
     GtUword buf[BLOCK_IO_SIZE];

--- a/src/match/eis-bwtseq-extinfo.c
+++ b/src/match/eis-bwtseq-extinfo.c
@@ -359,7 +359,7 @@ isSortModeTransition(RandomSeqAccessor origSeqAccess, GtUword seqLen,
 #endif
       accessSequence(origSeqAccess, syms + 1, 0, 1);
     gt_assert(retcode == 1);
-    syms[0] = UNDEFBWTCHAR;
+    syms[0] = GT_UNDEFBWTCHAR;
   }
   else /* pos == seqLen - 1 */
   {
@@ -368,7 +368,7 @@ isSortModeTransition(RandomSeqAccessor origSeqAccess, GtUword seqLen,
 #endif
       accessSequence(origSeqAccess, syms, seqLen - 2, 1);
     gt_assert(retcode == 1);
-    syms[1] = UNDEFBWTCHAR;
+    syms[1] = GT_UNDEFBWTCHAR;
   }
   {
     AlphabetRangeID range[2];
@@ -456,7 +456,7 @@ addLocateInfo(BitString cwDest, BitOffset cwOffset,
         if (mapVal != 0)
           accessSequence(state->origSeqAccess, &BWTSym, mapVal - 1, 1);
         else
-          BWTSym = UNDEFBWTCHAR;
+          BWTSym = GT_UNDEFBWTCHAR;
         if (state->rangeSort[MRAEncGetRangeOfSymbol(
                 alphabet, MRAEncMapSymbol(alphabet, BWTSym))]
             == SORTMODE_RANK)

--- a/src/match/eis-bwtseq-extinfo.c
+++ b/src/match/eis-bwtseq-extinfo.c
@@ -213,7 +213,7 @@ locBitsUpperBounds(void *cbState, struct segmentDesc *desc,
       for (i = 0; i < numSegmentDesc; ++i)
       {
         size_t len = desc[i].len;
-        maxSegLen = MAX(len, maxSegLen);
+        maxSegLen = GT_MAX(len, maxSegLen);
         if (state->featureToggles & BWTLocateCount)
           maxBitsTotal += requiredUlongBits(len) * desc[i].repeatCount;
         numSegmentsTotal += desc[i].repeatCount;
@@ -298,7 +298,7 @@ initAddLocateInfoState(struct addLocateInfoState *state,
         && locateInterval > 1)
     {
       GtUword stdLocMarks = srcLen / locateInterval,
-        extraLocMarksUpperBound = MIN(srcLen/2, srcLen - stdLocMarks);
+        extraLocMarksUpperBound = GT_MIN(srcLen/2, srcLen - stdLocMarks);
       if (stats)
       {
         GtUword nonValSortSyms = 0;
@@ -309,7 +309,7 @@ initAddLocateInfoState(struct addLocateInfoState *state,
                 alphabet, MRAEncMapSymbol(alphabet, i),
                 SORTMODE_VALUE, (int *)rangeSort))
             nonValSortSyms += stats->symbolDistributionTable[i];
-        extraLocMarksUpperBound = MIN3(extraLocMarksUpperBound, nonValSortSyms,
+        extraLocMarksUpperBound = GT_MIN3(extraLocMarksUpperBound, nonValSortSyms,
                                        srcLen - nonValSortSyms);
       }
       state->extraLocMarksUpperBound = extraLocMarksUpperBound;

--- a/src/match/eis-bwtseq-extinfo.c
+++ b/src/match/eis-bwtseq-extinfo.c
@@ -309,8 +309,9 @@ initAddLocateInfoState(struct addLocateInfoState *state,
                 alphabet, MRAEncMapSymbol(alphabet, i),
                 SORTMODE_VALUE, (int *)rangeSort))
             nonValSortSyms += stats->symbolDistributionTable[i];
-        extraLocMarksUpperBound = GT_MIN3(extraLocMarksUpperBound, nonValSortSyms,
-                                       srcLen - nonValSortSyms);
+        extraLocMarksUpperBound = GT_MIN3(extraLocMarksUpperBound,
+                                          nonValSortSyms,
+                                          srcLen - nonValSortSyms);
       }
       state->extraLocMarksUpperBound = extraLocMarksUpperBound;
     }

--- a/src/match/eis-bwtseq-priv.h
+++ b/src/match/eis-bwtseq-priv.h
@@ -24,7 +24,7 @@
 #include "match/pckbucket.h"
 
 enum {
-  bwtTerminatorSym = SEPARATOR - 3,
+  bwtTerminatorSym = GT_SEPARATOR - 3,
 };
 
 struct BWTSeq

--- a/src/match/eis-bwtseq.c
+++ b/src/match/eis-bwtseq.c
@@ -624,10 +624,10 @@ gt_BWTSeqVerifyIntegrity(BWTSeq *bwtSeq, const char *projectName,
       fputs("Checking context regeneration.\n", stderr);
       {
         GtUword i, start, subSeqLen,
-          maxSubSeqLen = MIN(MAX(MIN_CONTEXT_LEN, seqLen/CONTEXT_FRACTION),
+          maxSubSeqLen = GT_MIN(GT_MAX(MIN_CONTEXT_LEN, seqLen/CONTEXT_FRACTION),
                              MAX_CONTEXT_LEN),
-          numTries = MIN(MAX_NUM_CONTEXT_CHECKS,
-                         MAX(2, seqLen/CONTEXT_INTERVAL));
+          numTries = GT_MIN(MAX_NUM_CONTEXT_CHECKS,
+                         GT_MAX(2, seqLen/CONTEXT_INTERVAL));
         Symbol *contextBuf = gt_malloc(sizeof (Symbol) * MAX_CONTEXT_LEN);
         GtEncseqReader *esr =
            gt_encseq_create_reader_with_readmode(suffixArray.encseq,

--- a/src/match/eis-bwtseq.c
+++ b/src/match/eis-bwtseq.c
@@ -624,8 +624,9 @@ gt_BWTSeqVerifyIntegrity(BWTSeq *bwtSeq, const char *projectName,
       fputs("Checking context regeneration.\n", stderr);
       {
         GtUword i, start, subSeqLen,
-          maxSubSeqLen = GT_MIN(GT_MAX(MIN_CONTEXT_LEN, seqLen/CONTEXT_FRACTION),
-                             MAX_CONTEXT_LEN),
+          maxSubSeqLen = GT_MIN(GT_MAX(MIN_CONTEXT_LEN,
+                                seqLen/CONTEXT_FRACTION),
+                                MAX_CONTEXT_LEN),
           numTries = GT_MIN(MAX_NUM_CONTEXT_CHECKS,
                          GT_MAX(2, seqLen/CONTEXT_INTERVAL));
         Symbol *contextBuf = gt_malloc(sizeof (Symbol) * MAX_CONTEXT_LEN);

--- a/src/match/eis-bwtseq.c
+++ b/src/match/eis-bwtseq.c
@@ -64,7 +64,7 @@ initBWTSeqFromEncSeqIdx(BWTSeq *bwtSeq, struct encIdxSeq *seqIdx,
   gt_assert(gt_MRAEncGetSize(alphabet) ==  alphabetSize + 1);
   alphabetSize = gt_MRAEncGetSize(alphabet);
   bwtSeq->bwtTerminatorFallback = bwtTerminatorFlat
-    = MRAEncMapSymbol(alphabet, UNDEFBWTCHAR);
+    = MRAEncMapSymbol(alphabet, GT_UNDEFBWTCHAR);
   bwtSeq->bwtTerminatorFallbackRange = 1;
   bwtSeq->count = counts;
   bwtSeq->rangeSort = rangeSort;
@@ -178,7 +178,7 @@ getMatchBound(const BWTSeq *bwtSeq, const Symbol *query, size_t queryLen,
     qptr = query + queryLen - 1;
     qend = query - 1;
   }
-  gt_assert(ISNOTSPECIAL(*qptr));
+  gt_assert(GT_ISNOTSPECIAL(*qptr));
   cc = (unsigned int) *qptr;
   prebwt.mbtab = gt_bwtseq2mbtab((const FMindex *) bwtSeq);
   if (prebwt.mbtab != NULL)
@@ -204,7 +204,7 @@ getMatchBound(const BWTSeq *bwtSeq, const Symbol *query, size_t queryLen,
   {
     GtUwordPair occPair;
 
-    gt_assert(ISNOTSPECIAL(*qptr));
+    gt_assert(GT_ISNOTSPECIAL(*qptr));
     cc = (unsigned int) *qptr;
     if (prebwt.mbtab != NULL && prebwt.depth < prebwt.maxdepth)
     {
@@ -241,7 +241,7 @@ GtUword gt_packedindexuniqueforward(const BWTSeq *bwtSeq,
 #ifdef SKDEBUG
   printf("# start cc=%u\n",cc);
 #endif
-  if (ISSPECIAL(cc))
+  if (GT_ISSPECIAL(cc))
   {
     return 0;
   }
@@ -261,7 +261,7 @@ GtUword gt_packedindexuniqueforward(const BWTSeq *bwtSeq,
 #ifdef SKDEBUG
     printf("# cc=%u\n",cc);
 #endif
-    if (ISSPECIAL (cc))
+    if (GT_ISSPECIAL (cc))
     {
       return 0;
     }
@@ -308,7 +308,7 @@ GtUword gt_packedindexmstatsforward(const BWTSeq *bwtSeq,
 #ifdef SKDEBUG
   printf("# start cc=%u\n",cc);
 #endif
-  if (ISSPECIAL(cc))
+  if (GT_ISSPECIAL(cc))
   {
     return 0;
   }
@@ -333,7 +333,7 @@ GtUword gt_packedindexmstatsforward(const BWTSeq *bwtSeq,
 #ifdef SKDEBUG
     printf("# cc=%u\n",cc);
 #endif
-    if (ISSPECIAL (cc))
+    if (GT_ISSPECIAL (cc))
     {
       break;
     }
@@ -571,11 +571,11 @@ gt_BWTSeqVerifyIntegrity(BWTSeq *bwtSeq, const char *projectName,
          * will not return the terminator symbol */
         {
           Symbol sym = BWTSeqGetSym(bwtSeq, nextLocate);
-          if (sym != UNDEFBWTCHAR)
+          if (sym != GT_UNDEFBWTCHAR)
           {
             gt_error_set(err, "symbol mismatch at position "GT_WU": "
                       "%d vs. reference symbol %d", i - 1, (int)sym,
-                      (int)UNDEFBWTCHAR);
+                      (int)GT_UNDEFBWTCHAR);
             retval = VERIFY_BWTSEQ_LFMAPWALK_ERROR;
             break;
           }
@@ -658,7 +658,7 @@ gt_BWTSeqVerifyIntegrity(BWTSeq *bwtSeq, const char *projectName,
           }
           while (j < subSeqLen)
           {
-            Symbol symRef = UNDEFBWTCHAR;
+            Symbol symRef = GT_UNDEFBWTCHAR;
             Symbol symCmp = contextBuf[j];
             if (symCmp != symRef)
             {

--- a/src/match/eis-mrangealphabet.c
+++ b/src/match/eis-mrangealphabet.c
@@ -102,7 +102,7 @@ gt_MRAEncGTAlphaNew(const GtAlphabet *alpha)
     symsPerRange[0] = numofchars;
   }
   /* handle special symbols */
-  mappings[WILDCARD] = numofchars;
+  mappings[GT_WILDCARD] = numofchars;
   symsPerRange[1] = 1;
   result = gt_newMultiRangeAlphabetEncodingUInt8(2, symsPerRange, mappings);
   gt_free(mappings);

--- a/src/match/eis-sa-common-siop.h
+++ b/src/match/eis-sa-common-siop.h
@@ -26,7 +26,7 @@ sfxIdx2BWTSym(GtUword sufIdx, const GtEncseq *encseq,
 {
   return sufIdx != 0
     ? gt_encseq_get_encoded_char(encseq, sufIdx - 1, readmode)
-    : (GtUchar) UNDEFBWTCHAR;
+    : (GtUchar) GT_UNDEFBWTCHAR;
 }
 
 static inline size_t

--- a/src/match/eis-sa-common.h
+++ b/src/match/eis-sa-common.h
@@ -45,7 +45,7 @@ enum sfxDataRequest {
 };
 
 /**
- * @return Symbol at position sufIdx or UNDEFBWTCHAR i.e. the terminator
+ * @return Symbol at position sufIdx or GT_UNDEFBWTCHAR i.e. the terminator
  */
 static inline GtUchar
 sfxIdx2BWTSym(GtUword sufIdx, const GtEncseq *encseq,

--- a/src/match/eis-seqranges.c
+++ b/src/match/eis-seqranges.c
@@ -536,11 +536,11 @@ gt_SRLSymbolsInSeqRegion(struct seqRangeList *rangeList, GtUword start,
     return;
   /* iterate over ranges left */
   {
-    GtUword s = MAX(start, p->startPos);
+    GtUword s = GT_MAX(start, p->startPos);
     struct seqRange *maxRange = rangeList->ranges + rangeList->numRanges - 1;
     while (s <= end)
     {
-      GtUword overlap = MIN(p->startPos + seqRangeLen(p,
+      GtUword overlap = GT_MIN(p->startPos + seqRangeLen(p,
                                                             rangeList->symBits),
                                   end + 1) - s;
       occStore[MRAEncRevMapSymbol(rangeList->alphabet,
@@ -592,7 +592,7 @@ gt_SRLSymbolCountInSeqRegion(struct seqRangeList *rangeList,
           symCount -= start - p->startPos;
         if (sym == seqRangeSym(q, symBits))
         {
-          regionLength lastOverlap = MIN(end - q->startPos,
+          regionLength lastOverlap = GT_MIN(end - q->startPos,
                                          seqRangeLen(q, symBits));
           symCount += lastOverlap;
         }
@@ -602,14 +602,14 @@ gt_SRLSymbolCountInSeqRegion(struct seqRangeList *rangeList,
     else
     {
       GtUword symCount = 0;
-      GtUword s = MAX(start, p->startPos);
+      GtUword s = GT_MAX(start, p->startPos);
       Symbol sym = MRAEncMapSymbol(rangeList->alphabet, esym);
       unsigned symBits = rangeList->symBits;
       struct seqRange *maxRange = rangeList->ranges + rangeList->numRanges - 1;
       while (s < end)
       {
         if (seqRangeSym(p, symBits) == sym)
-          symCount += MIN(p->startPos + seqRangeLen(p, symBits), end) - s;
+          symCount += GT_MIN(p->startPos + seqRangeLen(p, symBits), end) - s;
         if (p == maxRange)
           break;
         s = (++p)->startPos;
@@ -662,7 +662,7 @@ gt_SRLAllSymbolsCountInSeqRegion(struct seqRangeList *rangeList,
           symCount -= start - p->startPos;
 
         {
-          regionLength lastOverlap = MIN(end - q->startPos,
+          regionLength lastOverlap = GT_MIN(end - q->startPos,
                                          seqRangeLen(q, symBits));
           symCount += lastOverlap;
         }
@@ -672,12 +672,12 @@ gt_SRLAllSymbolsCountInSeqRegion(struct seqRangeList *rangeList,
     else
     {
       GtUword symCount = 0;
-      GtUword s = MAX(start, p->startPos);
+      GtUword s = GT_MAX(start, p->startPos);
       struct seqRange *maxRange = rangeList->ranges + rangeList->numRanges - 1;
       unsigned symBits = rangeList->symBits;
       while (s < end)
       {
-        symCount += MIN(p->startPos + seqRangeLen(p, symBits), end) - s;
+        symCount += GT_MIN(p->startPos + seqRangeLen(p, symBits), end) - s;
         if (p == maxRange)
           break;
         s = (++p)->startPos;
@@ -711,7 +711,7 @@ gt_SRLApplyRangesToSubString(struct seqRangeList *rangeList,
     {
       size_t i;
       unsigned maxSubstPos =
-        MIN(nextRange->startPos + seqRangeLen(nextRange, symBits),
+        GT_MIN(nextRange->startPos + seqRangeLen(nextRange, symBits),
             start + len) - subStringOffset;
       Symbol sym = MRAEncRevMapSymbol(rangeList->alphabet,
                                       seqRangeSym(nextRange, symBits));

--- a/src/match/eis-sequencemultiread.c
+++ b/src/match/eis-sequencemultiread.c
@@ -200,7 +200,7 @@ seqReaderSetRead(void *src, void *dest, size_t len)
       /* pos is in backlog */
       GtUword subLen, charsWritten;
 
-      subLen = MIN(elemsLeft, readerSet->backlogStartPos - pos
+      subLen = GT_MIN(elemsLeft, readerSet->backlogStartPos - pos
                               + readerSet->backlogLen);
       gt_assert(state->xltor.translateData == NULL);
       /*
@@ -239,7 +239,7 @@ seqReaderSetFindMinOpenRequestBySet(SeqReaderSet *readerSet, int setSpec)
   gt_assert(readerSet);
   for (i = 0; i < readerSet->numConsumers; ++i)
     if (readerSet->consumers[i].tag & setSpec)
-      min = MIN(min, readerSet->consumers[i].nextReadPos);
+      min = GT_MIN(min, readerSet->consumers[i].nextReadPos);
   return min;
 }
 
@@ -251,7 +251,7 @@ seqReaderSetFindMinOpenRequestByVal(SeqReaderSet *readerSet, int tagVal)
   gt_assert(readerSet);
   for (i = 0; i < readerSet->numConsumers; ++i)
     if (readerSet->consumers[i].tag == tagVal)
-      min = MIN(min, readerSet->consumers[i].nextReadPos);
+      min = GT_MIN(min, readerSet->consumers[i].nextReadPos);
   return min;
 }
 #endif
@@ -265,7 +265,7 @@ seqReaderSetFindMinOpenRequest(SeqReaderSet *readerSet)
   p = readerSet->consumerList;
   while (p)
   {
-    min = MIN(min, seqReaderSetGetConsumerNextPos(p));
+    min = GT_MIN(min, seqReaderSetGetConsumerNextPos(p));
     p = p->next;
   }
   return min;
@@ -310,7 +310,7 @@ seqReaderSetMove2Backlog(void *backlogState, const void *seqData,
     readerSet->backlogStartPos = requestMinPos;
   }
   {
-    GtUword copyStartPos = MAX(requestMinPos, requestStart);
+    GtUword copyStartPos = GT_MAX(requestMinPos, requestStart);
     size_t copyLen = requestLen - copyStartPos + requestStart;
     /* 3. extend backlog to also accept all invalidated values still needed */
     if (copyLen)

--- a/src/match/eis-specialsrank.c
+++ b/src/match/eis-specialsrank.c
@@ -178,7 +178,7 @@ specialsRankFromSampleTable(const SpecialsRankLookup *ranker, GtUword pos)
       gt_encseq_reader_reinit_with_readmode(esr, encseq, readmode, samplePos);
       do {
         samplePos++;
-        if (ISSPECIAL(gt_encseq_reader_next_encoded_char(esr)))
+        if (GT_ISSPECIAL(gt_encseq_reader_next_encoded_char(esr)))
           ++rankCount;
       } while (samplePos < encseqQueryMax);
     }

--- a/src/match/eis-specialsrank.c
+++ b/src/match/eis-specialsrank.c
@@ -124,9 +124,9 @@ gt_newSpecialsRankLookup(const GtEncseq *encseq, GtReadmode readmode,
     {
       while (pos < nextSamplePos)
       {
-        pos = MIN(MAX(pos, range.start), nextSamplePos);
-        sum += MIN(range.end - pos, nextSamplePos - pos);
-        pos = MIN(range.end, nextSamplePos);
+        pos = GT_MIN(GT_MAX(pos, range.start), nextSamplePos);
+        sum += GT_MIN(range.end - pos, nextSamplePos - pos);
+        pos = GT_MIN(range.end, nextSamplePos);
         if (pos < nextSamplePos)
         {
           nextRange(&range, sri, readmode, seqLastPos);
@@ -172,7 +172,7 @@ specialsRankFromSampleTable(const SpecialsRankLookup *ranker, GtUword pos)
     const GtEncseq *encseq = ranker->encseq;
     GtEncseqReader *esr = rankTable->scanState;
     GtReadmode readmode = rankTable->readmode;
-    GtUword encseqQueryMax = MIN(pos, encSeqLen);
+    GtUword encseqQueryMax = GT_MIN(pos, encSeqLen);
     if (samplePos < encseqQueryMax)
     {
       gt_encseq_reader_reinit_with_readmode(esr, encseq, readmode, samplePos);

--- a/src/match/eis-suffixarray-interface.c
+++ b/src/match/eis-suffixarray-interface.c
@@ -217,7 +217,7 @@ gt_SANewMRAEnc(const GtAlphabet *gtalphabet)
   MRAEnc *alphabet;
   gt_assert(gtalphabet != NULL);
   alphabet = gt_MRAEncGTAlphaNew(gtalphabet);
-  gt_MRAEncAddSymbolToRange(alphabet, SEPARATOR, 1);
+  gt_MRAEncAddSymbolToRange(alphabet, GT_SEPARATOR, 1);
   return alphabet;
 }
 

--- a/src/match/eis-suffixerator-interface.c
+++ b/src/match/eis-suffixerator-interface.c
@@ -199,9 +199,9 @@ newSeqStatsFromCharDist(const GtEncseq *encseq,
       = (GtUword) gt_encseq_charcount(encseq,(GtUchar) i);
     regularSymsSum += stats->symbolDistributionTable[i];
   }
-  stats->symbolDistributionTable[WILDCARD] = len - regularSymsSum - numOfSeqs;
-  stats->symbolDistributionTable[SEPARATOR] += numOfSeqs;
-  stats->symbolDistributionTable[UNDEFBWTCHAR] += 1;
+  stats->symbolDistributionTable[GT_WILDCARD] = len - regularSymsSum - numOfSeqs;
+  stats->symbolDistributionTable[GT_SEPARATOR] += numOfSeqs;
+  stats->symbolDistributionTable[GT_UNDEFBWTCHAR] += 1;
   return stats;
 }
 
@@ -306,7 +306,7 @@ gt_SfxINewMRAEnc(const sfxInterface *si)
   MRAEnc *alphabet;
   gt_assert(si);
   alphabet = gt_MRAEncGTAlphaNew(gt_SfxIGetAlphabet(si));
-  gt_MRAEncAddSymbolToRange(alphabet, SEPARATOR, 1);
+  gt_MRAEncAddSymbolToRange(alphabet, GT_SEPARATOR, 1);
   return alphabet;
 }
 

--- a/src/match/eis-suffixerator-interface.c
+++ b/src/match/eis-suffixerator-interface.c
@@ -199,7 +199,8 @@ newSeqStatsFromCharDist(const GtEncseq *encseq,
       = (GtUword) gt_encseq_charcount(encseq,(GtUchar) i);
     regularSymsSum += stats->symbolDistributionTable[i];
   }
-  stats->symbolDistributionTable[GT_WILDCARD] = len - regularSymsSum - numOfSeqs;
+  stats->symbolDistributionTable[GT_WILDCARD] = len - regularSymsSum
+                                                 - numOfSeqs;
   stats->symbolDistributionTable[GT_SEPARATOR] += numOfSeqs;
   stats->symbolDistributionTable[GT_UNDEFBWTCHAR] += 1;
   return stats;

--- a/src/match/eis-suffixerator-interface.c
+++ b/src/match/eis-suffixerator-interface.c
@@ -377,7 +377,7 @@ SfxIGenerate(void *iface,
   {
     if (generateStart < sfxi->lastGeneratedStart + sfxi->lastGeneratedLen)
     {
-      size_t copyLen = MIN(elemsLeft, sfxi->lastGeneratedStart
+      size_t copyLen = GT_MIN(elemsLeft, sfxi->lastGeneratedStart
                            + sfxi->lastGeneratedLen - generateStart),
         charsWritten =
         SDRTranslateSuffixsortspace(xltor, output,

--- a/src/match/eis-voiditf.c
+++ b/src/match/eis-voiditf.c
@@ -84,9 +84,9 @@ bool gt_BwtseqpositionwithoutSEPiterator_next(GtUword *pos,
       cc = BWTSeqGetSym(bspi->bwtseq, bspi->currentbound);
     } else
     {
-      cc = SEPARATOR;
+      cc = GT_SEPARATOR;
     }
-    if (cc != SEPARATOR)
+    if (cc != GT_SEPARATOR)
     {
       *pos = gt_BWTSeqLocateMatch(bspi->bwtseq,
                                   bspi->currentbound,
@@ -166,7 +166,7 @@ GtUchar gt_bwtseqgetsymbol(GtUword bound,const FMindex *fmindex)
   {
     return BWTSeqGetSym((const BWTSeq *) fmindex, bound);
   }
-  return SEPARATOR;
+  return GT_SEPARATOR;
 }
 
 GtUchar gt_Bwtseqcontextiterator_next(GtUword *bound,
@@ -179,7 +179,7 @@ GtUchar gt_Bwtseqcontextiterator_next(GtUword *bound,
     cc = BWTSeqGetSym(bsci->bwtseq, bsci->bound);
   } else
   {
-    cc = SEPARATOR;
+    cc = GT_SEPARATOR;
   }
   *bound = bsci->bound = BWTSeqLFMap(bsci->bwtseq, bsci->bound, &bsci->extBits);
   return cc;
@@ -390,7 +390,7 @@ void bwtrangewithspecial(GT_UNUSED GtArrayBoundswithchar *bwci,
     = MRAEncGetRangeSize(EISGetAlphabet(bwtseq->seqIdx),1);
   gt_assert(rangesize < (AlphabetRangeSize) 4);
   BWTSeqPosPairRangeOcc(bwtseq, 1, parent->left, parent->right,rangeOccs);
-    inchar = WILDCARD
+    inchar = GT_WILDCARD
     bwtcode = MRAEncMapSymbol(EISGetAlphabet(bwtseq->seqIdx),WILDCARD);
     idx = bwtcode -  MRAEncGetRangeBase(EISGetAlphabet(bwtseq->seqIdx),1);
     if (rangeOccs[idx] < rangeOccs[rangesize+idx])

--- a/src/match/encseq2offset.c
+++ b/src/match/encseq2offset.c
@@ -81,16 +81,16 @@ GtUword *gt_encseqtable2sequenceoffsets(
         = gt_encseq_get_encoded_char(suffixarraytable[idx].encseq,
                                      0,
                                      suffixarraytable[idx].readmode);
-      if (ISSPECIAL(lastofprevious))
+      if (GT_ISSPECIAL(lastofprevious))
       {
-        if (ISSPECIAL(firstofcurrent))
+        if (GT_ISSPECIAL(firstofcurrent))
         {
           tmpspecialranges--;
           tmprealspecialranges--;
         }
       } else
       {
-        if (ISNOTSPECIAL(firstofcurrent))
+        if (GT_ISNOTSPECIAL(firstofcurrent))
         {
           tmpspecialranges++;
           tmprealspecialranges++;

--- a/src/match/enum-patt.c
+++ b/src/match/enum-patt.c
@@ -121,7 +121,7 @@ const GtUchar *gt_nextEnumpatterniterator(GtUword *patternlen,
   for (j=0; j<*patternlen; j++)
   {
     cc = gt_encseq_reader_next_encoded_char(epi->esr);
-    if (ISSPECIAL(cc))
+    if (GT_ISSPECIAL(cc))
     {
       cc = (GtUchar) (random() % epi->alphasize);
     }

--- a/src/match/esa-maxpairs.c
+++ b/src/match/esa-maxpairs.c
@@ -139,8 +139,8 @@ static int cartproduct1_maxpairs(GtBUstate_maxpairs *state,
   for (spptr = start; spptr < start + pl->length; spptr++)
   {
     if (state->processmaxpairs(state->processmaxpairsinfo,&state->genericencseq,
-                               fatherdepth,MIN(leafnumber,*spptr),
-                                           MAX(leafnumber,*spptr),err) != 0)
+                               fatherdepth,GT_MIN(leafnumber,*spptr),
+                                           GT_MAX(leafnumber,*spptr),err) != 0)
     {
       return -1;
     }
@@ -169,8 +169,8 @@ static int cartproduct2_maxpairs(GtBUstate_maxpairs *state,
     {
       if (state->processmaxpairs(state->processmaxpairsinfo,
                                  &state->genericencseq,
-                                 fatherdepth,MIN(*spptr1,*spptr2),
-                                             MAX(*spptr1,*spptr2),err) != 0)
+                                 fatherdepth,GT_MIN(*spptr1,*spptr2),
+                                             GT_MAX(*spptr1,*spptr2),err) != 0)
       {
         return -1;
       }
@@ -274,8 +274,8 @@ static int processleafedge_maxpairs(bool firstsucc,
     {
       if (state->processmaxpairs(state->processmaxpairsinfo,
                                  &state->genericencseq,
-                                 fatherdepth,MIN(leafnumber,*spptr),
-                                             MAX(leafnumber,*spptr),err) != 0)
+                                 fatherdepth,GT_MIN(leafnumber,*spptr),
+                                             GT_MAX(leafnumber,*spptr),err) != 0)
       {
         return -2;
       }
@@ -438,8 +438,8 @@ static int processbranchingedge_maxpairs(bool firstsucc,
       {
         if (state->processmaxpairs(state->processmaxpairsinfo,
                                    &state->genericencseq,
-                                   fatherdepth,MIN(*fptr,*spptr),
-                                               MAX(*fptr,*spptr),err) != 0)
+                                   fatherdepth,GT_MIN(*fptr,*spptr),
+                                               GT_MAX(*fptr,*spptr),err) != 0)
         {
           return -4;
         }

--- a/src/match/esa-maxpairs.c
+++ b/src/match/esa-maxpairs.c
@@ -274,8 +274,9 @@ static int processleafedge_maxpairs(bool firstsucc,
     {
       if (state->processmaxpairs(state->processmaxpairsinfo,
                                  &state->genericencseq,
-                                 fatherdepth,GT_MIN(leafnumber,*spptr),
-                                             GT_MAX(leafnumber,*spptr),err) != 0)
+                                 fatherdepth,
+                                 GT_MIN(leafnumber,*spptr),
+                                 GT_MAX(leafnumber,*spptr),err) != 0)
       {
         return -2;
       }

--- a/src/match/esa-minunique.c
+++ b/src/match/esa-minunique.c
@@ -44,7 +44,7 @@ GtUword gt_suffixarrayuniqueforward (const void *genericindex,
   {
     if (itv.left < itv.right)
     {
-      if (qptr >= qend || ISSPECIAL(*qptr) ||
+      if (qptr >= qend || GT_ISSPECIAL(*qptr) ||
           !gt_lcpintervalfindcharchildintv(suffixarray->encseq,
                                            suffixarray->readmode,
                                            totallength,
@@ -84,7 +84,7 @@ GtUword gt_suffixarraymstats (const void *genericindex,
   for (qptr = qstart; /* Nothing */; qptr++, offset++)
   {
     gt_assert(itv.left <= itv.right);
-    if (qptr >= qend || ISSPECIAL(*qptr) ||
+    if (qptr >= qend || GT_ISSPECIAL(*qptr) ||
         !gt_lcpintervalfindcharchildintv(suffixarray->encseq,
                                       suffixarray->readmode,
                                       totallength,
@@ -124,7 +124,7 @@ GtUword gt_suffixarrayfindmums (const void *genericindex,
   for (qptr = qstart; /* Nothing */; qptr++, offset++)
   {
     gt_assert(itv.left <= itv.right);
-    if (qptr >= qend || ISSPECIAL(*qptr) ||
+    if (qptr >= qend || GT_ISSPECIAL(*qptr) ||
         !gt_lcpintervalfindcharchildintv(suffixarray->encseq,
                                          suffixarray->readmode,
                                          totallength,
@@ -163,7 +163,7 @@ GtRange gt_suffixarrayfindinterval (const void *genericindex,
   {
     Simplelcpinterval itv;
 
-    if (qptr >= qend || ISSPECIAL(*qptr) ||
+    if (qptr >= qend || GT_ISSPECIAL(*qptr) ||
         !gt_lcpintervalfindcharchildintv(suffixarray->encseq,
                                          suffixarray->readmode,
                                          totallength,

--- a/src/match/esa-mmsearch.c
+++ b/src/match/esa-mmsearch.c
@@ -66,7 +66,7 @@ static GtUchar gt_mmsearch_accessquery(const GtQueryrepresentation *queryrep,
   }
   if (GT_ISDIRCOMPLEMENT(queryrep->readmode))
   {
-    if (ISSPECIAL(cc))
+    if (GT_ISSPECIAL(cc))
     {
       return cc;
     }
@@ -102,7 +102,7 @@ static GtUchar gt_mmsearch_accessquery(const GtQueryrepresentation *queryrep,
           retcode = (int) (currentquerychar - currentdbchar);\
           if (retcode == 0)\
           {\
-            if (ISSPECIAL(currentdbchar) && ISSPECIAL(currentquerychar))\
+            if (GT_ISSPECIAL(currentdbchar) && GT_ISSPECIAL(currentquerychar))\
             {\
               retcode = -1;\
               break;\
@@ -358,7 +358,7 @@ static bool gt_mmsearch_isleftmaximal(const GtEncseq *dbencseq,
   dbleftchar = gt_encseq_get_encoded_char(dbencseq, /* Random access */
                                           dbstart-1,
                                           readmode);
-  if (ISSPECIAL(dbleftchar) ||
+  if (GT_ISSPECIAL(dbleftchar) ||
       dbleftchar != gt_mmsearch_accessquery(querysubstring->queryrep,
                                             querysubstring->currentoffset-1))
   {
@@ -382,7 +382,7 @@ static bool gt_mum_isleftmaximal(const GtEncseq *dbencseq,
   dbleftchar = gt_encseq_get_encoded_char(dbencseq, /* Random access */
                                           dbstart-1,
                                           readmode);
-  if (ISSPECIAL(dbleftchar) || dbleftchar != query[queryoffset-1])
+  if (GT_ISSPECIAL(dbleftchar) || dbleftchar != query[queryoffset-1])
   {
     return true;
   }
@@ -411,7 +411,7 @@ static GtUword gt_mmsearch_extendright(const GtEncseq *dbencseq,
        dbpos++, querypos++)
   {
     dbchar = gt_encseq_reader_next_encoded_char(esr);
-    if (ISSPECIAL(dbchar) ||
+    if (GT_ISSPECIAL(dbchar) ||
         dbchar != gt_mmsearch_accessquery(querysubstring->queryrep,querypos))
     {
       break;
@@ -477,7 +477,7 @@ void gt_queryuniquematch(bool selfmatch,
                          NULL);
       processquerymatch(processquerymatchinfo,querymatchspaceptr);
     }
-    if (queryrep->sequence[offset] == (GtUchar) SEPARATOR)
+    if (queryrep->sequence[offset] == (GtUchar) GT_SEPARATOR)
     {
       localqueryunitnum++;
       localqueryoffset = 0;
@@ -572,7 +572,7 @@ static void gt_querysubstringmatch(bool selfmatch,
     gt_mmsearchiterator_delete(mmsi);
     mmsi = NULL;
     if (gt_mmsearch_accessquery(queryrep,querysubstring.currentoffset)
-        == (GtUchar) SEPARATOR)
+        == (GtUchar) GT_SEPARATOR)
     {
       localqueryunitnum++;
       localqueryoffset = 0;

--- a/src/match/esa-mmsearch.c
+++ b/src/match/esa-mmsearch.c
@@ -145,7 +145,7 @@ static bool gt_mmsearch(const GtEncseq *dbencseq,
       while (right > left + 1)
       {
         mid = GT_DIV2(left+right);
-        lcplen = MIN(lpref,rpref);
+        lcplen = GT_MIN(lpref,rpref);
         GT_MMSEARCH_COMPARE(ESASUFFIXPTRGET(suftab,mid),lcplen);
         if (retcode <= 0)
         {
@@ -182,7 +182,7 @@ static bool gt_mmsearch(const GtEncseq *dbencseq,
       while (right > left + 1)
       {
         mid = GT_DIV2(left+right);
-        lcplen = MIN(lpref,rpref);
+        lcplen = GT_MIN(lpref,rpref);
         GT_MMSEARCH_COMPARE(ESASUFFIXPTRGET(suftab,mid),lcplen);
         if (retcode >= 0)
         {

--- a/src/match/esa-shulen.c
+++ b/src/match/esa-shulen.c
@@ -431,7 +431,7 @@ static GtUword gt_esa2shulengthatposition(const Suffixarray *suffixarray,
         printf("read %u\n",(unsigned int) *qptr);
       }
       */
-      if (qptr >= qend || ISSPECIAL(*qptr) ||
+      if (qptr >= qend || GT_ISSPECIAL(*qptr) ||
           !gt_lcpintervalfindcharchildintv(suffixarray->encseq,
                                            suffixarray->readmode,
                                            totallength,
@@ -463,7 +463,7 @@ static GtUword gt_esa2shulengthquery(const Suffixarray *suffixarray,
 
   for (qptr = query, remaining = querylen; remaining > 0; qptr++, remaining--)
   {
-    if (ISSPECIAL(*qptr))
+    if (GT_ISSPECIAL(*qptr))
     {
       gmatchlength = 0;
     } else

--- a/src/match/esa-splititv-simple.c
+++ b/src/match/esa-splititv-simple.c
@@ -22,7 +22,7 @@
 #include "esa-splititv.h"
 
 #define SEQUENCE(ENCSEQ,POS) (((POS) == totallength) \
-                             ? (GtUchar) SEPARATOR\
+                             ? (GtUchar) GT_SEPARATOR\
                              : gt_encseq_get_encoded_char(ENCSEQ, \
                                                                  POS, \
                                                                  readmode))

--- a/src/match/esa-splititv.c
+++ b/src/match/esa-splititv.c
@@ -22,7 +22,7 @@
 #include "esa-splititv.h"
 
 #define SEQUENCE(ENCSEQ,POS) (((POS) == totallength) \
-                             ? (GtUchar) SEPARATOR\
+                             ? (GtUchar) GT_SEPARATOR\
                              : gt_encseq_get_encoded_char(ENCSEQ, \
                                                                  POS, \
                                                                  readmode))
@@ -117,9 +117,9 @@ GtUword gt_findmaximalprefixinESA(const GtEncseq *encseq,
 
   for (idx = 0; idx < querylen; idx++)
   {
-    if (ISSPECIAL(query[idx]))
+    if (GT_ISSPECIAL(query[idx]))
     {
-      gt_assert(query[idx] != SEPARATOR);
+      gt_assert(query[idx] != GT_SEPARATOR);
       break;
     }
     if (!gt_lcpintervalfindcharchildintv(encseq,
@@ -170,7 +170,7 @@ void gt_lcpintervalsplitwithoutspecial(GtArrayBoundswithchar *bwci,
   {
     leftcc = SEQUENCE(encseq,ESASUFFIXPTRGET(suftab,leftbound) + parentoffset);
     gt_assert(bwci->nextfreeBoundswithchar < bwci->allocatedBoundswithchar);
-    if (ISSPECIAL(leftcc))
+    if (GT_ISSPECIAL(leftcc))
     {
       ADDPREVIOUSRBOUND(rightbound);
       ADDCURRENTLBOUND(rightbound+1);
@@ -206,7 +206,7 @@ GtUchar gt_lcpintervalextendlcp(const GtEncseq *encseq,
 
   ccl = SEQUENCE(encseq,ESASUFFIXPTRGET(suftab,parentleft) + parentoffset);
   ccr = SEQUENCE(encseq,ESASUFFIXPTRGET(suftab,parentright) + parentoffset);
-  if (ccl != ccr || ISSPECIAL(ccl))
+  if (ccl != ccr || GT_ISSPECIAL(ccl))
   {
     return alphasize;
   }

--- a/src/match/firstcodes.c
+++ b/src/match/firstcodes.c
@@ -679,10 +679,10 @@ static int gt_firstcodes_init(GtFirstcodesinfo *fci,
     = (unsigned int) gt_firstcodes_round(log((double) totallength));
   if (logtotallength >= 8U)
   {
-    fci->markprefixunits = MAX(8U,logtotallength - 8U);
+    fci->markprefixunits = GT_MAX(8U,logtotallength - 8U);
   } else
   {
-    fci->markprefixunits = MIN(kmersize/2U,8U);
+    fci->markprefixunits = GT_MIN(kmersize/2U,8U);
   }
   if (fci->markprefixunits >= 2U)
   {

--- a/src/match/fmi-fwduni.c
+++ b/src/match/fmi-fwduni.c
@@ -41,7 +41,7 @@ GtUword gt_skfmuniqueforward (const void *genericindex,
   gt_assert(qstart < qend);
   qptr = qstart;
   cc = *qptr++;
-  if (ISSPECIAL(cc))
+  if (GT_ISSPECIAL(cc))
   {
     return 0;
   }
@@ -50,7 +50,7 @@ GtUword gt_skfmuniqueforward (const void *genericindex,
   while (qptr < qend && bwtbound.lbound + 1 < bwtbound.ubound)
   {
     cc = *qptr;
-    if (ISSPECIAL (cc))
+    if (GT_ISSPECIAL (cc))
     {
       return 0;
     }
@@ -85,7 +85,7 @@ GtUword gt_skfmmstats (const void *genericindex,
   gt_assert(qstart < qend);
   qptr = qstart;
   cc = *qptr;
-  if (ISSPECIAL(cc))
+  if (GT_ISSPECIAL(cc))
   {
     return 0;
   }
@@ -99,7 +99,7 @@ GtUword gt_skfmmstats (const void *genericindex,
   for (qptr++; qptr < qend; qptr++)
   {
     cc = *qptr;
-    if (ISSPECIAL (cc))
+    if (GT_ISSPECIAL (cc))
     {
       break;
     }

--- a/src/match/fmi-locate.c
+++ b/src/match/fmi-locate.c
@@ -62,7 +62,7 @@ GtUword gt_fmfindtextpos (const Fmindex *fm,GtUword idx)
 
   while ((idx & fm->markdistminus1) != 0)
   {
-    if (idx == fm->longestsuffixpos || ISSPECIAL(cc = ACCESSBWTTEXT(idx)))
+    if (idx == fm->longestsuffixpos || GT_ISSPECIAL(cc = ACCESSBWTTEXT(idx)))
     {
       GtUword smallestgeq
                = searchsmallestgeq(fm->specpos.spaceGtPairBwtidx,

--- a/src/match/fmi-sufbwtstream.c
+++ b/src/match/fmi-sufbwtstream.c
@@ -224,10 +224,10 @@ static int nextesamergedsufbwttabvalues(Definedunsignedlong *longest,
       }
       longest->defined = true;
       longest->valueunsignedlong = bwtpos;
-      *bwtvalue = (GtUchar) UNDEFBWTCHAR;
+      *bwtvalue = (GtUchar) GT_UNDEFBWTCHAR;
     } else
     {
-      *bwtvalue = (GtUchar) SEPARATOR;
+      *bwtvalue = (GtUchar) GT_SEPARATOR;
     }
   } else
   {
@@ -457,7 +457,7 @@ int gt_sufbwt2fmindex(Fmindex *fmindex,
         *markptr++ = suftabvalue;
         nextmark += fmindex->markdist;
       }
-      if (ISBWTSPECIAL(cc))
+      if (GT_ISBWTSPECIAL(cc))
       {
         if (storeindexpos && bwtpos < firstignorespecial)
         {

--- a/src/match/ft-eoplist.c
+++ b/src/match/ft-eoplist.c
@@ -605,7 +605,7 @@ void gt_eoplist_trace2cigar(GtEoplist *eoplist,bool dtrace,GtUword trace_delta)
       aligned_v = (GtUword) eoplist->trace.spaceint[idx];
     }
     gt_assert(offset_u < eoplist->ulen);
-    aligned_u = MIN(trace_delta,eoplist->ulen - offset_u);
+    aligned_u = GT_MIN(trace_delta,eoplist->ulen - offset_u);
     this_distance = gt_full_front_edist_trace_distance(eoplist->fet_segment,
                                                        eoplist->useq + offset_u,
                                                        aligned_u,
@@ -823,7 +823,7 @@ void gt_eoplist_set_sequences(GtEoplist *eoplist,
 static int gt_eoplist_numwidth(const GtEoplist *eoplist)
 {
   gt_assert(eoplist != NULL);
-  return 1 + log10((double) MAX(eoplist->ustart + eoplist->ulen - 1,
+  return 1 + log10((double) GT_MAX(eoplist->ustart + eoplist->ulen - 1,
                                 eoplist->vstart + eoplist->vlen - 1));
 }
 
@@ -1090,11 +1090,11 @@ void gt_eoplist_format_generic(FILE *fp,
                            topbuf,
                            top_seqlength,
                            top_start_pos,
-                           eoplist->ustart + MIN(idx_u,eoplist->ulen - 1),
+                           eoplist->ustart + GT_MIN(idx_u,eoplist->ulen - 1),
                            midbuf,
                            lowbuf,
                            low_start_pos,
-                           low_start_base + MIN(idx_v,eoplist->vlen - 1),
+                           low_start_base + GT_MIN(idx_v,eoplist->vlen - 1),
                            fp);
   }
   if (eoplist->pol_info != NULL && eoplist->pol_info_out)
@@ -1182,7 +1182,7 @@ void gt_eoplist_format_exact(FILE *fp,
                                              : low_reference - eoplist->vstart;
 
   gt_assert(alignment_show_forward || top_seqlength > 0);
-  width = MIN(eoplist->ulen, eoplist_reader->width);
+  width = GT_MIN(eoplist->ulen, eoplist_reader->width);
   midbuf = topbuf + width;
   for (idx = 0; idx < (GtUword) width; idx++)
   {
@@ -1231,11 +1231,11 @@ void gt_eoplist_format_exact(FILE *fp,
                            topbuf,
                            top_seqlength,
                            top_start_pos,
-                           eoplist->ustart + MIN(idx,eoplist->ulen - 1),
+                           eoplist->ustart + GT_MIN(idx,eoplist->ulen - 1),
                            midbuf,
                            lowbuf,
                            low_start_pos,
-                           eoplist->vstart + MIN(idx,eoplist->vlen - 1),
+                           eoplist->vstart + GT_MIN(idx,eoplist->vlen - 1),
                            fp);
   }
 }

--- a/src/match/ft-eoplist.c
+++ b/src/match/ft-eoplist.c
@@ -894,7 +894,7 @@ void gt_eoplist_format_generic(FILE *fp,
           }
           if (characters != NULL)
           {
-            if (ISSPECIAL(cc_a))
+            if (GT_ISSPECIAL(cc_a))
             {
               cc_a = wildcardshow;
               is_match = false;
@@ -907,7 +907,7 @@ void gt_eoplist_format_generic(FILE *fp,
               }
               cc_a = characters[cc_a];
             }
-            if (ISSPECIAL(cc_b))
+            if (GT_ISSPECIAL(cc_b))
             {
               cc_b = wildcardshow;
               is_match = false;
@@ -984,7 +984,7 @@ void gt_eoplist_format_generic(FILE *fp,
                                                       : eoplist->ulen-1-idx_u];
           if (characters != NULL)
           {
-            if (ISSPECIAL(cc_a))
+            if (GT_ISSPECIAL(cc_a))
             {
               topbuf[pos] = wildcardshow;
             } else
@@ -1035,7 +1035,7 @@ void gt_eoplist_format_generic(FILE *fp,
           midbuf[pos] = EOPLIST_MISMATCHSYMBOL;
           if (characters != NULL)
           {
-            if (ISSPECIAL(cc_b))
+            if (GT_ISSPECIAL(cc_b))
             {
               lowbuf[pos] = wildcardshow;
             } else
@@ -1284,7 +1284,7 @@ void gt_eoplist_verify(const GtEoplist *eoplist,
           {
             const GtUchar a = eoplist->useq[sumulen+idx],
                           b = eoplist->vseq[sumvlen+idx];
-            if (a == b && !ISSPECIAL(a))
+            if (a == b && !GT_ISSPECIAL(a))
             {
               gt_assert(co.eoptype == GtMatchOp);
             } else
@@ -1292,7 +1292,7 @@ void gt_eoplist_verify(const GtEoplist *eoplist,
               gt_assert(!distinguish_mismatch_match ||
                         co.eoptype == GtMismatchOp);
             }
-            if (!distinguish_mismatch_match && (a != b || ISSPECIAL(a)))
+            if (!distinguish_mismatch_match && (a != b || GT_ISSPECIAL(a)))
             {
               sumdist++;
             }

--- a/src/match/ft-front-prune.c
+++ b/src/match/ft-front-prune.c
@@ -148,7 +148,7 @@ static GtUchar gt_sequenceobject_esr_get(GtFtSequenceObject *seq,GtUword idx)
   if (idx >= seq->cache_num_positions)
   {
     const GtUword addamount = 16UL;
-    GtUword cidx, tostore = MIN(seq->cache_num_positions + addamount,
+    GtUword cidx, tostore = GT_MIN(seq->cache_num_positions + addamount,
                                 seq->substringlength);
 
     if (tostore > seq->sequence_cache->allocated)
@@ -300,7 +300,7 @@ static void inline front_prune_add_matches(
                             match_mask;
     if (fv->matchhistory_size < max_history)
     {
-      fv->matchhistory_size = MIN(fv->matchhistory_size + fv->localmatch_count,
+      fv->matchhistory_size = GT_MIN(fv->matchhistory_size + fv->localmatch_count,
                                   max_history);
     }
     fv->row += fv->localmatch_count;
@@ -560,14 +560,14 @@ static GtFtFrontvalue *frontspace_allocate(GtUword minsizeforshift,
 {
   if (trimleft - fs->offset + valid >= fs->allocated)
   {
-    fs->allocated = 255UL + MAX(fs->allocated * 1.2,
+    fs->allocated = 255UL + GT_MAX(fs->allocated * 1.2,
                                            trimleft - fs->offset + valid);
     gt_assert(fs->allocated > trimleft - fs->offset + valid);
     fs->space = gt_realloc(fs->space,sizeof (GtFtFrontvalue) * fs->allocated);
     gt_assert(fs->space != NULL);
   }
   gt_assert(trimleft >= fs->offset);
-  if (trimleft - fs->offset > MAX(valid,minsizeforshift))
+  if (trimleft - fs->offset > GT_MAX(valid,minsizeforshift))
   {
     memcpy(fs->space,((GtFtFrontvalue *) fs->space) + trimleft - fs->offset,
            sizeof (GtFtFrontvalue) * valid);
@@ -725,7 +725,7 @@ GtUword front_prune_edist_inplace(
       {
         validbasefront->matchhistory_bits = (((uint64_t) 1) << seedlength) - 1;
       }
-      validbasefront->matchhistory_size = MIN(max_history,seedlength);
+      validbasefront->matchhistory_size = GT_MIN(max_history,seedlength);
       validbasefront->backreference = 0; /* No back reference */
       validbasefront->max_mismatches = 0;
       front_prune_add_matches(ft_longest_common,validbasefront + distance,

--- a/src/match/ft-front-prune.c
+++ b/src/match/ft-front-prune.c
@@ -300,8 +300,9 @@ static void inline front_prune_add_matches(
                             match_mask;
     if (fv->matchhistory_size < max_history)
     {
-      fv->matchhistory_size = GT_MIN(fv->matchhistory_size + fv->localmatch_count,
-                                  max_history);
+      fv->matchhistory_size = GT_MIN(fv->matchhistory_size
+                                       + fv->localmatch_count,
+                                     max_history);
     }
     fv->row += fv->localmatch_count;
   }

--- a/src/match/ft-front-prune.c
+++ b/src/match/ft-front-prune.c
@@ -202,7 +202,7 @@ static GtUchar ft_sequenceobject_get_char(GtFtSequenceObject *seq,GtUword idx)
       cc = seq->bytesequenceptr[accesspos];
     }
   }
-  if (seq->dir_is_complement && cc != WILDCARD)
+  if (seq->dir_is_complement && cc != GT_WILDCARD)
   {
     return GT_COMPLEMENTBASE(cc);
   }
@@ -221,7 +221,7 @@ static inline bool ft_sequenceobject_symbol_match(
   } else
   {
     const GtUchar cu = ft_sequenceobject_get_char(useq,upos);
-    return (cu != WILDCARD && cu == ft_sequenceobject_get_char(vseq,vpos))
+    return (cu != GT_WILDCARD && cu == ft_sequenceobject_get_char(vseq,vpos))
              ? true
              : false;
   }
@@ -861,7 +861,7 @@ static void inline gt_full_front_prune_add_matches(GtFtFrontvalue *midfront,
   for (upos = fv->row, vpos = fv->row + GT_FRONT_DIAGONAL(fv);
        upos < ulen && vpos < vlen &&
        useq[upos] == vseq[vpos]
-       && ISNOTSPECIAL(useq[upos])
+       && GT_ISNOTSPECIAL(useq[upos])
        ;
        upos++, vpos++)
        /* Nothing */;

--- a/src/match/ft-longest-common.inc
+++ b/src/match/ft-longest-common.inc
@@ -907,7 +907,7 @@ static GtUword ft_longest_common_twobit_twobit_wildcard(
         const GtUchar cu = gt_twobitencoding_char_at_pos(
                               useq->twobitencoding,
                               uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_twobitencoding_char_at_pos(
                               vseq->twobitencoding,
@@ -923,7 +923,7 @@ static GtUword ft_longest_common_twobit_twobit_wildcard(
         const GtUchar cu = gt_twobitencoding_char_at_pos(
                               useq->twobitencoding,
                               uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_twobitencoding_char_at_pos(
                               vseq->twobitencoding,
@@ -966,7 +966,7 @@ static GtUword ft_longest_common_twobit_encseq_reader_wildcard(
         const GtUchar cu = gt_twobitencoding_char_at_pos(
                               useq->twobitencoding,
                               uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_sequenceobject_esr_get(vseq,vptr)))
           break;
@@ -980,7 +980,7 @@ static GtUword ft_longest_common_twobit_encseq_reader_wildcard(
         const GtUchar cu = gt_twobitencoding_char_at_pos(
                               useq->twobitencoding,
                               uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_sequenceobject_esr_get(vseq,vptr))
           break;
@@ -1029,7 +1029,7 @@ static GtUword ft_longest_common_twobit_encseq_wildcard(
         const GtUchar cu = gt_twobitencoding_char_at_pos(
                               useq->twobitencoding,
                               uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_encseq_get_encoded_char(vseq->encseq,
                     vptr,
@@ -1045,7 +1045,7 @@ static GtUword ft_longest_common_twobit_encseq_wildcard(
         const GtUchar cu = gt_twobitencoding_char_at_pos(
                               useq->twobitencoding,
                               uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_encseq_get_encoded_char(vseq->encseq,
                     vptr,
@@ -1096,7 +1096,7 @@ static GtUword ft_longest_common_twobit_bytes_wildcard(
         const GtUchar cu = gt_twobitencoding_char_at_pos(
                               useq->twobitencoding,
                               uptr);
-        if (cu == WILDCARD || cu != GT_COMPLEMENTBASE(*vptr))
+        if (cu == GT_WILDCARD || cu != GT_COMPLEMENTBASE(*vptr))
           break;
         uptr += ustep;
         vptr += vstep;matchlength++;
@@ -1108,7 +1108,7 @@ static GtUword ft_longest_common_twobit_bytes_wildcard(
         const GtUchar cu = gt_twobitencoding_char_at_pos(
                               useq->twobitencoding,
                               uptr);
-        if (cu == WILDCARD || cu != *vptr)
+        if (cu == GT_WILDCARD || cu != *vptr)
           break;
         uptr += ustep;
         vptr += vstep;matchlength++;
@@ -1145,7 +1145,7 @@ static GtUword ft_longest_common_encseq_reader_twobit_wildcard(
       do
       {
         const GtUchar cu = gt_sequenceobject_esr_get(useq,uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_twobitencoding_char_at_pos(
                               vseq->twobitencoding,
@@ -1159,7 +1159,7 @@ static GtUword ft_longest_common_encseq_reader_twobit_wildcard(
       do
       {
         const GtUchar cu = gt_sequenceobject_esr_get(useq,uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_twobitencoding_char_at_pos(
                               vseq->twobitencoding,
@@ -1193,7 +1193,7 @@ static GtUword ft_longest_common_encseq_reader_encseq_reader_wildcard(
       do
       {
         const GtUchar cu = gt_sequenceobject_esr_get(useq,uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_sequenceobject_esr_get(vseq,vptr)))
           break;
@@ -1205,7 +1205,7 @@ static GtUword ft_longest_common_encseq_reader_encseq_reader_wildcard(
       do
       {
         const GtUchar cu = gt_sequenceobject_esr_get(useq,uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_sequenceobject_esr_get(vseq,vptr))
           break;
@@ -1244,7 +1244,7 @@ static GtUword ft_longest_common_encseq_reader_encseq_wildcard(
       do
       {
         const GtUchar cu = gt_sequenceobject_esr_get(useq,uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_encseq_get_encoded_char(vseq->encseq,
                     vptr,
@@ -1258,7 +1258,7 @@ static GtUword ft_longest_common_encseq_reader_encseq_wildcard(
       do
       {
         const GtUchar cu = gt_sequenceobject_esr_get(useq,uptr);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_encseq_get_encoded_char(vseq->encseq,
                     vptr,
@@ -1299,7 +1299,7 @@ static GtUword ft_longest_common_encseq_reader_bytes_wildcard(
       do
       {
         const GtUchar cu = gt_sequenceobject_esr_get(useq,uptr);
-        if (cu == WILDCARD || cu != GT_COMPLEMENTBASE(*vptr))
+        if (cu == GT_WILDCARD || cu != GT_COMPLEMENTBASE(*vptr))
           break;
         uptr++;
         vptr += vstep;
@@ -1309,7 +1309,7 @@ static GtUword ft_longest_common_encseq_reader_bytes_wildcard(
       do
       {
         const GtUchar cu = gt_sequenceobject_esr_get(useq,uptr);
-        if (cu == WILDCARD || cu != *vptr)
+        if (cu == GT_WILDCARD || cu != *vptr)
           break;
         uptr++;
         vptr += vstep;
@@ -1356,7 +1356,7 @@ static GtUword ft_longest_common_encseq_twobit_wildcard(
         const GtUchar cu = gt_encseq_get_encoded_char(useq->encseq,
                     uptr,
                     GT_READMODE_FORWARD);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_twobitencoding_char_at_pos(
                               vseq->twobitencoding,
@@ -1372,7 +1372,7 @@ static GtUword ft_longest_common_encseq_twobit_wildcard(
         const GtUchar cu = gt_encseq_get_encoded_char(useq->encseq,
                     uptr,
                     GT_READMODE_FORWARD);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_twobitencoding_char_at_pos(
                               vseq->twobitencoding,
@@ -1415,7 +1415,7 @@ static GtUword ft_longest_common_encseq_encseq_reader_wildcard(
         const GtUchar cu = gt_encseq_get_encoded_char(useq->encseq,
                     uptr,
                     GT_READMODE_FORWARD);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_sequenceobject_esr_get(vseq,vptr)))
           break;
@@ -1429,7 +1429,7 @@ static GtUword ft_longest_common_encseq_encseq_reader_wildcard(
         const GtUchar cu = gt_encseq_get_encoded_char(useq->encseq,
                     uptr,
                     GT_READMODE_FORWARD);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_sequenceobject_esr_get(vseq,vptr))
           break;
@@ -1478,7 +1478,7 @@ static GtUword ft_longest_common_encseq_encseq_wildcard(
         const GtUchar cu = gt_encseq_get_encoded_char(useq->encseq,
                     uptr,
                     GT_READMODE_FORWARD);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_encseq_get_encoded_char(vseq->encseq,
                     vptr,
@@ -1494,7 +1494,7 @@ static GtUword ft_longest_common_encseq_encseq_wildcard(
         const GtUchar cu = gt_encseq_get_encoded_char(useq->encseq,
                     uptr,
                     GT_READMODE_FORWARD);
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_encseq_get_encoded_char(vseq->encseq,
                     vptr,
@@ -1545,7 +1545,7 @@ static GtUword ft_longest_common_encseq_bytes_wildcard(
         const GtUchar cu = gt_encseq_get_encoded_char(useq->encseq,
                     uptr,
                     GT_READMODE_FORWARD);
-        if (cu == WILDCARD || cu != GT_COMPLEMENTBASE(*vptr))
+        if (cu == GT_WILDCARD || cu != GT_COMPLEMENTBASE(*vptr))
           break;
         uptr += ustep;
         vptr += vstep;matchlength++;
@@ -1557,7 +1557,7 @@ static GtUword ft_longest_common_encseq_bytes_wildcard(
         const GtUchar cu = gt_encseq_get_encoded_char(useq->encseq,
                     uptr,
                     GT_READMODE_FORWARD);
-        if (cu == WILDCARD || cu != *vptr)
+        if (cu == GT_WILDCARD || cu != *vptr)
           break;
         uptr += ustep;
         vptr += vstep;matchlength++;
@@ -1602,7 +1602,7 @@ static GtUword ft_longest_common_bytes_twobit_wildcard(
       do
       {
         const GtUchar cu = *uptr;
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_twobitencoding_char_at_pos(
                               vseq->twobitencoding,
@@ -1616,7 +1616,7 @@ static GtUword ft_longest_common_bytes_twobit_wildcard(
       do
       {
         const GtUchar cu = *uptr;
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_twobitencoding_char_at_pos(
                               vseq->twobitencoding,
@@ -1657,7 +1657,7 @@ static GtUword ft_longest_common_bytes_encseq_reader_wildcard(
       do
       {
         const GtUchar cu = *uptr;
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_sequenceobject_esr_get(vseq,vptr)))
           break;
@@ -1669,7 +1669,7 @@ static GtUword ft_longest_common_bytes_encseq_reader_wildcard(
       do
       {
         const GtUchar cu = *uptr;
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_sequenceobject_esr_get(vseq,vptr))
           break;
@@ -1716,7 +1716,7 @@ static GtUword ft_longest_common_bytes_encseq_wildcard(
       do
       {
         const GtUchar cu = *uptr;
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             GT_COMPLEMENTBASE(gt_encseq_get_encoded_char(vseq->encseq,
                     vptr,
@@ -1730,7 +1730,7 @@ static GtUword ft_longest_common_bytes_encseq_wildcard(
       do
       {
         const GtUchar cu = *uptr;
-        if (cu == WILDCARD ||
+        if (cu == GT_WILDCARD ||
             cu !=
             gt_encseq_get_encoded_char(vseq->encseq,
                     vptr,
@@ -1779,7 +1779,7 @@ static GtUword ft_longest_common_bytes_bytes_wildcard(
       do
       {
         const GtUchar cu = *uptr;
-        if (cu == WILDCARD || cu != GT_COMPLEMENTBASE(*vptr))
+        if (cu == GT_WILDCARD || cu != GT_COMPLEMENTBASE(*vptr))
           break;
         uptr += ustep;
         vptr += vstep;matchlength++;
@@ -1789,7 +1789,7 @@ static GtUword ft_longest_common_bytes_bytes_wildcard(
       do
       {
         const GtUchar cu = *uptr;
-        if (cu == WILDCARD || cu != *vptr)
+        if (cu == GT_WILDCARD || cu != *vptr)
           break;
         uptr += ustep;
         vptr += vstep;matchlength++;

--- a/src/match/ft-polish.c
+++ b/src/match/ft-polish.c
@@ -46,7 +46,7 @@ GtFtPolishing_info *polishing_info_new_with_bias(double errorpercentage,
     pol_info->cut_depth = (GtUword) 15;
   } else
   {
-    pol_info->cut_depth = MIN(history_size/2,(GtUword) 15);
+    pol_info->cut_depth = GT_MIN(history_size/2,(GtUword) 15);
   }
   pol_info->pol_size = 2 * pol_info->cut_depth;
   pol_info->entries = 1UL << pol_info->cut_depth;

--- a/src/match/ft-trimstat.c
+++ b/src/match/ft-trimstat.c
@@ -84,7 +84,7 @@ void gt_ft_trimstat_add_matchlength(GtFtTrimstat *trimstat,
                                     uint32_t matchlength)
 {
   gt_assert(trimstat != NULL && trimstat->matchlength_dist != NULL);
-  trimstat->matchlength_dist[MIN(100,matchlength)]++;
+  trimstat->matchlength_dist[GT_MIN(100,matchlength)]++;
 }
 #else
 void gt_ft_trimstat_add(GT_UNUSED GtFtTrimstat *trimstat,

--- a/src/match/greedyedist.c
+++ b/src/match/greedyedist.c
@@ -108,8 +108,8 @@ static void frontspecparms(const GtFrontResource *ftres,
     fspec->width = p + p + 1;
   } else
   {
-    fspec->left = MAX(-ftres->ulen,-p);
-    fspec->width = MIN(ftres->vlen,p) - fspec->left + 1;
+    fspec->left = GT_MAX(-ftres->ulen,-p);
+    fspec->width = GT_MIN(ftres->vlen,p) - fspec->left + 1;
   }
 #ifdef SKDEBUG
   printf("p="GT_WD",offset="GT_WD",left="GT_WD",width="GT_WD"\n",p,
@@ -294,7 +294,7 @@ GtUword greedyunitedist(GtFrontResource *ftres,
   gt_assert(gt_seqabstract_length(vseq) < (GtUword) LONG_MAX);
   ftres->ulen = (GtWord) gt_seqabstract_length(useq);
   ftres->vlen = (GtWord) gt_seqabstract_length(vseq);
-  ftres->integermin = -MAX(ftres->ulen,ftres->vlen);
+  ftres->integermin = -GT_MAX(ftres->ulen,ftres->vlen);
   prevfspec = &frontspecspace[0];
   firstfrontforward(useq,vseq,ftres,prevfspec);
   if (ftres->ulen == ftres->vlen &&
@@ -303,7 +303,7 @@ GtUword greedyunitedist(GtFrontResource *ftres,
     realdistance = 0;
   } else
   {
-    for (kval=1UL, r=1-MIN(ftres->ulen,ftres->vlen);
+    for (kval=1UL, r=1-GT_MIN(ftres->ulen,ftres->vlen);
          /* Nothing */ ; kval++, r++)
     {
       if (prevfspec == &frontspecspace[0])

--- a/src/match/idx-limdfs.c
+++ b/src/match/idx-limdfs.c
@@ -632,8 +632,8 @@ static void esa_overcontext(Limdfsresources *limdfsresources,
                           limdfsresources->genericindex->suffixarray->encseq,
                           pos,
                           limdfsresources->genericindex->suffixarray->readmode);
-    if (cc != (GtUchar) SEPARATOR &&
-        (!limdfsresources->nowildcards || cc != (GtUchar) WILDCARD))
+    if (cc != (GtUchar) GT_SEPARATOR &&
+        (!limdfsresources->nowildcards || cc != (GtUchar) GT_WILDCARD))
     {
 #ifdef SKDEBUG
       printf("cc=%u\n",(unsigned int) cc);
@@ -731,8 +731,8 @@ static void pck_overcontext(Limdfsresources *limdfsresources,
     {
       cc = gt_Bwtseqcontextiterator_next(&bound,bsci);
     }
-    if (cc != (GtUchar) SEPARATOR &&
-        (!limdfsresources->nowildcards || cc != (GtUchar) WILDCARD))
+    if (cc != (GtUchar) GT_SEPARATOR &&
+        (!limdfsresources->nowildcards || cc != (GtUchar) GT_WILDCARD))
     {
       Lcpintervalwithinfo *outstate;
 #ifdef SKDEBUG
@@ -1006,7 +1006,7 @@ static void esa_splitandprocess(Limdfsresources *limdfsresources,
     Indexbounds child;
     GtUword bound;
 
-    child.inchar = (GtUchar) WILDCARD;
+    child.inchar = (GtUchar) GT_WILDCARD;
     child.offset = parent->offset+1;
     child.code = 0;  /* not used, but we better define it */
     for (bound = firstspecial; bound <= parent->rightbound; bound++)
@@ -1106,7 +1106,7 @@ static void pck_splitandprocess(Limdfsresources *limdfsresources,
 
       child.offset = parent->offset+1;
       child.code = 0;  /* not used, but we better define it */
-      if (cc != (GtUchar) SEPARATOR)
+      if (cc != (GtUchar) GT_SEPARATOR)
       {
         child.leftbound = bound;
         child.inchar = cc;

--- a/src/match/idxlocalidp.c
+++ b/src/match/idxlocalidp.c
@@ -27,7 +27,7 @@
 #include "idxlocalisw.h"
 #include "idxlocalidp.h"
 
-#define MINUSINFTY (-1L)
+#define GT_MINUSINFTY (-1L)
 
 typedef struct
 {
@@ -170,20 +170,20 @@ static void secondcolumn (const Limdfsconstinfo *lci,LocaliColumn *outcol,
     ATADDRESS("",outcol);
   }
 #ifdef AFFINE
-  outcol->colvalues[0].repcell = MINUSINFTY;
+  outcol->colvalues[0].repcell = GT_MINUSINFTY;
   outcol->colvalues[0].inscell = lci->scorevalues.gapstart +
                                  lci->scorevalues.gapextend;
-  outcol->colvalues[0].delcell = MINUSINFTY;
+  outcol->colvalues[0].delcell = GT_MINUSINFTY;
 #endif
-  outcol->colvalues[0].bestcell = MINUSINFTY;
+  outcol->colvalues[0].bestcell = GT_MINUSINFTY;
   outcol->colvalues[0].tracebit = Notraceback;
   outcol->maxvalue = 0;
   outcol->pprefixlen = 0;
   for (i = 1UL; i <= lci->querylength; i++)
   {
 #ifdef AFFINE
-    outcol->colvalues[i].delcell = MINUSINFTY;
-    outcol->colvalues[i].inscell = MINUSINFTY;
+    outcol->colvalues[i].delcell = GT_MINUSINFTY;
+    outcol->colvalues[i].inscell = GT_MINUSINFTY;
     outcol->colvalues[i].repcell = REPLACEMENTSCORE(&lci->scorevalues,
                                                     dbchar,lci->query[i-1]);
     outcol->colvalues[i].bestcell = max2(outcol->colvalues[i].delcell,
@@ -191,7 +191,7 @@ static void secondcolumn (const Limdfsconstinfo *lci,LocaliColumn *outcol,
 #else
     Scoretype temp;
 
-    outcol->colvalues[i].bestcell = MINUSINFTY;
+    outcol->colvalues[i].bestcell = GT_MINUSINFTY;
     outcol->colvalues[i].tracebit = Notraceback;
     if (outcol->colvalues[i-1].bestcell > 0)
     {
@@ -235,7 +235,7 @@ static void nextcolumn (const Limdfsconstinfo *lci,
   }
   gt_assert(outcol->lenval >= lci->querylength+1);
 #ifdef AFFINE
-  outcol->colvalues[0].repcell = outcol->colvalues[0].delcell = MINUSINFTY;
+  outcol->colvalues[0].repcell = outcol->colvalues[0].delcell = GT_MINUSINFTY;
   if (incol->colvalues[0].inscell > 0)
   {
     if (incol->colvalues[0].bestcell > 0)
@@ -258,14 +258,14 @@ static void nextcolumn (const Limdfsconstinfo *lci,
                                      lci->scorevalues.gapextend;
     } else
     {
-      outcol->colvalues[0].inscell = MINUSINFTY;
+      outcol->colvalues[0].inscell = GT_MINUSINFTY;
     }
   }
   outcol->colvalues[0].bestcell = max3 (outcol->colvalues[0].repcell,
                                         outcol->colvalues[0].inscell,
                                         outcol->colvalues[0].delcell);
 #else
-  outcol->colvalues[0].bestcell = MINUSINFTY;
+  outcol->colvalues[0].bestcell = GT_MINUSINFTY;
   outcol->colvalues[0].tracebit = Notraceback;
 #endif
   outcol->maxvalue = 0;
@@ -280,7 +280,7 @@ static void nextcolumn (const Limdfsconstinfo *lci,
                                                       dbchar,lci->query[i-1]);
     } else
     {
-      outcol->colvalues[i].repcell = MINUSINFTY;
+      outcol->colvalues[i].repcell = GT_MINUSINFTY;
     }
     if (incol->colvalues[i].inscell > 0)
     {
@@ -304,7 +304,7 @@ static void nextcolumn (const Limdfsconstinfo *lci,
                                        lci->scorevalues.gapextend;
       } else
       {
-        outcol->colvalues[i].inscell = MINUSINFTY;
+        outcol->colvalues[i].inscell = GT_MINUSINFTY;
       }
     }
     if (outcol->colvalues[i-1].delcell > 0)
@@ -329,14 +329,14 @@ static void nextcolumn (const Limdfsconstinfo *lci,
                                        lci->scorevalues.gapextend;
       } else
       {
-        outcol->colvalues[i].delcell = MINUSINFTY;
+        outcol->colvalues[i].delcell = GT_MINUSINFTY;
       }
     }
     outcol->colvalues[i].bestcell = max3 (outcol->colvalues[i].repcell,
                                           outcol->colvalues[i].inscell,
                                           outcol->colvalues[i].delcell);
 #else
-    outcol->colvalues[i].bestcell = MINUSINFTY;
+    outcol->colvalues[i].bestcell = GT_MINUSINFTY;
     outcol->colvalues[i].tracebit = Notraceback;
     if (outcol->colvalues[i-1].bestcell > 0)
     {
@@ -374,7 +374,7 @@ static void inplacenextcolumn (const Limdfsconstinfo *lci,
   GtUword i;
   LocaliMatrixvalue nw, west;
 
-  column->colvalues[0].repcell = column->colvalues[0].delcell = MINUSINFTY;
+  column->colvalues[0].repcell = column->colvalues[0].delcell = GT_MINUSINFTY;
   if (column->colvalues[0].inscell > 0)
   {
     if (column->colvalues[0].bestcell > 0)
@@ -397,7 +397,7 @@ static void inplacenextcolumn (const Limdfsconstinfo *lci,
                                      lci->scorevalues.gapextend;
     } else
     {
-      column->colvalues[0].inscell = MINUSINFTY;
+      column->colvalues[0].inscell = GT_MINUSINFTY;
     }
   }
   column->colvalues[0].bestcell = max3 (column->colvalues[0].repcell,
@@ -416,7 +416,7 @@ static void inplacenextcolumn (const Limdfsconstinfo *lci,
                                                       dbchar,lci->query[i-1]);
     } else
     {
-      column->colvalues[i].repcell = MINUSINFTY;
+      column->colvalues[i].repcell = GT_MINUSINFTY;
     }
     if (west.inscell > 0)
     {
@@ -440,7 +440,7 @@ static void inplacenextcolumn (const Limdfsconstinfo *lci,
                                        lci->scorevalues.gapextend;
       } else
       {
-        column->colvalues[i].inscell = MINUSINFTY;
+        column->colvalues[i].inscell = GT_MINUSINFTY;
       }
     }
     if (column->colvalues[i-1].delcell > 0)
@@ -465,7 +465,7 @@ static void inplacenextcolumn (const Limdfsconstinfo *lci,
                                        lci->scorevalues.gapextend;
       } else
       {
-        column->colvalues[i].delcell = MINUSINFTY;
+        column->colvalues[i].delcell = GT_MINUSINFTY;
       }
     }
     nw = west;

--- a/src/match/idxlocalisw.c
+++ b/src/match/idxlocalisw.c
@@ -59,10 +59,10 @@ static Scoretype swlocalsimilarityscore(Scoretype *scol,
     nw = 0;
     vcurrent = gt_encseq_get_encoded_char(vencseq,j,
                                                    GT_READMODE_FORWARD);
-    gt_assert(vcurrent != (GtUchar) SEPARATOR);
+    gt_assert(vcurrent != (GtUchar) GT_SEPARATOR);
     for (scolptr = scol+1, uptr = useq; uptr < useq + ulen; scolptr++, uptr++)
     {
-      gt_assert(*uptr != (GtUchar) SEPARATOR);
+      gt_assert(*uptr != (GtUchar) GT_SEPARATOR);
       we = *scolptr;
       *scolptr = *(scolptr-1) + scorevalues->gapextend;
       if ((val = nw + REPLACEMENTSCORE(scorevalues,*uptr,vcurrent)) > *scolptr)
@@ -136,11 +136,11 @@ static void swlocalsimilarityregion(DPpoint *scol,
   {
     vcurrent = gt_encseq_get_encoded_char(vencseq,j,
                                                    GT_READMODE_FORWARD);
-    gt_assert(vcurrent != (GtUchar) SEPARATOR);
+    gt_assert(vcurrent != (GtUchar) GT_SEPARATOR);
     nw = *scol;
     for (scolptr = scol+1, uptr = useq; uptr < useq + ulen; scolptr++, uptr++)
     {
-      gt_assert(*uptr != (GtUchar) SEPARATOR);
+      gt_assert(*uptr != (GtUchar) GT_SEPARATOR);
       we = *scolptr;
       scolptr->similarity = (scolptr-1)->similarity + scorevalues->gapextend;
       scolptr->lu = (scolptr-1)->lu + 1;
@@ -207,14 +207,14 @@ static void swmaximalDPedges(Retracebits *edges,
   {
     vcurrent = gt_encseq_get_encoded_char(vencseq,j,
                                                    GT_READMODE_FORWARD);
-    gt_assert(vcurrent != (GtUchar) SEPARATOR);
+    gt_assert(vcurrent != (GtUchar) GT_SEPARATOR);
     nw = *scol;
     *scol = nw + scorevalues->gapextend;
     *eptr = INSERTIONBIT;
     for (scolptr = scol+1, uptr = useq, eptr++; uptr < useq + ulen;
          scolptr++, uptr++, eptr++)
     {
-      gt_assert(*uptr != (GtUchar) SEPARATOR);
+      gt_assert(*uptr != (GtUchar) GT_SEPARATOR);
       we = *scolptr;
       *scolptr = *(scolptr-1) + scorevalues->gapextend;
       *eptr = DELETIONBIT;

--- a/src/match/idxlocalisw.h
+++ b/src/match/idxlocalisw.h
@@ -31,7 +31,7 @@ typedef struct
             gapextend;    /* must be negative */
 } Scorevalues;
 
-#define REPLACEMENTSCORE(SV,A,B) (((A) != (B) || ISSPECIAL(A))\
+#define REPLACEMENTSCORE(SV,A,B) (((A) != (B) || GT_ISSPECIAL(A))\
                                    ? (SV)->mismatchscore\
                                    : (SV)->matchscore)
 

--- a/src/match/initeqsvec.c
+++ b/src/match/initeqsvec.c
@@ -38,8 +38,8 @@ void gt_initeqsvector(GtUword *eqsvector,
        pptr < pattern + patternlength && shiftmask != 0;
        pptr++, shiftmask <<= 1)
   {
-    gt_assert(*pptr != (GtUchar) SEPARATOR);
-    if (*pptr != (GtUchar) WILDCARD)
+    gt_assert(*pptr != (GtUchar) GT_SEPARATOR);
+    if (*pptr != (GtUchar) GT_WILDCARD)
     {
       eqsvector[(GtUword) *pptr] |= shiftmask;
     }
@@ -64,8 +64,8 @@ void gt_initeqsvectorrev(GtUword *eqsvectorrev,
        pptr >= pattern && shiftmask != 0;
        pptr--, shiftmask <<= 1)
   {
-    gt_assert(*pptr != (GtUchar) SEPARATOR);
-    if (*pptr != (GtUchar) WILDCARD)
+    gt_assert(*pptr != (GtUchar) GT_SEPARATOR);
+    if (*pptr != (GtUchar) GT_WILDCARD)
     {
       eqsvectorrev[(GtUword) *pptr] |= shiftmask;
     }

--- a/src/match/iter-window.c
+++ b/src/match/iter-window.c
@@ -65,7 +65,7 @@ const GtUchar *gt_windowiterator_next(GtUword *currentpos,
   while (wit->currentpos < wit->endpos)
   {
     currentchar = gt_encseq_reader_next_encoded_char(wit->esr);
-    if (ISSPECIAL(currentchar))
+    if (GT_ISSPECIAL(currentchar))
     {
       wit->bufsize = wit->firstpos = 0;
     } else
@@ -144,7 +144,7 @@ static void iteroverallwords(const GtEncseq *encseq,
   {
     currentchar = gt_encseq_get_encoded_char(encseq, esr, currentpos,
                                              GT_READMODE_FORWARD);
-    if (ISSPECIAL(currentchar))
+    if (GT_ISSPECIAL(currentchar))
     {
       bufsize = firstpos = 0;
     } else

--- a/src/match/karlin_altschul_stat.c
+++ b/src/match/karlin_altschul_stat.c
@@ -182,8 +182,8 @@ static ScoringFrequency *gt_karlin_altschul_stat_scoring_frequency(
     for (jdx = 0; jdx < numofchars; jdx++)
     {
       score = gt_scorehandler_get_replacement(scorehandler, idx, jdx);
-      obs_min = MIN(obs_min, score);
-      obs_max = MAX(obs_max, score);
+      obs_min = GT_MIN(obs_min, score);
+      obs_max = GT_MAX(obs_max, score);
     }
   }
 
@@ -698,10 +698,10 @@ static GtUword gt_evalue_length_adjustment(GtUword query_length,
   bool converged = false;
 
   /* l_max is the largest nonnegative solution of
-     K * (m - l) * (n - N * l) > MAX(m,n) */
+     K * (m - l) * (n - N * l) > GT_MAX(m,n) */
 
   space = actual_db_length * query_length
-          - MAX(query_length, actual_db_length)/K;
+          - GT_MAX(query_length, actual_db_length)/K;
   if (space < 0)
     return 0; /* length_adjustnment = 0 */
 

--- a/src/match/merger-trie.c
+++ b/src/match/merger-trie.c
@@ -63,7 +63,7 @@ static GtUchar getfirstedgechar(const Mergertrierep *trierep,
       node->suffixinfo.startpos + prevdepth >=
       gt_encseq_total_length(eri->encseqptr))
   {
-    return (GtUchar) SEPARATOR;
+    return (GtUchar) GT_SEPARATOR;
   }
   return gt_encseq_get_encoded_char(eri->encseqptr, /* Random access */
                         node->suffixinfo.startpos + prevdepth,
@@ -73,9 +73,9 @@ static GtUchar getfirstedgechar(const Mergertrierep *trierep,
 static int mtrie_comparecharacters(GtUchar cc1,unsigned int idx1,
                                    GtUchar cc2,unsigned int idx2)
 {
-  if (ISSPECIAL(cc1))
+  if (GT_ISSPECIAL(cc1))
   {
-    if (ISSPECIAL(cc2))
+    if (GT_ISSPECIAL(cc2))
     {
       if (idx1 <= idx2)
       {
@@ -90,7 +90,7 @@ static int mtrie_comparecharacters(GtUchar cc1,unsigned int idx1,
     }
   } else
   {
-    if (ISSPECIAL(cc2))
+    if (GT_ISSPECIAL(cc2))
     {
       return -1;  /* cc1 < cc2 */
     } else
@@ -142,7 +142,7 @@ static void showmergertrie2(const Mergertrierep *trierep,
               trierep->enseqreadinfo[current->suffixinfo.idx].encseqptr,
               pos,
               trierep->enseqreadinfo[current->suffixinfo.idx].readmode);
-      if (ISSPECIAL(cc))
+      if (GT_ISSPECIAL(cc))
       {
         printf("#\n");
         break;
@@ -151,7 +151,7 @@ static void showmergertrie2(const Mergertrierep *trierep,
     }
     if (MTRIE_ISLEAF(current))
     {
-      if (!ISSPECIAL(cc))
+      if (!GT_ISSPECIAL(cc))
       {
         printf("~\n");
       }
@@ -410,7 +410,7 @@ static Mergertrienode *mtrie_makenewbranch(Mergertrierep *trierep,
   if (suffixinfo->startpos + currentdepth >=
       gt_encseq_total_length(eri->encseqptr))
   {
-    cc2 = (GtUchar) SEPARATOR;
+    cc2 = (GtUchar) GT_SEPARATOR;
   } else
   {
     cc2 = gt_encseq_get_encoded_char(eri->encseqptr,
@@ -444,7 +444,7 @@ static GtUword getlcp(const GtEncseq *encseq1,
   {
     cc1 = gt_encseq_get_encoded_char(/*XXX*/ encseq1,i1,readmode1);
     if (cc1 != gt_encseq_get_encoded_char(/*XXX*/ encseq2,i2,readmode2)
-          || ISSPECIAL(cc1))
+          || GT_ISSPECIAL(cc1))
     {
       break;
     }
@@ -505,7 +505,7 @@ void gt_mergertrie_insertsuffix(Mergertrierep *trierep,
     {
       if (suffixinfo->startpos + currentdepth >= totallength)
       {
-        cc = (GtUchar) SEPARATOR;
+        cc = (GtUchar) GT_SEPARATOR;
       } else
       {
         /* Random access */

--- a/src/match/mssufpat.c
+++ b/src/match/mssufpat.c
@@ -242,7 +242,7 @@ static void pms_nextLimdfsstate(const Limdfsconstinfo *mt,
   const GtMssufpatLimdfsstate *incol =
                                      (const GtMssufpatLimdfsstate *) aliasincol;
 
-  gt_assert(ISNOTSPECIAL(currentchar));
+  gt_assert(GT_ISNOTSPECIAL(currentchar));
   gt_assert(currentdepth > 0);
 
   if (currentdepth > 1UL)
@@ -274,7 +274,7 @@ static void pms_inplacenextLimdfsstate(const Limdfsconstinfo *mt,
   GtMssufpatLimdfsstate *col = (GtMssufpatLimdfsstate *) aliascol;
   GtMssufpatLimdfsconstinfo *mti = (GtMssufpatLimdfsconstinfo*) mt;
 
-  gt_assert(ISNOTSPECIAL(currentchar));
+  gt_assert(GT_ISNOTSPECIAL(currentchar));
 #ifdef SKDEBUG
   tmp = col->prefixofsuffixbits;
 #endif

--- a/src/match/myersapm.c
+++ b/src/match/myersapm.c
@@ -104,14 +104,14 @@ void gt_edistmyersbitvectorAPM(Myersonlineresources *mor,
   for (pos = 0; pos < mor->totallength; pos++)
   {
     cc = gt_encseq_reader_next_encoded_char(mor->esr);
-    if (cc == (GtUchar) SEPARATOR)
+    if (cc == (GtUchar) GT_SEPARATOR)
     {
       Pv = ~0UL;
       Mv = 0UL;
       score = patternlength;
     } else
     {
-      if (cc == (GtUchar) WILDCARD)
+      if (cc == (GtUchar) GT_WILDCARD)
       {
         Eq = 0;
       } else

--- a/src/match/pckbucket.c
+++ b/src/match/pckbucket.c
@@ -142,7 +142,7 @@ static void pckbuckettable_followleafedge(Pckbuckettable *pckbt,
   {
     bdleaf.depth++;
     cc = gt_Bwtseqcontextiterator_next(&bdleaf.lowerbound,bsci);
-    if (ISSPECIAL(cc))
+    if (GT_ISSPECIAL(cc))
     {
       break;
     }

--- a/src/match/pssm.c
+++ b/src/match/pssm.c
@@ -116,7 +116,7 @@ void gt_lookaheadsearchPSSM(const GtEncseq *encseq,
   for (pos=0; pos < totallength; pos++)
   {
     currentchar = gt_encseq_reader_next_encoded_char(esr);
-    if (ISSPECIAL(currentchar))
+    if (GT_ISSPECIAL(currentchar))
     {
       bufsize = firstpos = 0;
     } else

--- a/src/match/qgram2code.h
+++ b/src/match/qgram2code.h
@@ -34,7 +34,7 @@ static inline unsigned int qgram2code(GtCodetype *code,
   for (i=(int) (qvalue-1); i>=0; i--)
   {
     a = qgram[i];
-    if (ISSPECIAL(a))
+    if (GT_ISSPECIAL(a))
     {
       return (unsigned int) i;
     }

--- a/src/match/qsort-array.gen
+++ b/src/match/qsort-array.gen
@@ -178,13 +178,13 @@ static void QSORTNAME(gt_inlinedarr_qsort_r) (
     pn = current.startindex + current.len;
     gt_assert(pa >= current.startindex);
     gt_assert(pb >= pa);
-    s = MIN ((GtUword) (pa - current.startindex),
+    s = GT_MIN ((GtUword) (pa - current.startindex),
              (GtUword) (pb - pa));
     gt_assert(pb >= s);
     GT_QSORT_ARR_VECSWAP (arr, current.startindex, pb - s, s);
     gt_assert(pd >= pc);
     gt_assert(pn > pd);
-    s = MIN ((GtUword) (pd - pc), (GtUword) (pn - pd - 1));
+    s = GT_MIN ((GtUword) (pd - pc), (GtUword) (pn - pd - 1));
     gt_assert(pn > s);
     GT_QSORT_ARR_VECSWAP (arr, pb, pn - s, s);
     gt_assert(pb >= pa);

--- a/src/match/qsort-inplace.gen
+++ b/src/match/qsort-inplace.gen
@@ -138,10 +138,10 @@ static void gt_inlined_qsort_r (Sorttype *arr,GtUword len,void *data)
       continue;
     }
     pn = current.startptr + current.len;
-    minval = MIN ((GtUword) (pa - current.startptr),
+    minval = GT_MIN ((GtUword) (pa - current.startptr),
                   (GtUword) (pb - pa));
     GT_QSORT_VECSWAP (current.startptr, pb - minval, minval);
-    minval = MIN ((GtUword) (pd - pc), (GtUword) (pn - pd - 1));
+    minval = GT_MIN ((GtUword) (pd - pc), (GtUword) (pn - pd - 1));
     GT_QSORT_VECSWAP (pb, pn - minval, minval);
     if ((minval = (GtUword) (pb - pa)) > 1UL)
     {

--- a/src/match/querymatch-align.c
+++ b/src/match/querymatch-align.c
@@ -134,7 +134,7 @@ void gt_querymatchoutoptions_extend(
     gt_assert(querymatchoutoptions != NULL);
     querymatchoutoptions->front_trace = front_trace_new();
     querymatchoutoptions->pol_info
-      = polishing_info_new_with_bias(weakends ? MAX(errorpercentage,20)
+      = polishing_info_new_with_bias(weakends ? GT_MAX(errorpercentage,20)
                                               : errorpercentage,
                                      matchscore_bias,
                                      history_size);

--- a/src/match/queue-inline.h
+++ b/src/match/queue-inline.h
@@ -92,7 +92,7 @@ static inline void extendqueuesize(GtInl_Queue *q,bool doublesize)
     addconst = q->queuesize;
   } else
   {
-    addconst = MIN(1024UL,q->queuesize);
+    addconst = GT_MIN(1024UL,q->queuesize);
   }
   newsize = q->queuesize + addconst;
   q->queuespace = gt_realloc(q->queuespace,sizeof (*q->queuespace) * newsize);

--- a/src/match/radixsort_str.c
+++ b/src/match/radixsort_str.c
@@ -247,8 +247,8 @@ static inline gt_radixsort_str_bucketnum_t
     /* now take the overflow into account */
     ova = GT_RADIXSORT_STR_OVERFLOW_NONSPECIAL(a);
     ovb = GT_RADIXSORT_STR_OVERFLOW_NONSPECIAL(b);
-    maxcodeslcp = GT_RADIXSORT_STR_KMERSIZE - MAX(ova, ovb);
-    return MIN(codeslcp, maxcodeslcp);
+    maxcodeslcp = GT_RADIXSORT_STR_KMERSIZE - GT_MAX(ova, ovb);
+    return GT_MIN(codeslcp, maxcodeslcp);
   }
   return 0;
 }
@@ -337,7 +337,7 @@ static void gt_radixsort_str_insertionsort(GtRadixsortstringinfo *rsi,
         }
         gt_lcptab_update(lcpvalues,subbucketleft,pl,
                          sortmaxdepth == 0 ? lcpvalue
-                                           : MIN(lcpvalue,sortmaxdepth));
+                                           : GT_MIN(lcpvalue,sortmaxdepth));
       }
       if (uvcmp < 0)
       {
@@ -456,7 +456,7 @@ void gt_radixsort_str_eqlen(GtRadixsortstringinfo *rsi,
               gt_lcptab_update(lcpvalues,subbucketleft,offset,
                                sortmaxdepth == 0
                                  ? subbucket.lcp
-                                 : MIN(subbucket.lcp,sortmaxdepth));
+                                 : GT_MIN(subbucket.lcp,sortmaxdepth));
             }
           }
           if (GT_RADIXSORT_STR_HAS_OVERFLOW(bucketnum))

--- a/src/match/randomcodes.c
+++ b/src/match/randomcodes.c
@@ -958,7 +958,7 @@ static inline GtUword gt_randomcodes_calculate_nofsamples(
     gt_assert(gt_encseq_min_seq_length(encseq) <= (GtUword)bucketkeysize);
   }
   nofsamples = nofkmers / sampling_factor;
-  return MAX(GT_RANDOMCODES_NOFSAMPLES_MIN, nofsamples);
+  return GT_MAX(GT_RANDOMCODES_NOFSAMPLES_MIN, nofsamples);
 }
 
 static void gt_randomcodes_generate_sampling_positions(GtUword *buffer,

--- a/src/match/rdj-contfinder.c
+++ b/src/match/rdj-contfinder.c
@@ -302,7 +302,7 @@ static inline void gt_contfinder_insertion_sort(
       {
         vlen = (vcorrected > 0) ? contfinder.seppos[vcorrected] -
           contfinder.seppos[vcorrected - 1] : contfinder.seppos[vcorrected] + 1;
-        len = MIN(ulen, vlen);
+        len = GT_MIN(ulen, vlen);
       }
       for (pos = bucket.depth, uvcmp = 0; uvcmp == 0 && pos < len;
           pos += GT_CONTFINDER_KMERSIZE)

--- a/src/match/rdj-contigs-graph.c
+++ b/src/match/rdj-contigs-graph.c
@@ -310,7 +310,7 @@ GtUword gt_contigs_graph_append_vertex(GtContigsGraph *cg,
       cg->v_spm[incoming][cg->nof_v].ptr + nof_e;
     if (cg->nof_spm_edges[incoming] + nof_e > cg->alloc_spm_edges[incoming])
     {
-      cg->alloc_spm_edges[incoming] += MAX(GT_CONTIGS_GRAPH_E_INC, nof_e);
+      cg->alloc_spm_edges[incoming] += GT_MAX(GT_CONTIGS_GRAPH_E_INC, nof_e);
       cg->e_spm[incoming] = gt_realloc(cg->e_spm[incoming],
           sizeof (*(cg->e_spm[incoming])) * cg->alloc_spm_edges[incoming]);
     }
@@ -329,7 +329,7 @@ GtUword gt_contigs_graph_append_vertex(GtContigsGraph *cg,
     cg->nof_units += nof_units;
     if (cg->nof_units > cg->alloc_units)
     {
-      cg->alloc_units += MAX(GT_CONTIGS_GRAPH_U_INC, nof_units);
+      cg->alloc_units += GT_MAX(GT_CONTIGS_GRAPH_U_INC, nof_units);
       cg->units = gt_realloc(cg->units,
           sizeof (*cg->units) * (cg->alloc_units));
     }

--- a/src/match/rdj-ovlfind-bf.c
+++ b/src/match/rdj-ovlfind-bf.c
@@ -41,7 +41,7 @@ static inline void spmfind_bf(const char *a, GtUword alen,
     void* procdata)
 {
   GtUword len, from;
-  from = MIN(alen, blen);
+  from = GT_MIN(alen, blen);
   if (self_comparison)
     from -= 1;
   for (len = from; len >= minlen; len--)

--- a/src/match/rdj-ovlfind-dp.c
+++ b/src/match/rdj-ovlfind-dp.c
@@ -222,7 +222,7 @@ GtContfind gt_ovlfind_dp(const char *u, GtUword m,
   }
   else
   {
-    max_edist = (GtUword)(max_error * MAX(m,n));
+    max_edist = (GtUword)(max_error * GT_MAX(m,n));
     row = gt_malloc(sizeof (GtOvlfindDpCell) * (n + 1));
     col = gt_malloc(sizeof (GtOvlfindDpCell) * (m + 1));
 

--- a/src/match/rdj-ovlfind-kmp.c
+++ b/src/match/rdj-ovlfind-kmp.c
@@ -67,7 +67,7 @@ static inline void spmfind_kmp(const char *a, GtUword alen,
 {
   gt_kmp_t q;
   GtUword max_matchlen;
-  max_matchlen = MIN(alen, blen);
+  max_matchlen = GT_MIN(alen, blen);
   if (self_comparison)
     max_matchlen -= 1;
   q = findnextmatch(a, b, alen - max_matchlen, alen - 1, pi);

--- a/src/match/reads2twobit.c
+++ b/src/match/reads2twobit.c
@@ -2329,6 +2329,6 @@ void gt_reads2twobit_enable_descs(GtReads2Twobit *r2t, bool clipped,
   }
   else
   {
-    r2t->descsfp = gt_xtmpfp_generic(NULL, TMPFP_AUTOREMOVE);
+    r2t->descsfp = gt_xtmpfp_generic(NULL, GT_TMPFP_AUTOREMOVE);
   }
 }

--- a/src/match/reads2twobit.c
+++ b/src/match/reads2twobit.c
@@ -445,8 +445,10 @@ static void gt_reads2twobit_switch_to_varlen_mode(
   gt_assert(next_seppos + state->seqlen == state->current.globalpos);
   gt_reads2twobit_append_seppos(state, state->current.globalpos - 1UL);
   gt_assert(state->current.seppos_nextfree == state->current.nofseqs);
-  state->current.seqlen_max = GT_MAX(state->current.seqlen_first, state->seqlen);
-  state->current.seqlen_min = GT_MIN(state->current.seqlen_first, state->seqlen);
+  state->current.seqlen_max = GT_MAX(state->current.seqlen_first,
+                                     state->seqlen);
+  state->current.seqlen_min = GT_MIN(state->current.seqlen_first,
+                                     state->seqlen);
   state->current.seqlen_first = 0;
 }
 

--- a/src/match/reads2twobit.c
+++ b/src/match/reads2twobit.c
@@ -445,8 +445,8 @@ static void gt_reads2twobit_switch_to_varlen_mode(
   gt_assert(next_seppos + state->seqlen == state->current.globalpos);
   gt_reads2twobit_append_seppos(state, state->current.globalpos - 1UL);
   gt_assert(state->current.seppos_nextfree == state->current.nofseqs);
-  state->current.seqlen_max = MAX(state->current.seqlen_first, state->seqlen);
-  state->current.seqlen_min = MIN(state->current.seqlen_first, state->seqlen);
+  state->current.seqlen_max = GT_MAX(state->current.seqlen_first, state->seqlen);
+  state->current.seqlen_min = GT_MIN(state->current.seqlen_first, state->seqlen);
   state->current.seqlen_first = 0;
 }
 

--- a/src/match/revcompl.c
+++ b/src/match/revcompl.c
@@ -28,10 +28,10 @@ void gt_inplace_reverse_complement(GtUchar *seq,GtUword len)
        frontptr <= backptr; frontptr++, backptr--)
   {
     tmp = *frontptr;
-    gt_assert((ISSPECIAL(*backptr) || *backptr < 4) &&
-              (ISSPECIAL(tmp) || tmp < 4));
-    *frontptr = ISSPECIAL(*backptr) ? *backptr : GT_COMPLEMENTBASE(*backptr);
-    *backptr = ISSPECIAL(tmp) ? tmp : GT_COMPLEMENTBASE(tmp);
+    gt_assert((GT_ISSPECIAL(*backptr) || *backptr < 4) &&
+              (GT_ISSPECIAL(tmp) || tmp < 4));
+    *frontptr = GT_ISSPECIAL(*backptr) ? *backptr : GT_COMPLEMENTBASE(*backptr);
+    *backptr = GT_ISSPECIAL(tmp) ? tmp : GT_COMPLEMENTBASE(tmp);
   }
 }
 
@@ -54,7 +54,7 @@ void gt_inplace_complement(GtUchar *seq,GtUword len)
 
   for (ptr = seq; ptr < seq + len; ptr++)
   {
-    gt_assert(ISSPECIAL(*ptr) || *ptr < 4);
+    gt_assert(GT_ISSPECIAL(*ptr) || *ptr < 4);
     *ptr = GT_COMPLEMENTBASE(*ptr);
   }
 }

--- a/src/match/seed-extend.c
+++ b/src/match/seed-extend.c
@@ -388,7 +388,8 @@ void gt_optimal_maxalilendiff_perc_mat_history(
 
       gt_assert(errorpercentage <= 100 - GT_EXTEND_MIN_IDENTITY_PERCENTAGE &&
                 sensitivity >= 90 && sensitivity - 90 <= 10);
-      best_value = best_percmathistory_maxalilendiff[GT_MIN(sensitivity - 90,9)];
+      best_value = best_percmathistory_maxalilendiff[GT_MIN(sensitivity
+                                                               - 90,9)];
       *maxalignedlendifference = best_value[errorpercentage].maxalilendiff;
       *perc_mat_history = best_value[errorpercentage].percmathistory;
     } else

--- a/src/match/seed-extend.c
+++ b/src/match/seed-extend.c
@@ -55,7 +55,7 @@ GtWord gt_optimalxdropbelowscore(GtUword errorpercentage,GtUword sensitivity)
 {
   gt_assert(errorpercentage <= 100 - GT_EXTEND_MIN_IDENTITY_PERCENTAGE &&
             sensitivity >= 90 && sensitivity - 90 <= 10);
-  return best_xdropbelow[MIN(sensitivity - 90,9)][errorpercentage];
+  return best_xdropbelow[GT_MIN(sensitivity - 90,9)][errorpercentage];
 }
 
 GtXdropmatchinfo *gt_xdrop_matchinfo_new(GtUword userdefinedleastlength,
@@ -388,7 +388,7 @@ void gt_optimal_maxalilendiff_perc_mat_history(
 
       gt_assert(errorpercentage <= 100 - GT_EXTEND_MIN_IDENTITY_PERCENTAGE &&
                 sensitivity >= 90 && sensitivity - 90 <= 10);
-      best_value = best_percmathistory_maxalilendiff[MIN(sensitivity - 90,9)];
+      best_value = best_percmathistory_maxalilendiff[GT_MIN(sensitivity - 90,9)];
       *maxalignedlendifference = best_value[errorpercentage].maxalilendiff;
       *perc_mat_history = best_value[errorpercentage].percmathistory;
     } else
@@ -469,8 +469,8 @@ double gt_greedy_dna_sequence_bias_get(const GtEncseq *encseq)
     double ratio;
     int bias_index;
 
-    ratio = (double) MIN(atcount, gccount) / (atcount + gccount);
-    bias_index = (int) MAX(0.0, (ratio + 0.025) * 20.0 - 1.0);
+    ratio = (double) GT_MIN(atcount, gccount) / (atcount + gccount);
+    bias_index = (int) GT_MAX(0.0, (ratio + 0.025) * 20.0 - 1.0);
     gt_assert(bias_index < sizeof bias_factor/sizeof bias_factor[0]);
     return bias_factor[bias_index];
   }
@@ -1102,7 +1102,7 @@ static bool gt_extend_sesp(bool forxdrop,
   if (sesp->same_encseq && sesp->dbseqnum == sesp->queryseqnum)
   {
     gt_assert(sesp->querystart_relative >= v_left_ext);
-    r_urightbound = MIN(sesp->dbseqlength,
+    r_urightbound = GT_MIN(sesp->dbseqlength,
                          sesp->querystart_relative - v_left_ext);
   } else
   {

--- a/src/match/seq_or_encseq.h
+++ b/src/match/seq_or_encseq.h
@@ -19,14 +19,14 @@
         (SORE)->seqlength = SEQLENGTH
 
 #define GT_SEQORENCSEQ_INIT_SEQ(SORE,SEQ,SEQDESC,SEQLENGTH,CHARACTERS,\
-                                WILDCARDSHOW,HASWILDCARDS)\
+                                GT_WILDCARDSHOW,HASWILDCARDS)\
         (SORE)->encseq = NULL;\
         (SORE)->seq = SEQ;\
         (SORE)->desc = SEQDESC;\
         (SORE)->seqlength = SEQLENGTH;\
         (SORE)->seqstartpos = 0;\
         (SORE)->characters = CHARACTERS;\
-        (SORE)->wildcardshow = WILDCARDSHOW;\
+        (SORE)->wildcardshow = GT_WILDCARDSHOW;\
         (SORE)->haswildcards = HASWILDCARDS
 
 typedef struct

--- a/src/match/seqabstract.c
+++ b/src/match/seqabstract.c
@@ -218,7 +218,7 @@ GtUword gt_seqabstract_lcp(bool rightextension,
     GtUchar u_cc, v_cc;
 
     u_cc = gt_seqabstract_get_encoded_char(rightextension,useq,u_start + lcp);
-    if (ISSPECIAL(u_cc))
+    if (GT_ISSPECIAL(u_cc))
     {
       break;
     }
@@ -227,7 +227,7 @@ GtUword gt_seqabstract_lcp(bool rightextension,
       u_cc = GT_COMPLEMENTBASE(u_cc);
     }
     v_cc = gt_seqabstract_get_encoded_char(rightextension,vseq,v_start + lcp);
-    if (ISSPECIAL(v_cc))
+    if (GT_ISSPECIAL(v_cc))
     {
       break;
     }
@@ -253,12 +253,12 @@ char *gt_seqabstract_get(bool rightextension,const GtSeqabstract *seq)
   {
     GtUchar cc = gt_seqabstract_get_encoded_char(rightextension,seq,idx);
 
-    if (cc == WILDCARD)
+    if (cc == GT_WILDCARD)
     {
       buffer[idx] = '#';
     } else
     {
-      if (cc == SEPARATOR)
+      if (cc == GT_SEPARATOR)
       {
         buffer[idx] = '$';
       } else

--- a/src/match/seqabstract.c
+++ b/src/match/seqabstract.c
@@ -212,7 +212,7 @@ GtUword gt_seqabstract_lcp(bool rightextension,
 
   gt_assert(useq != NULL && vseq != NULL &&
             useq->len >= u_start && vseq->len >= v_start);
-  maxlen = MIN(useq->len - u_start, vseq->len - v_start);
+  maxlen = GT_MIN(useq->len - u_start, vseq->len - v_start);
   for (lcp = 0; lcp < maxlen; lcp++)
   {
     GtUchar u_cc, v_cc;

--- a/src/match/sfx-apfxlen.c
+++ b/src/match/sfx-apfxlen.c
@@ -98,7 +98,7 @@ unsigned int gt_recommendedprefixlength(unsigned int numofchars,
     unsigned int mbp = gt_maxbasepower(numofchars);
     if (mbp >= 1U)
     {
-      return MIN(mbp,prefixlength);
+      return GT_MIN(mbp,prefixlength);
     } else
     {
       return prefixlength;
@@ -118,7 +118,7 @@ unsigned int gt_whatisthemaximalprefixlength(unsigned int numofchars,
                                           totallength+1,
                                           withspecialsuffixes);
   mbp = gt_maxbasepower(numofchars);
-  maxprefixlen = MIN(mbp,maxprefixlen);
+  maxprefixlen = GT_MIN(mbp,maxprefixlen);
   if (prefixlenbits > 0)
   {
     unsigned int tmplength;

--- a/src/match/sfx-bentsedg.c
+++ b/src/match/sfx-bentsedg.c
@@ -1259,13 +1259,13 @@ static void gt_sort_bentleysedgewick(GtBentsedgresources *bsr,
       }
     }
     gt_assert(pb >= pa);
-    wtmp = MIN(pa,pb-pa);
+    wtmp = GT_MIN(pa,pb-pa);
     /* move w elements at the left to the middle */
     gt_assert(pb >= wtmp && wtmp <= pb - wtmp);
     vectorswap(bsr->sssp, subbucketleft, subbucketleft+pb-wtmp, wtmp);
     gt_assert(pd >= pc);
     gt_assert(bucketright >= pd);
-    wtmp = MIN(pd-pc, bucketright-pd);
+    wtmp = GT_MIN(pd-pc, bucketright-pd);
     /* move w elements at the right to the middle */
     gt_assert(bucketright + 1 >= wtmp && pb + wtmp <= bucketright+1-wtmp);
     vectorswap(bsr->sssp, subbucketleft+pb, subbucketleft+bucketright+1-wtmp,

--- a/src/match/sfx-bentsedg.c
+++ b/src/match/sfx-bentsedg.c
@@ -43,10 +43,10 @@
                                                           POS,bsr->readmode)
 #define ACCESSCHARSEQ(ESR)     gt_encseq_reader_next_encoded_char(ESR)
 #define ISNOTEND(POS)          ((POS) < bsr->totallength &&\
-                                ISNOTSPECIAL(ACCESSCHARRAND(POS)))
+                                GT_ISNOTSPECIAL(ACCESSCHARRAND(POS)))
 
 #define DEREFSTOPPOSSEQ(VAR,POS,STOPPOS,ESR)\
-        (((POS) < (STOPPOS) && ISNOTSPECIAL(VAR = ACCESSCHARSEQ(ESR))) ?\
+        (((POS) < (STOPPOS) && GT_ISNOTSPECIAL(VAR = ACCESSCHARSEQ(ESR))) ?\
         ((GtUword) VAR) : GT_UNIQUEINT(POS))
 
 #define DEREFSEQ(VAR,POS,ESR) DEREFSTOPPOSSEQ(VAR,POS,bsr->totallength,ESR)
@@ -76,7 +76,7 @@
         VAR = (((cptr = gt_suffixsortspace_get(bsr->sssp,SUBBUCKETLEFT,IDX)+\
                         depth)\
                 < bsr->totallength &&\
-                ISNOTSPECIAL(TMPVAR = ACCESSCHARRAND(cptr)))\
+                GT_ISNOTSPECIAL(TMPVAR = ACCESSCHARRAND(cptr)))\
                     ? ((GtUword) TMPVAR) : GT_UNIQUEINT(cptr))
 
 typedef GtEndofTwobitencoding GtSfxcmp;

--- a/src/match/sfx-bltrie.c
+++ b/src/match/sfx-bltrie.c
@@ -26,7 +26,8 @@
 #include "sfx-bltrie.h"
 #include "sfx-suffixgetset.h"
 
-#define GT_BLINDTRIECHAR_GT_ISSPECIAL(X)     ((X) >= (GtBlindtriesymbol) GT_WILDCARD)
+#define GT_BLINDTRIECHAR_GT_ISSPECIAL(X) \
+        ((X) >= (GtBlindtriesymbol) GT_WILDCARD)
 #define GT_BLINDTRIE_REFNULL              0
 #define GT_BLINDTRIE_BITSFORRIGHTSIBLING  31
 #define GT_BLINDTRIE_ROOTIDX              0

--- a/src/match/sfx-bltrie.c
+++ b/src/match/sfx-bltrie.c
@@ -26,7 +26,7 @@
 #include "sfx-bltrie.h"
 #include "sfx-suffixgetset.h"
 
-#define GT_BLINDTRIECHAR_ISSPECIAL(X)     ((X) >= (GtBlindtriesymbol) WILDCARD)
+#define GT_BLINDTRIECHAR_GT_ISSPECIAL(X)     ((X) >= (GtBlindtriesymbol) GT_WILDCARD)
 #define GT_BLINDTRIE_REFNULL              0
 #define GT_BLINDTRIE_BITSFORRIGHTSIBLING  31
 #define GT_BLINDTRIE_ROOTIDX              0
@@ -383,7 +383,7 @@ static void blindtrie_makeroot(GtBlindtrie *blindtrie,
                 gt_encseq_get_encoded_char(blindtrie->encseq,
                                            currentstartpos,
                                            blindtrie->readmode);
-    if (GT_BLINDTRIECHAR_ISSPECIAL(firstchar))
+    if (GT_BLINDTRIECHAR_GT_ISSPECIAL(firstchar))
     {
       firstchar = GT_UNIQUEINT(currentstartpos);
     }
@@ -488,7 +488,7 @@ static GtBlindtriesnodeptr blindtrie_findcompanion(
                   gt_encseq_get_encoded_char(blindtrie->encseq,
                                              currentstartpos + headdepth,
                                              blindtrie->readmode);
-        if (GT_BLINDTRIECHAR_ISSPECIAL(newchar))
+        if (GT_BLINDTRIECHAR_GT_ISSPECIAL(newchar))
         {
           newchar = GT_UNIQUEINT(currentstartpos + headdepth);
         }
@@ -610,11 +610,11 @@ static GtUword blindtrie_cmpcharbychar_getlcp(
     {
       cc1 = (GtBlindtriesymbol)
             gt_encseq_reader_next_encoded_char(blindtrie->esr1);
-      if (GT_BLINDTRIECHAR_ISSPECIAL(cc1))
+      if (GT_BLINDTRIECHAR_GT_ISSPECIAL(cc1))
       {
         if (mm_oldsuffixisseparator != NULL)
         {
-          *mm_oldsuffixisseparator = (cc1 == SEPARATOR) ? true : false;
+          *mm_oldsuffixisseparator = (cc1 == GT_SEPARATOR) ? true : false;
         }
         cc1 = GT_UNIQUEINT(leafpos + lcp);
       }
@@ -630,7 +630,7 @@ static GtUword blindtrie_cmpcharbychar_getlcp(
     {
       cc2 = (GtBlindtriesymbol)
             gt_encseq_reader_next_encoded_char(blindtrie->esr2);
-      if (GT_BLINDTRIECHAR_ISSPECIAL(cc2))
+      if (GT_BLINDTRIECHAR_GT_ISSPECIAL(cc2))
       {
         cc2 = GT_UNIQUEINT(currentstartpos + lcp);
       }

--- a/src/match/sfx-copysort.c
+++ b/src/match/sfx-copysort.c
@@ -178,7 +178,7 @@ static GtUword *leftcontextofspecialchardist(unsigned int numofchars,
         if (range.end < totallength)
         {
           cc = gt_encseq_get_encoded_char(encseq,range.end,convertedreadmode);
-          if (ISNOTSPECIAL(cc))
+          if (GT_ISNOTSPECIAL(cc))
           {
             specialchardist[cc]++;
           }
@@ -191,7 +191,7 @@ static GtUword *leftcontextofspecialchardist(unsigned int numofchars,
         if (range.start > 0)
         {
           cc = gt_encseq_get_encoded_char(encseq,range.start-1,readmode);
-          if (ISNOTSPECIAL(cc))
+          if (GT_ISNOTSPECIAL(cc))
           {
             specialchardist[cc]++;
           }
@@ -205,7 +205,7 @@ static GtUword *leftcontextofspecialchardist(unsigned int numofchars,
     if (gt_encseq_lengthofspecialprefix(encseq) == 0)
     {
       cc = gt_encseq_get_encoded_char(encseq,0,convertedreadmode);
-      gt_assert(ISNOTSPECIAL(cc));
+      gt_assert(GT_ISNOTSPECIAL(cc));
       specialchardist[cc]++;
     }
   } else
@@ -213,7 +213,7 @@ static GtUword *leftcontextofspecialchardist(unsigned int numofchars,
     if (gt_encseq_lengthofspecialsuffix(encseq) == 0)
     {
       cc = gt_encseq_get_encoded_char(encseq,totallength-1,readmode);
-      gt_assert(ISNOTSPECIAL(cc));
+      gt_assert(GT_ISNOTSPECIAL(cc));
       specialchardist[cc]++;
     }
   }
@@ -411,7 +411,7 @@ static void gt_copysort_forwardderive(const GtBucketspec2 *bucketspec2,
       GtUchar cc = gt_encseq_get_encoded_char(bucketspec2->encseq,
                                               startpos-1,
                                               bucketspec2->readmode);
-      if (ISNOTSPECIAL(cc) && !bucketspec2->superbuckettab[cc].sorted)
+      if (GT_ISNOTSPECIAL(cc) && !bucketspec2->superbuckettab[cc].sorted)
       {
         GT_SUFFIXSORTSPACE_EXPORT_SET(suffixsortspace,exportptr,
                                       targetoffset[cc],startpos - 1);
@@ -438,7 +438,7 @@ static void gt_copysort_backwardderive(const GtBucketspec2 *bucketspec2,
       GtUchar cc = gt_encseq_get_encoded_char(bucketspec2->encseq,
                                               startpos-1,
                                               bucketspec2->readmode);
-      if (ISNOTSPECIAL(cc) && !bucketspec2->superbuckettab[cc].sorted)
+      if (GT_ISNOTSPECIAL(cc) && !bucketspec2->superbuckettab[cc].sorted)
       {
         GT_SUFFIXSORTSPACE_EXPORT_SET(suffixsortspace,exportptr,
                                       targetoffset[cc],startpos - 1);

--- a/src/match/sfx-diffcov.c
+++ b/src/match/sfx-diffcov.c
@@ -1120,7 +1120,7 @@ static void dc_fill_samplelcpvalues(bool cmpcharbychar,GtDifferencecover *dcov)
                                                dcov->readmode);
               cc2 = gt_encseq_get_encoded_char(dcov->encseq,start1+lcpinherit,
                                                dcov->readmode);
-              if (ISSPECIAL(cc1) || ISSPECIAL(cc2) || cc1 != cc2)
+              if (GT_ISSPECIAL(cc1) || GT_ISSPECIAL(cc2) || cc1 != cc2)
               {
                 break;
               }
@@ -1492,7 +1492,7 @@ static void dc_differencecover_sortsample0(GtDifferencecover *dcov,
       if (pos < dcov->totallength)
       {
         cc = gt_encseq_get_encoded_char(dcov->encseq,pos,dcov->readmode);
-        if (ISSPECIAL(cc))
+        if (GT_ISSPECIAL(cc))
         {
           fullspecials++;
         }
@@ -1532,7 +1532,7 @@ static void dc_differencecover_sortsample0(GtDifferencecover *dcov,
       if (pos < dcov->totallength)
       {
         cc = gt_encseq_get_encoded_char(dcov->encseq,pos,dcov->readmode);
-        if (ISNOTSPECIAL(cc))
+        if (GT_ISNOTSPECIAL(cc))
         {
           dc_suffixptrset(dcov,posinserted,pos);
           posinserted++;

--- a/src/match/sfx-diffcov.c
+++ b/src/match/sfx-diffcov.c
@@ -1050,7 +1050,8 @@ static void dc_init_sfxstrategy_for_sample(Sfxstrategy *sfxstrategy,
 #define SETMAXCOUNT(COMP)\
     if (mainsfxstrategy->COMP >= 1UL)\
     {\
-      sfxstrategy->COMP = GT_MAX(2UL,mainsfxstrategy->COMP * sampledproportion);\
+      sfxstrategy->COMP = GT_MAX(2UL,\
+                                 mainsfxstrategy->COMP * sampledproportion);\
     }
     SETMAXCOUNT(maxcountingsort);
     SETMAXCOUNT(maxbltriesort);
@@ -1193,7 +1194,8 @@ static void dc_differencecover_sortsample(GtDifferencecover *dcov,
   dcov->multimappower = gt_bcktab_multimappower(dcov->bcktab);
   dcov->maxcode = gt_bcktab_numofallcodes(dcov->bcktab) - 1;
   esr1 = gt_encseq_create_reader_with_readmode(dcov->encseq,dcov->readmode,0);
-  dcov->rangestobesorted = gt_inl_queue_new(GT_MAX(16UL,GT_DIV2(dcov->maxcode)));
+  dcov->rangestobesorted = gt_inl_queue_new(GT_MAX(16UL,
+                                                   GT_DIV2(dcov->maxcode)));
   dcov->filltable = gt_filllargestchartable(dcov->numofchars,
                                             dcov->prefixlength);
   gt_assert(dcov->bcktab != NULL);
@@ -1479,7 +1481,8 @@ static void dc_differencecover_sortsample0(GtDifferencecover *dcov,
   dcov->bcktab = NULL;
   dcov->multimappower = NULL;
   dcov->maxcode = 0;
-  dcov->rangestobesorted = gt_inl_queue_new(GT_MAX(16UL,GT_DIV2(dcov->maxcode)));
+  dcov->rangestobesorted = gt_inl_queue_new(GT_MAX(16UL,
+                                            GT_DIV2(dcov->maxcode)));
   dcov->filltable = NULL;
   dcov->leftborder = NULL;
   diffptr = dcov->diffvalues;

--- a/src/match/sfx-diffcov.c
+++ b/src/match/sfx-diffcov.c
@@ -1050,7 +1050,7 @@ static void dc_init_sfxstrategy_for_sample(Sfxstrategy *sfxstrategy,
 #define SETMAXCOUNT(COMP)\
     if (mainsfxstrategy->COMP >= 1UL)\
     {\
-      sfxstrategy->COMP = MAX(2UL,mainsfxstrategy->COMP * sampledproportion);\
+      sfxstrategy->COMP = GT_MAX(2UL,mainsfxstrategy->COMP * sampledproportion);\
     }
     SETMAXCOUNT(maxcountingsort);
     SETMAXCOUNT(maxbltriesort);
@@ -1193,7 +1193,7 @@ static void dc_differencecover_sortsample(GtDifferencecover *dcov,
   dcov->multimappower = gt_bcktab_multimappower(dcov->bcktab);
   dcov->maxcode = gt_bcktab_numofallcodes(dcov->bcktab) - 1;
   esr1 = gt_encseq_create_reader_with_readmode(dcov->encseq,dcov->readmode,0);
-  dcov->rangestobesorted = gt_inl_queue_new(MAX(16UL,GT_DIV2(dcov->maxcode)));
+  dcov->rangestobesorted = gt_inl_queue_new(GT_MAX(16UL,GT_DIV2(dcov->maxcode)));
   dcov->filltable = gt_filllargestchartable(dcov->numofchars,
                                             dcov->prefixlength);
   gt_assert(dcov->bcktab != NULL);
@@ -1479,7 +1479,7 @@ static void dc_differencecover_sortsample0(GtDifferencecover *dcov,
   dcov->bcktab = NULL;
   dcov->multimappower = NULL;
   dcov->maxcode = 0;
-  dcov->rangestobesorted = gt_inl_queue_new(MAX(16UL,GT_DIV2(dcov->maxcode)));
+  dcov->rangestobesorted = gt_inl_queue_new(GT_MAX(16UL,GT_DIV2(dcov->maxcode)));
   dcov->filltable = NULL;
   dcov->leftborder = NULL;
   diffptr = dcov->diffvalues;
@@ -1751,8 +1751,8 @@ static GtUword gt_differencecover_eval_lcp(const GtLcptrace *lcptrace,
     gt_assert(dcov->rmq != NULL);
     return (GtUword)
             gt_rmq_find_min_value(dcov->rmq,
-                                  MIN(lcptrace->idx1,lcptrace->idx2)+1,
-                                  MAX(lcptrace->idx1,lcptrace->idx2))
+                                  GT_MIN(lcptrace->idx1,lcptrace->idx2)+1,
+                                  GT_MAX(lcptrace->idx1,lcptrace->idx2))
              + lcptrace->offset;
   }
   return (GtUword) lcptrace->offset;
@@ -2047,13 +2047,13 @@ static void QSORTNAME(gt_inlinedarr_qsort_r) (QSORTNAME(Datatype) data,
     pn = current.startindex + current.len;
     gt_assert(pa >= current.startindex);
     gt_assert(pb >= pa);
-    s = MIN ((GtUword) (pa - current.startindex),
+    s = GT_MIN ((GtUword) (pa - current.startindex),
              (GtUword) (pb - pa));
     gt_assert(pb >= s);
     GT_QSORT_ARR_VECSWAP (data, current.startindex, pb - s, s);
     gt_assert(pd >= pc);
     gt_assert(pn > pd);
-    s = MIN ((GtUword) (pd - pc), (GtUword) (pn - pd - 1));
+    s = GT_MIN ((GtUword) (pd - pc), (GtUword) (pn - pd - 1));
     gt_assert(pn > s);
     GT_QSORT_ARR_VECSWAP (data, pb, pn - s, s);
     gt_assert(pb >= pa);

--- a/src/match/sfx-enumcodes.c
+++ b/src/match/sfx-enumcodes.c
@@ -181,7 +181,7 @@ GtCodetype gt_Enumcodeatposition_filledqgramcode(const Enumcodeatposition *ecp,
     cc = gt_encseq_get_encoded_char_nospecial(ecp->encseq,
                                               pos + idx,
                                               ecp->readmode);
-    gt_assert(ISNOTSPECIAL(cc));
+    gt_assert(GT_ISNOTSPECIAL(cc));
     code += ecp->multimappower[idx][cc];
   }
   return code;
@@ -210,7 +210,7 @@ bool gt_Enumcodeatposition_filledqgramcodestopatmax(
     cc = gt_encseq_get_encoded_char_nospecial(ecp->encseq,
                                               pos + idx,
                                               ecp->readmode);
-    gt_assert(ISNOTSPECIAL(cc));
+    gt_assert(GT_ISNOTSPECIAL(cc));
     tmpcode += ecp->multimappower[idx][cc];
     if (tmpcode > stopcode)
     {

--- a/src/match/sfx-lcpvalues.c
+++ b/src/match/sfx-lcpvalues.c
@@ -96,12 +96,12 @@ static GtUword computelocallcpvalue(const Suffixwithcode *previoussuffix,
 
   if (previoussuffix->code == currentsuffix->code)
   {
-    lcpvalue = MIN(previoussuffix->prefixindex,
+    lcpvalue = GT_MIN(previoussuffix->prefixindex,
                    currentsuffix->prefixindex);
   } else
   {
     gt_assert(previoussuffix->code < currentsuffix->code);
-    lcpvalue = MIN(previoussuffix->prefixindex,currentsuffix->prefixindex);
+    lcpvalue = GT_MIN(previoussuffix->prefixindex,currentsuffix->prefixindex);
     if (minchanged < lcpvalue)
     {
       lcpvalue = minchanged;
@@ -608,7 +608,7 @@ void gt_Outlcpinfo_prebucket(GtOutlcpinfo *outlcpinfo,
       if (outlcpinfo->previousbucketwasempty)
       {
         outlcpinfo->minchanged
-          = MIN(outlcpinfo->minchanged,
+          = GT_MIN(outlcpinfo->minchanged,
                 gt_turningwheel_minchanged(outlcpinfo->turnwheel));
       } else
       {

--- a/src/match/sfx-linlcp.c
+++ b/src/match/sfx-linlcp.c
@@ -53,7 +53,7 @@ GtUword *gt_ENCSEQ_lcp13_kasai(const GtEncseq *encseq,
         cc1 = gt_encseq_get_encoded_char(encseq, pos+lcpvalue, readmode);
         cc2 = gt_encseq_get_encoded_char(encseq, previousstart+lcpvalue,
                                                 readmode);
-        if (cc1 == cc2 && ISNOTSPECIAL(cc1))
+        if (cc1 == cc2 && GT_ISNOTSPECIAL(cc1))
         {
           lcpvalue++;
         } else
@@ -104,7 +104,7 @@ unsigned int *gt_plain_lcp13_kasai(GtUword *maxlcp,
 
         cc1 = sequence[pos+lcpvalue];
         cc2 = sequence[previousstart+lcpvalue];
-        if (cc1 == cc2 && (!withspecial || ISNOTSPECIAL(cc1)))
+        if (cc1 == cc2 && (!withspecial || GT_ISNOTSPECIAL(cc1)))
         {
           lcpvalue++;
         } else
@@ -164,7 +164,7 @@ unsigned int *gt_plain_lcp_phialgorithm(bool onlyplcp,
       {
         GtUchar cc1 = ptr1[lcpvalue];
         GtUchar cc2 = ptr2[lcpvalue];
-        if (cc1 == cc2 && (!withspecial || ISNOTSPECIAL(cc1)))
+        if (cc1 == cc2 && (!withspecial || GT_ISNOTSPECIAL(cc1)))
         {
           lcpvalue++;
         } else
@@ -259,7 +259,7 @@ static void gt_ENCSEQ_set_relevant_from_inversetab(
       if (pos > 0)
       {
         GtUchar cc = gt_encseq_get_encoded_char(encseq, pos-1, readmode);
-        if (ISSPECIAL(cc))
+        if (GT_ISSPECIAL(cc))
         {
           gt_compact_ulong_store_update(rightposinverse, pos, idx);
         }
@@ -386,7 +386,7 @@ static GtUword gt_ENCSEQ_sa2ranknext(GtCompactUlongStore *ranknext,
     if (pos > 0)
     {
       GtUchar cc = gt_encseq_get_encoded_char(encseq, pos-1, readmode);
-      if (ISNOTSPECIAL(cc))
+      if (GT_ISNOTSPECIAL(cc))
       {
         gt_assert(occless[cc] < partwidth);
         gt_compact_ulong_store_update(ranknext, occless[cc], idx);
@@ -418,7 +418,7 @@ static GtUword gt_ENCSEQ_sa2ranknext(GtCompactUlongStore *ranknext,
       {
         GtUchar cc = gt_encseq_get_encoded_char(encseq, range.start-1,
                                                 readmode);
-        if (ISNOTSPECIAL(cc))
+        if (GT_ISNOTSPECIAL(cc))
         {
           gt_assert(occless[cc] < partwidth);
           gt_compact_ulong_store_update(ranknext, occless[cc], specialidx);
@@ -504,7 +504,7 @@ GtCompactUlongStore *gt_ENCSEQ_lcp9_manzini(GtCompactUlongStore *spacefortab,
           previouscc1pos++;
           cc1 = gt_encseq_reader_next_encoded_char(esr1);
         }
-        if (ISSPECIAL(cc1))
+        if (GT_ISSPECIAL(cc1))
         {
           break;
         }

--- a/src/match/sfx-linlcp.c
+++ b/src/match/sfx-linlcp.c
@@ -96,7 +96,7 @@ unsigned int *gt_plain_lcp13_kasai(GtUword *maxlcp,
     if (fillpos > 0 && fillpos < partwidth)
     {
       GtUword previousstart = (GtUword) suftab[fillpos-1],
-              lastoffset = totallength - MAX(pos,previousstart);
+              lastoffset = totallength - GT_MAX(pos,previousstart);
 
       while (lcpvalue < lastoffset)
       {
@@ -156,7 +156,7 @@ unsigned int *gt_plain_lcp_phialgorithm(bool onlyplcp,
     if (pos != suftab0)
     {
       const unsigned int currentphitab = phitab[pos];
-      const GtUword lastoffset = totallength - MAX(pos,currentphitab);
+      const GtUword lastoffset = totallength - GT_MAX(pos,currentphitab);
       const GtUchar *ptr1 = sequence + pos,
                     *ptr2 = sequence + currentphitab;
 

--- a/src/match/sfx-lwcheck.c
+++ b/src/match/sfx-lwcheck.c
@@ -104,7 +104,7 @@ static void gt_suftab_bk_suffixorder(LW_accesschar accesschar,
     if (position > 0)
     {
       GtUchar cc = accesschar(encseq,position-1,readmode);
-      if (ISNOTSPECIAL(cc))
+      if (GT_ISNOTSPECIAL(cc))
       {
         GtUword checkpos;
 
@@ -219,7 +219,7 @@ void gt_suftab_lightweightcheck(LW_accesschar accesschar,
     cc = accesschar(encseq,position,readmode);
     if (idx > 0)
     {
-      if (ISSPECIAL(cc))
+      if (GT_ISSPECIAL(cc))
       {
         if (firstspecial == totallength)
         {
@@ -229,7 +229,7 @@ void gt_suftab_lightweightcheck(LW_accesschar accesschar,
           rangestore[rangeidx].end = idx-1;
           rangestore[rangeidx++].firstchar = previouscc;
         }
-        if (ISSPECIAL(previouscc))
+        if (GT_ISSPECIAL(previouscc))
         {
           if (previouspos > position)
           {
@@ -241,7 +241,7 @@ void gt_suftab_lightweightcheck(LW_accesschar accesschar,
         }
       } else
       {
-        if (ISSPECIAL(previouscc))
+        if (GT_ISSPECIAL(previouscc))
         {
           fprintf(stderr, "incorrect order: "GT_WU"="GT_WU"=SPECIAL > "
                   "%u="GT_WU"="GT_WU"\n", idx-1, position, (unsigned int) cc,
@@ -270,7 +270,7 @@ void gt_suftab_lightweightcheck(LW_accesschar accesschar,
       }
     } else
     {
-      if (ISSPECIAL(cc))
+      if (GT_ISSPECIAL(cc))
       {
         firstspecial = 0;
       }

--- a/src/match/sfx-mappedstr.c
+++ b/src/match/sfx-mappedstr.c
@@ -551,7 +551,8 @@ const GtKmercode *gt_kmercodeiterator_encseq_next(
   if (kmercodeiterator->currentposition < kmercodeiterator->totallength +
                                           kmercodeiterator->spwp->kmersize)
   {
-    gt_kmerstream_shiftrightwithchar(kmercodeiterator->spwp,(GtUchar) GT_WILDCARD);
+    gt_kmerstream_shiftrightwithchar(kmercodeiterator->spwp,
+                                     (GtUchar) GT_WILDCARD);
     gt_kmerstream_newcode(&kmercodeiterator->kmercode, kmercodeiterator->spwp);
     kmercodeiterator->currentposition++;
     return &kmercodeiterator->kmercode;
@@ -695,7 +696,8 @@ int gt_kmercodeiterator_filetab_next(const GtKmercode **kmercodeptr,
   if (kmercodeiterator->currentposition < kmercodeiterator->totallength +
                                           kmercodeiterator->spwp->kmersize)
   {
-    gt_kmerstream_shiftrightwithchar(kmercodeiterator->spwp,(GtUchar) GT_WILDCARD);
+    gt_kmerstream_shiftrightwithchar(kmercodeiterator->spwp,
+                                     (GtUchar) GT_WILDCARD);
     gt_kmerstream_newcode(&kmercodeiterator->kmercode, kmercodeiterator->spwp);
     kmercodeiterator->currentposition++,
     *kmercodeptr = &kmercodeiterator->kmercode;

--- a/src/match/sfx-mappedstr.c
+++ b/src/match/sfx-mappedstr.c
@@ -81,7 +81,7 @@ static GtCodetype windowkmer2code(unsigned int numofchars,
   bool foundspecial;
 
   cc = cyclicwindow[firstindex];
-  if (ISSPECIAL(cc))
+  if (GT_ISSPECIAL(cc))
   {
     integercode = (GtCodetype) (numofchars-1);
     foundspecial = true;
@@ -98,7 +98,7 @@ static GtCodetype windowkmer2code(unsigned int numofchars,
     } else
     {
       cc = cyclicwindow[(firstindex+i) % kmersize];
-      if (ISSPECIAL(cc))
+      if (GT_ISSPECIAL(cc))
       {
         ADDNEXTCHAR(integercode,numofchars-1,numofchars);
         foundspecial = true;
@@ -138,7 +138,7 @@ static unsigned int determinefirstspecialposition(unsigned int windowwidth,
 
   for (i=0; i < windowwidth; i++)
   {
-    if (ISSPECIAL(cyclicwindow[(firstindex+i) % kmersize]))
+    if (GT_ISSPECIAL(cyclicwindow[(firstindex+i) % kmersize]))
     {
       return i;
     }
@@ -201,7 +201,7 @@ static void special_queue_verify(const GtKmerstream *kmerstream)
   {
     GtUchar cc = kmerstream->cyclicwindow[(kmerstream->firstindex+i) %
                                            kmerstream->kmersize];
-    if (ISSPECIAL(cc))
+    if (GT_ISSPECIAL(cc))
     {
       gt_assert (queueptr->lengthofleftcontext == contextsize);
       if (queueptr > kmerstream->specialqueue.queuespace)
@@ -338,7 +338,7 @@ static void gt_kmerstream_updatespecialpositions(GtKmerstream *spwp,
       special_queueu_head_delete(&spwp->specialqueue);
     }
   }
-  if (ISNOTSPECIAL(charcode))
+  if (GT_ISNOTSPECIAL(charcode))
   {
     if (spwp->lengthwithoutspecial == spwp->kmersize)
     {
@@ -551,7 +551,7 @@ const GtKmercode *gt_kmercodeiterator_encseq_next(
   if (kmercodeiterator->currentposition < kmercodeiterator->totallength +
                                           kmercodeiterator->spwp->kmersize)
   {
-    gt_kmerstream_shiftrightwithchar(kmercodeiterator->spwp,(GtUchar) WILDCARD);
+    gt_kmerstream_shiftrightwithchar(kmercodeiterator->spwp,(GtUchar) GT_WILDCARD);
     gt_kmerstream_newcode(&kmercodeiterator->kmercode, kmercodeiterator->spwp);
     kmercodeiterator->currentposition++;
     return &kmercodeiterator->kmercode;
@@ -695,7 +695,7 @@ int gt_kmercodeiterator_filetab_next(const GtKmercode **kmercodeptr,
   if (kmercodeiterator->currentposition < kmercodeiterator->totallength +
                                           kmercodeiterator->spwp->kmersize)
   {
-    gt_kmerstream_shiftrightwithchar(kmercodeiterator->spwp,(GtUchar) WILDCARD);
+    gt_kmerstream_shiftrightwithchar(kmercodeiterator->spwp,(GtUchar) GT_WILDCARD);
     gt_kmerstream_newcode(&kmercodeiterator->kmercode, kmercodeiterator->spwp);
     kmercodeiterator->currentposition++,
     *kmercodeptr = &kmercodeiterator->kmercode;
@@ -767,7 +767,7 @@ void getencseqkmers(const GtEncseq *encseq,
   gt_encseq_reader_delete(esr);
   for (overshoot=0; overshoot<kmersize; overshoot++)
   {
-    gt_kmerstream_shiftrightwithchar(spwp,(GtUchar) WILDCARD);
+    gt_kmerstream_shiftrightwithchar(spwp,(GtUchar) GT_WILDCARD);
     gt_kmerstream_newcode(&spwp->currentkmercode,spwp);
     processkmercode(processkmercodeinfo,
                     overshoot + currentposition + 1 - spwp->kmersize,

--- a/src/match/sfx-run.c
+++ b/src/match/sfx-run.c
@@ -189,7 +189,7 @@ static int bwttab2file(Outfileinfo *outfileinfo,
       startpos = gt_suffixsortspace_getdirect(suffixsortspace,pos);
       if (startpos == 0)
       {
-        cc = (GtUchar) UNDEFBWTCHAR;
+        cc = (GtUchar) GT_UNDEFBWTCHAR;
       } else
       {
         if (outfileinfo->outfpbwttab != NULL)

--- a/src/match/sfx-sain.c
+++ b/src/match/sfx-sain.c
@@ -322,12 +322,12 @@ static GtUword gt_sainseq_getchar(const GtSainseq *sainseq,
         GtUchar cc = gt_encseq_get_encoded_char(sainseq->seq.encseq,
                                                 position,
                                                 sainseq->readmode);
-        return ISSPECIAL(cc) ? GT_UNIQUEINT(position) : (GtUword) cc;
+        return GT_ISSPECIAL(cc) ? GT_UNIQUEINT(position) : (GtUword) cc;
       }
     case GT_SAIN_BARE_ENCSEQ:
       {
         GtUchar cc = sainseq->seq.plainseq[position];
-        return ISSPECIAL(cc) ? GT_UNIQUEINT(position) : (GtUword) cc;
+        return GT_ISSPECIAL(cc) ? GT_UNIQUEINT(position) : (GtUword) cc;
       }
   }
 #ifndef S_SPLINT_S

--- a/src/match/sfx-sain.inc
+++ b/src/match/sfx-sain.inc
@@ -1198,11 +1198,11 @@ static int gt_sain_ENCSEQ_compare_Sstarstrings(const GtSainseq *sainseq,
     cc1 = (GtUword) gt_encseq_get_encoded_char(
 encseq,
 (GtUword) (start1),
-sainseq->readmode);if (ISSPECIAL(cc1)) { cc1 = GT_UNIQUEINT(start1); };
+sainseq->readmode);if (GT_ISSPECIAL(cc1)) { cc1 = GT_UNIQUEINT(start1); };
     cc2 = (GtUword) gt_encseq_get_encoded_char(
 encseq,
 (GtUword) (start2),
-sainseq->readmode);if (ISSPECIAL(cc2)) { cc2 = GT_UNIQUEINT(start2); };
+sainseq->readmode);if (GT_ISSPECIAL(cc2)) { cc2 = GT_UNIQUEINT(start2); };
     if (cc1 < cc2)
     {
       return -1;
@@ -1252,7 +1252,7 @@ esr = gt_encseq_create_reader_with_readmode(
   for (position = (GtUsainindextype) (sainseq->totallength-1); /* Nothing */;
        position--)
   {
-    GtUword currentcc = ISSPECIAL(tmpcc =
+    GtUword currentcc = GT_ISSPECIAL(tmpcc =
 gt_encseq_reader_next_encoded_char(esr))
  ? GT_UNIQUEINT(position) : (GtUword) tmpcc;
     bool currentisStype = (currentcc < nextcc ||
@@ -1300,7 +1300,7 @@ esr = gt_encseq_create_reader_with_readmode(
   for (position = (GtUsainindextype) (sainseq->totallength-1); /* Nothing */;
        position--)
   {
-    GtUword currentcc = ISSPECIAL(tmpcc =
+    GtUword currentcc = GT_ISSPECIAL(tmpcc =
 gt_encseq_reader_next_encoded_char(esr))
  ? GT_UNIQUEINT(position) : (GtUword) tmpcc;
     bool currentisStype = (currentcc < nextcc ||
@@ -1352,7 +1352,7 @@ esr = gt_encseq_create_reader_with_readmode(
   for (position = (GtUsainindextype) (sainseq->totallength-1); /* Nothing */;
        position--)
   {
-    GtUword currentcc = ISSPECIAL(tmpcc =
+    GtUword currentcc = GT_ISSPECIAL(tmpcc =
 gt_encseq_reader_next_encoded_char(esr))
  ? GT_UNIQUEINT(position) : (GtUword) tmpcc;
     bool currentisStype = (currentcc < nextcc ||
@@ -1398,9 +1398,9 @@ static int gt_sain_BARE_ENCSEQ_compare_Sstarstrings(const GtSainseq *sainseq,
       return -1;
     }
     cc1 = (GtUword)
-plainseq[start1];if (ISSPECIAL(cc1)) { cc1 = GT_UNIQUEINT(start1); };
+plainseq[start1];if (GT_ISSPECIAL(cc1)) { cc1 = GT_UNIQUEINT(start1); };
     cc2 = (GtUword)
-plainseq[start2];if (ISSPECIAL(cc2)) { cc2 = GT_UNIQUEINT(start2); };
+plainseq[start2];if (GT_ISSPECIAL(cc2)) { cc2 = GT_UNIQUEINT(start2); };
     if (cc1 < cc2)
     {
       return -1;
@@ -1447,7 +1447,7 @@ GtUchar tmpcc;
        position--)
   {
     GtUword currentcc = (GtUword)
-ISSPECIAL(tmpcc =
+GT_ISSPECIAL(tmpcc =
 plainseq[position])
   ? GT_UNIQUEINT(position) : (GtUword) tmpcc;
     bool currentisStype = (currentcc < nextcc ||
@@ -1492,7 +1492,7 @@ GtUchar tmpcc;
        position--)
   {
     GtUword currentcc = (GtUword)
-ISSPECIAL(tmpcc =
+GT_ISSPECIAL(tmpcc =
 plainseq[position])
   ? GT_UNIQUEINT(position) : (GtUword) tmpcc;
     bool currentisStype = (currentcc < nextcc ||
@@ -1541,7 +1541,7 @@ GtUchar tmpcc;
        position--)
   {
     GtUword currentcc = (GtUword)
-ISSPECIAL(tmpcc =
+GT_ISSPECIAL(tmpcc =
 plainseq[position])
   ? GT_UNIQUEINT(position) : (GtUword) tmpcc;
     bool currentisStype = (currentcc < nextcc ||

--- a/src/match/sfx-shortreadsort.c
+++ b/src/match/sfx-shortreadsort.c
@@ -487,12 +487,12 @@ static void QSORTNAME(gt_inlinedarr_qsort_r) (
     }
     pn = current.startindex + current.len;
     gt_assert(pa >= current.startindex && pb >= pa);
-    s = MIN ((GtUword) (pa - current.startindex),
+    s = GT_MIN ((GtUword) (pa - current.startindex),
              (GtUword) (pb - pa));
     gt_assert(pb >= s);
     GT_QSORT_ARR_VECSWAP (arr, current.startindex, pb - s, s);
     gt_assert(pd >= pc && pn > pd);
-    s = MIN ((GtUword) (pd - pc), (GtUword) (pn - pd - 1));
+    s = GT_MIN ((GtUword) (pd - pc), (GtUword) (pn - pd - 1));
     gt_assert(pn > s);
     GT_QSORT_ARR_VECSWAP (arr, pb, pn - s, s);
     gt_assert(pb >= pa);

--- a/src/match/sfx-suffixer.c
+++ b/src/match/sfx-suffixer.c
@@ -243,7 +243,7 @@ static GtCodetype getencseqcode(const GtEncseq *encseq,
   {
     gt_assert((GtUword) (pos + idx) < totallength);
     cc = gt_encseq_get_encoded_char_nospecial(encseq,pos + idx,readmode);
-    gt_assert(ISNOTSPECIAL(cc));
+    gt_assert(GT_ISNOTSPECIAL(cc));
     code += multimappower[idx][cc];
   }
   return code;

--- a/src/match/shu-dfs.c
+++ b/src/match/shu-dfs.c
@@ -88,7 +88,7 @@ static inline GtUword **get_special_pos(const FMindex *index,
   for (row_idx = 0; row_idx < first_special_row; row_idx ++)
   {
     cc = gt_bwtseqgetsymbol(row_idx, index);
-    if (ISSPECIAL(cc))
+    if (GT_ISSPECIAL(cc))
     {
       special_char_rows_and_pos[0][special_idx] = row_idx;
       special_char_rows_and_pos[1][special_idx] =

--- a/src/match/spaced-seeds.c
+++ b/src/match/spaced-seeds.c
@@ -142,7 +142,7 @@ static void spse_nextLimdfsstate(const Limdfsconstinfo *mt,
 #endif
   SpseLimdfsconstinfo *mti = (SpseLimdfsconstinfo*) mt;
 
-  gt_assert(ISNOTSPECIAL(currentchar));
+  gt_assert(GT_ISNOTSPECIAL(currentchar));
   gt_assert(currentdepth > 0);
   gt_assert(incol->pathmatches);
 
@@ -160,7 +160,7 @@ static void spse_inplacenextLimdfsstate(const Limdfsconstinfo *mt,
   SpseLimdfsstate *col = (SpseLimdfsstate *) aliascol;
   const SpseLimdfsconstinfo *mti = (const SpseLimdfsconstinfo*) mt;
 
-  gt_assert(ISNOTSPECIAL(currentchar));
+  gt_assert(GT_ISNOTSPECIAL(currentchar));
   gt_assert(currentdepth > 0);
   col->pathmatches = setpathmatch(mti->seedbitvector,
                                   mti->pattern,

--- a/src/match/spmsuftab.c
+++ b/src/match/spmsuftab.c
@@ -85,5 +85,5 @@ size_t gt_spmsuftab_requiredspace(GtUword numofentries,
 
   return sizeof (GtSpmsuftab) +
          gt_compact_ulong_store_size(numofentries,
-                                     MIN(bitsforpositions,bitsforseqnumrelpos));
+                                     GT_MIN(bitsforpositions,bitsforseqnumrelpos));
 }

--- a/src/match/spmsuftab.c
+++ b/src/match/spmsuftab.c
@@ -85,5 +85,6 @@ size_t gt_spmsuftab_requiredspace(GtUword numofentries,
 
   return sizeof (GtSpmsuftab) +
          gt_compact_ulong_store_size(numofentries,
-                                     GT_MIN(bitsforpositions,bitsforseqnumrelpos));
+                                     GT_MIN(bitsforpositions,
+                                            bitsforseqnumrelpos));
 }

--- a/src/match/tagerator.c
+++ b/src/match/tagerator.c
@@ -336,14 +336,14 @@ static int dotransformtag(GtUchar *transformedtag,
   for (idx = 0; idx < taglen; idx++)
   {
     charcode = symbolmap[currenttag[idx]];
-    if (charcode == (GtUchar) UNDEFCHAR)
+    if (charcode == (GtUchar) GT_UNDEFCHAR)
     {
       gt_error_set(err,"undefined character '%c' in tag number " Formatuint64_t,
                 currenttag[idx],
                 PRINTuint64_tcast(tagnumber));
       return -1;
     }
-    if (charcode == (GtUchar) WILDCARD)
+    if (charcode == (GtUchar) GT_WILDCARD)
     {
       if (replacewildcard)
       {

--- a/src/match/test-mappedstr.c
+++ b/src/match/test-mappedstr.c
@@ -48,7 +48,7 @@ static GtCodetype qgram2codefillspecial(unsigned int numofchars,
   {
     /* for testing */
     cc = gt_encseq_get_encoded_char(encseq,startpos,readmode);
-    if (ISSPECIAL(cc))
+    if (GT_ISSPECIAL(cc))
     {
       integercode = (GtCodetype) (numofchars - 1);
       foundspecial = true;
@@ -73,7 +73,7 @@ static GtCodetype qgram2codefillspecial(unsigned int numofchars,
       {
         /* for testing */
         cc = gt_encseq_get_encoded_char(encseq,pos,readmode);
-        if (ISSPECIAL(cc))
+        if (GT_ISSPECIAL(cc))
         {
           ADDNEXTCHAR(integercode,numofchars-1,numofchars);
           foundspecial = true;

--- a/src/match/test-maxpairs.c
+++ b/src/match/test-maxpairs.c
@@ -89,7 +89,7 @@ static GtUword gt_samplesubstring(bool replacespecialchars,
 
     for (idx = 0; idx < substringlength; idx++)
     {
-      if (ISSPECIAL(seqspace[idx]))
+      if (GT_ISSPECIAL(seqspace[idx]))
       {
         seqspace[idx] = (GtUchar) (random() % numofchars);
       }
@@ -246,7 +246,7 @@ static GtUword *gt_sequence2markpositions(GtUword *numofsequences,
   *numofsequences = 1UL;
   for (idx=0; idx<seqlen; idx++)
   {
-    if (seq[idx] == (GtUchar) SEPARATOR)
+    if (seq[idx] == (GtUchar) GT_SEPARATOR)
     {
       (*numofsequences)++;
     }
@@ -259,7 +259,7 @@ static GtUword *gt_sequence2markpositions(GtUword *numofsequences,
   spacemarkpos = gt_malloc(sizeof *spacemarkpos * allocatedmarkpos);
   for (idx=0, nextfreemarkpos = 0; idx<seqlen; idx++)
   {
-    if (seq[idx] == (GtUchar) SEPARATOR)
+    if (seq[idx] == (GtUchar) GT_SEPARATOR)
     {
       spacemarkpos[nextfreemarkpos++] = idx;
     }
@@ -316,12 +316,12 @@ int gt_testmaxpairs(const char *indexname,
     gt_assert(dbseq != NULL);
     query = dbseq + dblen + 1;
     gt_assert(query != NULL);
-    dbseq[dblen] = SEPARATOR;
+    dbseq[dblen] = GT_SEPARATOR;
     querylen = gt_samplesubstring(true,query,encseq,substringlength);
     if (querylen < (GtUword) minlength || dblen < (GtUword) minlength ||
-        dbseq[0] == SEPARATOR || query[0] == SEPARATOR ||
-        dbseq[substringlength-1] == SEPARATOR ||
-        query[substringlength-1] == SEPARATOR)
+        dbseq[0] == GT_SEPARATOR || query[0] == GT_SEPARATOR ||
+        dbseq[substringlength-1] == GT_SEPARATOR ||
+        query[substringlength-1] == GT_SEPARATOR)
     {
       continue;
     }

--- a/src/match/twobits2kmers.c
+++ b/src/match/twobits2kmers.c
@@ -306,7 +306,7 @@ void gt_encseq_faststream(const GtEncseq *encseq,
           pairbitsum += (uint64_t) cc;
           ccesr = gt_encseq_reader_next_encoded_char(esr);
           pairbitsum += (uint64_t) ccesr;
-          gt_assert(cc == ccesr || ISSPECIAL(ccesr));
+          gt_assert(cc == ccesr || GT_ISSPECIAL(ccesr));
         }
         break;
       case BSRS_reader_multi:

--- a/src/match/tyr-mersplit.c
+++ b/src/match/tyr-mersplit.c
@@ -58,7 +58,7 @@ static GtUword extractprefixbytecode(GtUword merbytes,
 {
   GtUword idx, code = 0;
 
-  for (idx=0; idx < MIN((GtUword) sizeof (GtUword),merbytes); idx++)
+  for (idx=0; idx < GT_MIN((GtUword) sizeof (GtUword),merbytes); idx++)
   {
     code = (code << 8) | bytecode[idx];
     if (GT_MULT4(idx+1) == (GtUword) prefixlength)

--- a/src/match/tyr-occratio.c
+++ b/src/match/tyr-occratio.c
@@ -102,7 +102,7 @@ static void iteritvdistribution(GtArrayuint64_t *distribution,
          pos = startpos + length - 1;
          ulen <= (GtUword) maxmersize &&
          pos < totallength &&
-         ISNOTSPECIAL(gt_encseq_get_encoded_char(encseq,pos,readmode));
+         GT_ISNOTSPECIAL(gt_encseq_get_encoded_char(encseq,pos,readmode));
          pos++, ulen++)
     {
       if (ulen >= (GtUword) minmersize)

--- a/src/match/tyr-search.c
+++ b/src/match/tyr-search.c
@@ -163,7 +163,7 @@ static void singleseqtyrsearch(const Tyrindex *tyrindex,
   offset = 0;
   while (qptr <= query + querylen - tyrsearchinfo->mersize)
   {
-    skipvalue = containsspecialbytestring(qptr,offset,tyrsearchinfo->mersize);
+    skipvalue = gt_containsspecialbytestring(qptr,offset,tyrsearchinfo->mersize);
     if (skipvalue == tyrsearchinfo->mersize)
     {
       offset = tyrsearchinfo->mersize-1;

--- a/src/match/tyr-search.c
+++ b/src/match/tyr-search.c
@@ -163,13 +163,15 @@ static void singleseqtyrsearch(const Tyrindex *tyrindex,
   offset = 0;
   while (qptr <= query + querylen - tyrsearchinfo->mersize)
   {
-    skipvalue = gt_containsspecialbytestring(qptr,offset,tyrsearchinfo->mersize);
+    skipvalue = gt_containsspecialbytestring(qptr,offset,
+                                             tyrsearchinfo->mersize);
     if (skipvalue == tyrsearchinfo->mersize)
     {
       offset = tyrsearchinfo->mersize-1;
       if (tyrsearchinfo->searchstrand & STRAND_FORWARD)
       {
-        result = gt_searchsinglemer(qptr,tyrindex,tyrsearchinfo,tyrbckinfo);
+        result = gt_searchsinglemer(qptr,tyrindex,
+                                    tyrsearchinfo,tyrbckinfo);
         if (result != NULL)
         {
           mermatchoutput(tyrindex,

--- a/src/match/xdrop.c
+++ b/src/match/xdrop.c
@@ -242,8 +242,9 @@ void gt_evalxdroparbitscoresextend(bool forward,
          k;         /* lbound - 1 <= k <= ubound + 1*/
   /*The following function calculates the maximal allowed number of
     generations with all front values equal minus infinity.*/
-  const int allowedMININFINITYINTgenerations = GT_MAX(GT_MAX(res->arbitdistances.mis,
-                                                       res->arbitdistances.ins),
+  const int allowedMININFINITYINTgenerations = GT_MAX(
+                                               GT_MAX(res->arbitdistances.mis,
+                                                      res->arbitdistances.ins),
                                                    res->arbitdistances.del) - 1;
   int currentMININFINITYINTgeneration = 0;
   GtXdropfrontvalue tmpfront;

--- a/src/match/xdrop.c
+++ b/src/match/xdrop.c
@@ -74,14 +74,14 @@ void gt_showfrontvalues(const GtArrayGtXdropfrontvalue *fronts,
                        GtWord vlen)
 {
   GtUword l, max_l;
-  GtWord i, j, k, d, filled = 0, integermax = MAX(ulen,vlen),
+  GtWord i, j, k, d, filled = 0, integermax = GT_MAX(ulen,vlen),
        integermin = -integermax;
 
   printf("frontvalues:\n");
   printf("        ");
   printf("%-3c ", vseqptr[0]);
   /* print vseq */
-  max_l = MIN(fronts->nextfreeGtXdropfrontvalue,
+  max_l = GT_MIN(fronts->nextfreeGtXdropfrontvalue,
               (GtUword) GT_XDROP_FRONTIDX(distance, distance));
   for (i = 1L; i < vlen; i++)
     printf("%-3c ", vseqptr[i]);
@@ -232,7 +232,7 @@ void gt_evalxdroparbitscoresextend(bool forward,
                vlen = (GtWord) gt_seqabstract_length(vseq),
                end_k =
                  (GtWord) ulen - vlen, /* diagonal of endpoint (ulen, vlen) */
-               integermax = (GtWord) MAX(ulen, vlen),
+               integermax = (GtWord) GT_MAX(ulen, vlen),
                integermin = -integermax,
                dback = GT_XDROP_SETDBACK(xdropbelowscore);
   GtWord idx,
@@ -242,7 +242,7 @@ void gt_evalxdroparbitscoresextend(bool forward,
          k;         /* lbound - 1 <= k <= ubound + 1*/
   /*The following function calculates the maximal allowed number of
     generations with all front values equal minus infinity.*/
-  const int allowedMININFINITYINTgenerations = MAX(MAX(res->arbitdistances.mis,
+  const int allowedMININFINITYINTgenerations = GT_MAX(GT_MAX(res->arbitdistances.mis,
                                                        res->arbitdistances.ins),
                                                    res->arbitdistances.del) - 1;
   int currentMININFINITYINTgeneration = 0;
@@ -316,7 +316,7 @@ void gt_evalxdroparbitscoresextend(bool forward,
           tmpfront.direction = GT_XDROP_INSERTIONBIT;
         }
       }
-      /* if i = MINUSINFINITYINY or MINUSINFINITYINY + 1 */
+      /* if i = GT_MINUSINFINITYINY or GT_MINUSINFINITYINY + 1 */
       if (i < 0) {
         if (tmpfront.direction == (GtUchar) 0)
           alwaysMININFINITYINT = false;
@@ -337,7 +337,7 @@ void gt_evalxdroparbitscoresextend(bool forward,
         else {
           if (k <= -currd || k >= currd ||
               (gt_xdrop_frontvalue_get(res, currd-1, k) < i &&
-               i <= MIN(ulen, vlen + k))) {
+               i <= GT_MIN(ulen, vlen + k))) {
             if (ulen > i && vlen > j) {
               GtUword lcp;
               gt_assert(forward || (ulen - 1 >= (GtWord) i &&

--- a/src/tools/gt_condenseq_extract.c
+++ b/src/tools/gt_condenseq_extract.c
@@ -128,7 +128,7 @@ gt_condenseq_extract_option_parser_new(void *tool_arguments)
 
   /* -sepchar */
   option = gt_option_new_string("sepchar",
-                                "specify character to print as SEPARATOR "
+                                "specify character to print as GT_SEPARATOR "
                                 "(implies option -output concat",
                                 arguments->sepchar, "|");
   gt_option_parser_add_option(op, option);

--- a/src/tools/gt_condenseq_hmmsearch.c
+++ b/src/tools/gt_condenseq_hmmsearch.c
@@ -216,7 +216,7 @@ static void hmmsearch_create_fine_fas(GtStr *fine_fasta_filename,
   FILE *outfp;
 
   tree_iter = gt_rbtree_iter_new_from_first(seqnums);
-  outfp = gt_xtmpfp_generic(fine_fasta_filename, TMPFP_USETEMPLATE);
+  outfp = gt_xtmpfp_generic(fine_fasta_filename, GT_TMPFP_USETEMPLATE);
   gt_outfp = gt_file_new_from_fileptr(outfp);
   seqnum = gt_rbtree_iter_data(tree_iter);
   while (seqnum != NULL) {

--- a/src/tools/gt_encseq2spm.c
+++ b/src/tools/gt_encseq2spm.c
@@ -232,7 +232,7 @@ static bool gt_encseq2spm_kmersize(GtEncseq2spmArguments *arguments,
   }
   else
   {
-    *kmersize = MIN((unsigned int) GT_UNITSIN2BITENC,
+    *kmersize = GT_MIN((unsigned int) GT_UNITSIN2BITENC,
         arguments->minmatchlength);
   }
   gt_log_log("kmersize=%u", *kmersize);

--- a/src/tools/gt_encseq_bench.c
+++ b/src/tools/gt_encseq_bench.c
@@ -194,7 +194,7 @@ static GtSortedlengthinfo *gt_sortedlengthinfo_new(const GtEncseq *encseq,
                sortedlengthinfo->numofdifferentseqlen] = seqlen;
             gt_assert(gt_encseq_get_encoded_char(encseq,currentpos,
                                                  GT_READMODE_FORWARD)
-                      == (GtUchar) SEPARATOR);
+                      == (GtUchar) GT_SEPARATOR);
           }
           currentpos += 1UL + seqlen;
         }
@@ -222,7 +222,7 @@ static GtUword gt_sortedlengthinfo_seqnum(const GtEncseq *encseq,
 
   gt_assert(position < totallength);
   if (gt_encseq_get_encoded_char(encseq,position,GT_READMODE_FORWARD)
-                    == (GtUchar) SEPARATOR) {
+                    == (GtUchar) GT_SEPARATOR) {
     return ULONG_MAX;
   }
   recordnum = gt_encseq_sep2seqnum(sortedlengthinfo->seqlenseppos,

--- a/src/tools/gt_encseq_decode.c
+++ b/src/tools/gt_encseq_decode.c
@@ -128,7 +128,7 @@ static GtOptionParser* gt_encseq_decode_option_parser_new(void *tool_arguments)
 
   /* -sepchar */
   optionsep = gt_option_new_string("sepchar",
-                                   "specify character to print as SEPARATOR",
+                                   "specify character to print as GT_SEPARATOR",
                                    arguments->sepchar, "|");
   gt_option_parser_add_option(op, optionsep);
   gt_option_imply(optionsep, optionmode);
@@ -296,7 +296,7 @@ static int output_sequence(GtEncseq *encseq, GtEncseqDecodeArguments *args,
       if (args->singlechars) {
         for (j = from; j <= to; j++) {
           char cc = gt_encseq_get_decoded_char(encseq, j, args->rm);
-          if (cc == (char) SEPARATOR)
+          if (cc == (char) GT_SEPARATOR)
             cc = gt_str_get(args->sepchar)[0];
           gt_xfputc(cc, stdout);
         }
@@ -305,7 +305,7 @@ static int output_sequence(GtEncseq *encseq, GtEncseqDecodeArguments *args,
         if (esr) {
           for (j = from; j <= to; j++) {
             char cc = gt_encseq_reader_next_decoded_char(esr);
-            if (cc == (char) SEPARATOR)
+            if (cc == (char) GT_SEPARATOR)
               cc = gt_str_get(args->sepchar)[0];
             gt_xfputc(cc, stdout);
           }

--- a/src/tools/gt_encseq_sample.c
+++ b/src/tools/gt_encseq_sample.c
@@ -128,7 +128,7 @@ static GtOptionParser* gt_encseq_sample_option_parser_new(void *tool_arguments)
 
   /* -sepchar */
   optionsep = gt_option_new_string("sepchar",
-                                   "specify character to print as SEPARATOR",
+                                   "specify character to print as GT_SEPARATOR",
                                    arguments->sepchar, "|");
   gt_option_parser_add_option(op, optionsep);
   gt_option_imply(optionsep, optionmode);

--- a/src/tools/gt_linspace_align.c
+++ b/src/tools/gt_linspace_align.c
@@ -375,7 +375,7 @@ static void gt_linspace_print_sequence(const GtUchar *characters,
       cc = seq[idx];
     } else
     {
-      if (ISSPECIAL(seq[idx]))
+      if (GT_ISSPECIAL(seq[idx]))
       {
         cc = wildcardshow;
       } else

--- a/src/tools/gt_linspace_align.c
+++ b/src/tools/gt_linspace_align.c
@@ -43,12 +43,12 @@
 #include "tools/gt_linspace_align.h"
 
 #define LEFT_DIAGONAL_SHIFT(similarity, ulen, vlen) \
-                            -((1-similarity)*(MAX(ulen,vlen)) +\
-                            MIN(((GtWord)ulen-(GtWord)vlen),0))
+                            -((1-similarity)*(GT_MAX(ulen,vlen)) +\
+                            GT_MIN(((GtWord)ulen-(GtWord)vlen),0))
 
 #define RIGHT_DIAGONAL_SHIFT(similarity, ulen, vlen) \
-                             ((1-similarity)*(MAX(ulen,vlen)) -\
-                             MAX(((GtWord)ulen-(GtWord)vlen),0))
+                             ((1-similarity)*(GT_MAX(ulen,vlen)) -\
+                             GT_MAX(((GtWord)ulen-(GtWord)vlen),0))
 
 typedef struct{
   GtStr      *outputfile; /*default stdout*/
@@ -536,13 +536,13 @@ static int gt_all_against_all_alignment_check(bool affine,
             right_dist = RIGHT_DIAGONAL_SHIFT(arguments->similarity, ulen,
                                               vlen);
           }
-          if ((left_dist > MIN(0, (GtWord)vlen-(GtWord)ulen))||
-              (right_dist < MAX(0, (GtWord)vlen-(GtWord)ulen)))
+          if ((left_dist > GT_MIN(0, (GtWord)vlen-(GtWord)ulen))||
+              (right_dist < GT_MAX(0, (GtWord)vlen-(GtWord)ulen)))
           {
             gt_error_set(err, "ERROR: invalid diagonalband for global "
                               "alignment (ulen: "GT_WU", vlen: "GT_WU")\n"
-                              "left_dist <= MIN(0, vlen-ulen) and "
-                              "right_dist >= MAX(0, vlen-ulen)", ulen, vlen);
+                              "left_dist <= GT_MIN(0, vlen-ulen) and "
+                              "right_dist >= GT_MAX(0, vlen-ulen)", ulen, vlen);
             had_err = 1;
           }
           if (!had_err)

--- a/src/tools/gt_packedindex_chk_search.c
+++ b/src/tools/gt_packedindex_chk_search.c
@@ -150,12 +150,12 @@ gt_packedindex_chk_search(int argc, const char *argv[], GtError *err)
                                          true);
         if (params.maxPatLen < 0)
           params.maxPatLen =
-            MAX(params.minPatLen,
+            GT_MAX(params.minPatLen,
                 125 * gt_recommendedprefixlength(numofchars,totalLen,
                                          GT_RECOMMENDED_MULTIPLIER_DEFAULT,
                                          true)/100);
         else
-          params.maxPatLen = MAX(params.maxPatLen, params.minPatLen);
+          params.maxPatLen = GT_MAX(params.maxPatLen, params.minPatLen);
       }
       fprintf(stderr, "Using patterns of lengths "GT_WU" to "GT_WU"\n",
               params.minPatLen, params.maxPatLen);

--- a/src/tools/gt_readjoiner_overlap.c
+++ b/src/tools/gt_readjoiner_overlap.c
@@ -248,7 +248,7 @@ static int gt_readjoiner_overlap_runner(GT_UNUSED int argc,
   verbose_logger = gt_logger_new(arguments->verbose, GT_LOGGER_DEFLT_PREFIX,
       stdout);
   gt_logger_log(verbose_logger, "verbose output activated");
-  kmersize = MIN((unsigned int) GT_UNITSIN2BITENC, arguments->minmatchlength);
+  kmersize = GT_MIN((unsigned int) GT_UNITSIN2BITENC, arguments->minmatchlength);
 
   el = gt_encseq_loader_new();
   gt_encseq_loader_drop_description_support(el);

--- a/src/tools/gt_seed_extend.c
+++ b/src/tools/gt_seed_extend.c
@@ -951,14 +951,14 @@ static int gt_seed_extend_runner(int argc,
   } else {
     maxseedlength = gt_maxbasepower(nchars) - 1;
   }
-  maxseqlength = MIN(gt_encseq_max_seq_length(aencseq),
+  maxseqlength = GT_MIN(gt_encseq_max_seq_length(aencseq),
                      gt_encseq_max_seq_length(bencseq));
 
   if (arguments->dbs_seedlength == UINT_MAX)
   {
     if (arguments->maxmat == 1)
     {
-      arguments->dbs_seedlength = MIN(maxseedlength, arguments->se_alignlength);
+      arguments->dbs_seedlength = GT_MIN(maxseedlength, arguments->se_alignlength);
     } else
     {
       unsigned int local_seedlength, log_avg_totallength;
@@ -968,19 +968,19 @@ static int gt_seed_extend_runner(int argc,
       log_avg_totallength
         = (unsigned int) gt_round_to_long(gt_log_base(avg_totallength,
                                                       (double) nchars));
-      local_seedlength = (unsigned int) MIN3(log_avg_totallength,
+      local_seedlength = (unsigned int) GT_MIN3(log_avg_totallength,
                                              maxseqlength,maxseedlength);
-      arguments->dbs_seedlength = MAX(local_seedlength, 2);
+      arguments->dbs_seedlength = GT_MAX(local_seedlength, 2);
     }
     if (gt_option_is_set(arguments->se_ref_op_spacedseed))
     {
-      arguments->dbs_seedlength = MIN(maxseedlength,
+      arguments->dbs_seedlength = GT_MIN(maxseedlength,
                                       (arguments->dbs_seedlength * 3)/2);
-      arguments->dbs_seedlength = MAX(arguments->dbs_seedlength,
+      arguments->dbs_seedlength = GT_MAX(arguments->dbs_seedlength,
                                       GT_SPACED_SEED_FIRST_SPAN);
     }
   }
-  if (!had_err && arguments->dbs_seedlength > MIN(maxseedlength, maxseqlength))
+  if (!had_err && arguments->dbs_seedlength > GT_MIN(maxseedlength, maxseqlength))
   {
     if (maxseedlength <= maxseqlength) {
       gt_error_set(err, "maximum seedlength for alphabet of size %u is %u "

--- a/src/tools/gt_seqcorrect.c
+++ b/src/tools/gt_seqcorrect.c
@@ -295,7 +295,7 @@ static bool gt_seqcorrect_bucketkey_kmersize(GtSeqcorrectArguments *arguments,
   else
   {
     gt_assert(arguments->correction_kmersize > 1U);
-    *kmersize = MIN((unsigned int) GT_UNITSIN2BITENC,
+    *kmersize = GT_MIN((unsigned int) GT_UNITSIN2BITENC,
         arguments->correction_kmersize - 1);
   }
   gt_log_log("bucketkey kmersize=%u", *kmersize);

--- a/src/tools/gt_seqorder.c
+++ b/src/tools/gt_seqorder.c
@@ -189,7 +189,7 @@ static int seqorder_str_compare_lex(const void *v1, const void *v2, void *data)
 
   desc1 = gt_encseq_description((GtEncseq*) data, &desclen1, n1);
   desc2 = gt_encseq_description((GtEncseq*) data, &desclen2, n2);
-  rval = strncmp(desc1, desc2, MIN(desclen1, desclen2) * sizeof *desc1);
+  rval = strncmp(desc1, desc2, GT_MIN(desclen1, desclen2) * sizeof *desc1);
   if (rval == 0)
   {
     if (desclen1 > desclen2)
@@ -216,10 +216,10 @@ static int seqorder_str_compare_num(const void *v1, const void *v2, void *data)
   char buf[BUFSIZ];
   desc1 = gt_encseq_description((GtEncseq*) data, &desclen1, n1);
   desc2 = gt_encseq_description((GtEncseq*) data, &desclen2, n2);
-  (void) strncpy(buf, desc1, MIN(BUFSIZ, desclen1) * sizeof (char));
+  (void) strncpy(buf, desc1, GT_MIN(BUFSIZ, desclen1) * sizeof (char));
   buf[desclen1] = '\0';
   arval = gt_parse_uword(&anum, buf);
-  (void) strncpy(buf, desc2, MIN(BUFSIZ, desclen2) * sizeof (char));
+  (void) strncpy(buf, desc2, GT_MIN(BUFSIZ, desclen2) * sizeof (char));
   buf[desclen2] = '\0';
   brval = gt_parse_uword(&bnum, buf);
   if (arval == 0 && brval == 0)

--- a/src/tools/gt_sfxmap.c
+++ b/src/tools/gt_sfxmap.c
@@ -394,14 +394,14 @@ static GtUword gt_sfxmap_determinenumberofwholeleaves(
   for (idx = 0; idx < totallength; idx++)
   {
     cc = gt_encseq_reader_next_encoded_char(esr);
-    if (cc == (GtUchar) SEPARATOR)
+    if (cc == (GtUchar) GT_SEPARATOR)
     {
       sequencestart = true;
     } else
     {
       if (sequencestart)
       {
-        if (cc != (GtUchar) WILDCARD)
+        if (cc != (GtUchar) GT_WILDCARD)
         {
           wholeleafcount++;
         }
@@ -438,7 +438,7 @@ static int gt_sfxmap_comparefullsuffixes(const GtEncseq *encseq,
   {
     if (pos1 >= totallength)
     {
-      cc1 = (GtUchar) SEPARATOR;
+      cc1 = (GtUchar) GT_SEPARATOR;
     } else
     {
       cc1 = (esr1 != NULL) ? gt_encseq_reader_next_encoded_char(esr1)
@@ -446,15 +446,15 @@ static int gt_sfxmap_comparefullsuffixes(const GtEncseq *encseq,
     }
     if (pos2 >= totallength)
     {
-      cc2 = (GtUchar) SEPARATOR;
+      cc2 = (GtUchar) GT_SEPARATOR;
     } else
     {
       cc2 = (esr2 != NULL) ? gt_encseq_reader_next_encoded_char(esr2)
                            : gt_encseq_get_encoded_char(encseq,pos2,readmode);
     }
-    if (ISSPECIAL(cc1))
+    if (GT_ISSPECIAL(cc1))
     {
-      if (ISSPECIAL(cc2))
+      if (GT_ISSPECIAL(cc2))
       {
         if (pos1 < pos2)
         {
@@ -477,7 +477,7 @@ static int gt_sfxmap_comparefullsuffixes(const GtEncseq *encseq,
       break;
     } else
     {
-      if (ISSPECIAL(cc2))
+      if (GT_ISSPECIAL(cc2))
       {
         *maxlcp = pos1 - start1;
         retval = -1; /* a < b */
@@ -636,7 +636,7 @@ static int gt_sfxmap_checkentiresuftab(const char *filename,
                                                      ESASUFFIXPTRGET(suftab,
                                                                      idx),
                                                      readmode)
-                   : SEPARATOR);
+                   : GT_SEPARATOR);
         fprintf(stderr,", maxlcp(bruteforce) = "GT_WU" != "GT_WU"(fast)\n",
                           maxlcp, currentlcp);
         exit(GT_EXIT_PROGRAMMING_ERROR);
@@ -811,7 +811,7 @@ static int gt_sfxmap_esa(const Sfxmapoptions *arguments, GtLogger *logger,
           for (idx = (GtUword) 1; idx<totallength; idx++)
           {
             if (suffixarray.bwttab[idx-1] != suffixarray.bwttab[idx] ||
-                ISSPECIAL(suffixarray.bwttab[idx]))
+                GT_ISSPECIAL(suffixarray.bwttab[idx]))
             {
               bwtdifferentconsecutive++;
             }
@@ -827,7 +827,7 @@ static int gt_sfxmap_esa(const Sfxmapoptions *arguments, GtLogger *logger,
             while (gt_readnextfromstream_GtUchar(&cc,&suffixarray.bwttabstream)
                    == 1)
             {
-              if (prevcc != cc || ISSPECIAL(cc))
+              if (prevcc != cc || GT_ISSPECIAL(cc))
               {
                 bwtdifferentconsecutive++;
               }

--- a/src/tools/gt_simreads.c
+++ b/src/tools/gt_simreads.c
@@ -412,7 +412,7 @@ static int gt_simreads_runner(GT_UNUSED int argc,
     for (i = 0; i < readlen; i++)
     {
       ch = gt_encseq_reader_next_encoded_char(target_reader);
-      if (ch == (GtUchar)SEPARATOR)
+      if (ch == (GtUchar) GT_SEPARATOR)
       {
         break;
       }

--- a/src/tools/gt_wtree_bench.c
+++ b/src/tools/gt_wtree_bench.c
@@ -131,10 +131,10 @@ static int gt_wtree_bench_bench_wtree(GtWtree *wt,
     symbol = gt_wtree_access(wt, gt_rand_max(length-1));
     c = gt_wtree_encseq_unmap_decoded(wt, symbol);
     switch (c) {
-      case (char) SEPARATOR:
+      case (char) GT_SEPARATOR:
         printf("$");
         break;
-      case (char) UNDEFCHAR:
+      case (char) GT_UNDEFCHAR:
         gt_error_set(err, "undefined char in sequence, can't print");
         had_err = 1;
         break;


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Ensure that `#define`s and public function symbols have proper GenomeTools prefixes (`GT_`/`Gt`/`gt_`)
  - Ensure linewidth limit and whitespace standards
