### PR TITLE
Implement leaf deletion for gtpython API

### DIFF
--- a/gtpython/gt/extended/feature_node.py
+++ b/gtpython/gt/extended/feature_node.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2014 Daniel Standage <daniel.standage@gmail.com>
-# Copyright (c) 2008-2009 Sascha Steinbiss <steinbiss@zbh.uni-hamburg.de>
+# Copyright (c) 2008-2009, 2021 Sascha Steinbiss <sascha@steinbiss.name>
 # Copyright (c) 2008-2009 Center for Bioinformatics, University of Hamburg
 #
 # Permission to use, copy, modify, and distribute this software for any
@@ -132,6 +132,15 @@ class FeatureNode(GenomeNode):
     def unset_score(self):
         gtlib.gt_feature_node_unset_score(self.gn)
 
+    def number_of_children(self):
+        return gtlib.gt_feature_node_number_of_children(self.gn)
+
+    def remove_leaf(self, leaf):
+        nofc = leaf.number_of_children()
+        if nofc > 0:
+            gterror("%s is not a leaf, it has %d children" % (leaf, nofc))
+        gtlib.gt_feature_node_remove_leaf(self, leaf)
+
     score = cachedproperty(get_score, set_score, unset_score)
 
     def get_attribute(self, attrib):
@@ -203,6 +212,11 @@ class FeatureNode(GenomeNode):
         gtlib.gt_feature_node_set_type.argtypes = [c_void_p, c_char_p]
         gtlib.gt_feature_node_unset_score.restype = None
         gtlib.gt_feature_node_unset_score.argtypes = [c_void_p]
+        gtlib.gt_feature_node_remove_leaf.restype = None
+        gtlib.gt_feature_node_remove_leaf.argtypes = [c_void_p,
+                                                      FeatureNode]
+        gtlib.gt_feature_node_number_of_children.restype = c_ulong
+        gtlib.gt_feature_node_number_of_children.argtypes = [c_void_p]
 
     register = classmethod(register)
 

--- a/gtpython/tests/__init__.py
+++ b/gtpython/tests/__init__.py
@@ -1,17 +1,15 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from test_alphabet import *
-from test_commentnode import *
-from test_customvisitor import *
-from test_encseq import *
-from test_featurenode import *
-from test_metanode import *
-from test_sequencenode import *
-from test_iterators import *
-from test_stream import *
-from test_range import *
-from test_version import *
+from .test_alphabet import *
+from .test_commentnode import *
+from .test_customvisitor import *
+from .test_encseq import *
+from .test_featurenode import *
+from .test_metanode import *
+from .test_sequencenode import *
+from .test_iterators import *
+from .test_stream import *
+from .test_range import *
+from .test_version import *
 
-import unittest
-unittest.main()

--- a/gtpython/tests/test_featurenode.py
+++ b/gtpython/tests/test_featurenode.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from gt import FeatureNode, FeatureNodeIteratorDepthFirst, GenomeNode
+from gt import FeatureNode, FeatureNodeIteratorDepthFirst, FeatureNodeIteratorDirect, GenomeNode, GTError
 
 
 class FeatureNodeTestCase(unittest.TestCase):
@@ -171,6 +171,38 @@ class TestFeatureNodeProperties(unittest.TestCase):
 
         f2 = FeatureNode.create_from_ptr(g.gn, True)
         self.assertEqual((100, 500), f2.range)
+
+
+class TestFeatureNodeRemoveLeaf(unittest.TestCase):
+
+    def setUp(self):
+        seqid = "foo"
+        self.gene = FeatureNode.create_new(seqid, "gene", 100, 900, "+")
+        exon = FeatureNode.create_new(seqid, "exon", 100, 200, "+")
+        self.gene.add_child(exon)
+        intron = FeatureNode.create_new(seqid, "intron", 201, 799, "+")
+        self.gene.add_child(intron)
+        exon = FeatureNode.create_new(seqid, "exon", 800, 900, "+")
+        self.gene.add_child(exon)
+
+    def test_remove_leaf(self):
+        fin = FeatureNodeIteratorDirect(self.gene)
+        while True:
+            fn = fin.next()
+            if not fn:
+                break
+            if fn.get_type() == "intron":
+                self.gene.remove_leaf(fn)
+        while True:
+            fn = fin.next()
+            if not fn:
+                break
+            if fn.get_type()!= "intron":
+                self.fail()
+
+    def test_remove_leaf_fail(self):
+        self.assertRaises(AttributeError, self.gene.remove_leaf, 1)
+        self.assertRaises(GTError, self.gene.remove_leaf, self.gene)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Add `feature_node.remove_leaf()`.
  - Fix pytest test invocation for Python 3.
  - Add tests.

## Related issues

Adresses #969 by adding a missing Python API function.