### PR TITLE
Ensure pseudo feature node range is updated

### DIFF
--- a/src/extended/gff3_parser.c
+++ b/src/extended/gff3_parser.c
@@ -563,6 +563,7 @@ static int process_id_attr(const char *id, GtFeatureNode *feature_node,
                                                 parser->feature_info);
             replace_node(fn, pseudo_node, genome_nodes);
             gt_feature_node_add_child(pseudo_node, feature_node);
+            update_pseudo_node_range(pseudo_node, feature_node);
             *is_child = true;
           }
         }


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Ensure that the pseudo node range is updated to reflect the whole span of the children also when it is created. The range was previously only extended after the _third_ child is seen, pseudo nodes with only two children always were stuck with the range of the first one. This caused issues when pseudo node ranges are used to derive overlapping clusters, like #985.

## Related issues

Fixes #985 by ensuring that the sortable clusters are calculated correctly by fixing pseudo-node range derivation.
