### PR TITLE
extend buffer for hmmscan output parsing

### DIFF
--- a/src/ltr/ltrdigest_pdom_visitor.c
+++ b/src/ltr/ltrdigest_pdom_visitor.c
@@ -57,7 +57,7 @@
 #include "ltr/ltrdigest_def.h"
 #include "ltr/ltrdigest_pdom_visitor.h"
 
-#define GT_HMMER_BUF_LEN  122
+#define GT_HMMER_BUF_LEN  64000
 
 struct GtLTRdigestPdomVisitor {
   const GtNodeVisitor parent_instance;


### PR DESCRIPTION
## Brief summary

This PR fixes a bug where long `TMPDIR` values can lead to excessively long lines in the `hmmscan` output (which contains the full path to the temporary HMM files in the `TMPDIR`). These lines can exceed the buffer size for parsing outputs and cause the parsing of the whole output to fail.

This patch makes sure that long lines in the output also fit into the buffer to be made available for parsing. 
Thanks to E. Aunin for bringing this to my attention.

This PR introduces the following changes:

  - Extend buffer size for `hmmscan` output parsing to 64K.

# Related issues

Probably related and fixing #662.
