### PR TITLE
Update README.* and INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -21,7 +21,6 @@ Possible arguments:
 - amalgamation=yes to compile as an amalgamation
 - cairo=no         to disable AnnotationSketch, dropping Cairo/Pango deps
 - errorcheck=no    to disable the handling of compiler warnings as errors
-- universal=yes    to build a universal binary
 - useshared=yes    to use the system's shared libraries
 - verbose=yes      to make the build more verbose
 
@@ -48,7 +47,7 @@ AnnotationSketch support is not required, GenomeTools can be built without
 graphics support by invoking make as above with the argument `cairo=no'.
 
 
-Building GenomeTools on Mac OS X (>= 10.6):
+Building GenomeTools on macOS:
 -------------------------------------------
 
 Make sure the command line developer tools are installed:
@@ -60,22 +59,10 @@ AnnotationSketch support (cairo=no). To build GenomeTools with AnnotationSketch,
 you can use Homebrew (http://brew.sh) to install the necessary dependencies
 required for building:
 
-$ brew install caskroom/cask/brew-cask
-$ brew cask install xquartz
-$ brew install cairo
-$ brew install pango
+$ brew install pango cairo libffi pkg-config
 
-To start the build process, invoke make as stated above.
-
-
-Building GenomeTools as a Universal Binary (on PPC systems with Mac OS X < v10.6):
-----------------------------------------------------------------------------------
-
-Invoke make as above with the argument universal=yes.
-Note that on later Mac OS X systems (those with an Intel CPU) the universal=yes
-option is not required. Also, do not use it on Mac OS X 10.6 (Snow Leopard) or
-later as PowerPC support has since been discontinued. Thus trying to build a
-universal binary may lead to problems.
+To start the build process, invoke make as stated above. You might need to set
+the PKG_CONFIG_PATH environment variable to /usr/local/opt/libffi/lib/pkgconfig.
 
 
 Building GenomeTools on Windows (using Cygwin):

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 This directory contains the source code for GenomeTools (gt).
 
-Copyright (c) 2003-2016 G. Gremme, S. Steinbiss, S. Kurtz, and CONTRIBUTORS
-Copyright (c) 2003-2016 Center for Bioinformatics, University of Hamburg
+Copyright (c) 2003-2021 G. Gremme, S. Steinbiss, S. Kurtz, and CONTRIBUTORS
+Copyright (c) 2003-2021 Center for Bioinformatics, University of Hamburg
 See LICENSE file or http://genometools.org/license.html for license details.
 
 The GenomeTools genome analysis system is a collection of bioinformatics tools
@@ -10,6 +10,7 @@ It is based on a C library named ``libgenometools''.
 
 doc/                   some documentation
 gtdata/                data needed by gt (during runtime)
+gtgo/                  contains GenomeTools Go bindings
 gtruby/                contains GenomeTools Ruby bindings (-> gtruby/README)
 gtpython/              contains GenomeTools Python bindings (-> gtpython/README)
 gtscripts/             some GenomeTools scripts (can be executed with gt)

--- a/README.md
+++ b/README.md
@@ -14,22 +14,35 @@ If you are interested in gene prediction, have a look at
 ### [Platforms](#platforms)
 
 GenomeTools has been designed to run on every POSIX compliant UNIX system, for
-example, Linux, Mac OS X, and OpenBSD.
+example, Linux, macOS, and OpenBSD.
 
 ### [Building and Installation](#build-install)
 
-Debian (testing) and Ubuntu (raring and later) users can install the most recent
+#### Debian-based operating systems
+
+Debian and Ubuntu users can install the most recent
 stable version simply using apt, e.g.
 ```bash
 % apt-get install genometools
 ```
-to install the `gt` executable. To install the library and development headers,
-use
+(as root) to install the `gt` executable. To install the library and development headers, use
 ```bash
 % apt-get install libgenometools0 libgenometools0-dev
 ```
 instead.
 
+#### macOS (via Homebrew)
+
+If [Homebrew](https://brew.sh) is installed, GenomeTools can be installed on
+supported macOS versions using `brew`:
+```bash
+$ brew install genometools
+```
+
+#### Building from source
+
+To use GenomeTools on systems that do not have native packages, or to modify
+GenomeTools at build time, you need to build from source.
 [Source tarballs](https://github.com/genometools/genometools/releases) are
 available from GitHub. For instructions on how to build the source by yourself,
 have a look at the
@@ -38,12 +51,12 @@ In most cases (e.g. on a 64-bit Linux system) something like
 ```bash
 $ make -j4
 ```
-should suffice. On 32-bit systems, add the `32bit=yes` option. Add `cairo=no`
-if you do not have the Cairo libraries and their
-development headers installed. This will, however, remove *AnnotationSketch*
-support from the resulting binary. When your binary has been built, use the
-`install` target and `prefix` option to install the compiled binary on your
-system. Make sure you repeat all the options from the original `make` run. So
+should suffice. On 32-bit systems, add the `32bit=yes` option. Add `cairo=no` if
+you do not have the Cairo libraries and their development headers installed.
+This will, however, remove *AnnotationSketch* support from the resulting binary.
+When your binary has been built, use the `install` target and `prefix` option to
+install the compiled binary on your system. Make sure you repeat all the options
+from the original `make` run. So
 ```bash
 $ make -j4 install prefix=~/gt
 ```
@@ -53,19 +66,14 @@ system-wide (requires root access).
 
 ### [Contributing](#contributing)
 
-GenomeTools uses a [collective code construction
-contract](http://genometools.org/contract.html) for contributions (and the
-[process](http://genometools.org/contribute.html) explains how to submit a
-patch). Basically, just fork this repository on GitHub, start hacking on your
-own feature branch and submit a pull request when you are ready. Our recommended
-coding style is explained in the
+GenomeTools uses a
+[collective code construction contract](http://genometools.org/contract.html)
+for contributions (and the [process](http://genometools.org/contribute.html)
+explains how to submit a patch). Basically, just fork this repository on GitHub,
+start hacking on your own feature branch and submit a pull request when you are
+ready. Our recommended coding style is explained in the
 [developer's guide](http://genometools.org/documents/devguide.pdf) (among other
 technical guidelines).
 
 To report a bug, ask a question, or suggest new features, use the
 [GenomeTools issue tracker](https://github.com/genometools/genometools/issues).
-
-If you only have a small question and a [gitter.im](https://gitter.im) account,
-you can check
-[![Gitter chat](https://badges.gitter.im/genometools/genometools.png)]
-(https://gitter.im/genometools/genometools) if one of the developers is online.


### PR DESCRIPTION
## Brief summary

Watching some issues being reported that seem to be caused by a misunderstanding of how to install GenomeTools (most likely after googling), I propose a slight update of the `README` and `INSTALL` files.

This PR introduces the following changes:

  - Clarify supported Debian and Ubuntu versions for `apt` installation. GenomeTools has been in stable for years now.
  - Add Homebrew install instructions for Mac users.
  - Switch to current "macOS" name instead of "Mac OS X".
  - Remove Gitter reference (or does anyone still watch that?)
  - Note in `README` in what cases building from source is required.
  - Remove reference to universal binaries from `INSTALL` as that should be only of historic value and may confuse readers.
  - Mention `gtgo/` in `README`.
  - Update Homebrew dependency list to what is really required according to the macOS CI builds.

