### PR TITLE
enable pthreads by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,7 @@ else
                     src/gtlua/layout_lua.c
 endif
 
-ifeq ($(threads),yes)
+ifneq ($(threads),no)
   EXP_CPPFLAGS += -DGT_THREADS_ENABLED
   EXP_LDLIBS += -lpthread
   GTSHAREDLIB_LIBDEP += -lpthread


### PR DESCRIPTION
## Brief summary

I would like to start a discussion about making `threads=yes` the default. With #971 I have added a way of doing things that will not work properly without pthread support, and I think it's time to finally expect this on target systems. Any objections?

This PR introduces the following changes:

  - Change `Makefile` to treat `threads` as always enabled unless explicitly disabled.

## Related issues

Blocks #971 
