### PR TITLE
make GenomeTools compile on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,8 +324,10 @@ endif
 ifneq ($(SYSTEM),Windows)
   EXP_CPPFLAGS += -DLUA_DL_DLOPEN
   ifneq ($(SYSTEM),FreeBSD)
+  ifneq ($(SYSTEM),OpenBSD)
     LUA_LDLIB:=-ldl
     EXP_LDLIBS += -ldl
+  endif
   endif
 endif
 
@@ -457,7 +459,9 @@ ifneq ($(with-sqlite),no)
     ifneq ($(SYSTEM),Windows)
       EXP_LDLIBS += -lpthread
       ifneq ($(SYSTEM),FreeBSD)
+      ifneq ($(SYSTEM),OpenBSD)
         EXP_LDLIBS += -ldl
+      endif
       endif
     endif
   endif

--- a/src/external/samtools-0.1.18/knetfile.c
+++ b/src/external/samtools-0.1.18/knetfile.c
@@ -40,6 +40,7 @@
 #ifndef _WIN32
 #include <netdb.h>
 #include <arpa/inet.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #endif
 


### PR DESCRIPTION
These patches allow GenomTools to be compiled on OpenBSD (with `sharedlib=no`).

AnnotationSketch can be included if `cairo` and `pango` are installed.