### PR TITLE
implement less efficient but correct -sortlines

### DIFF
--- a/src/match/dbs_spaced_seeds.c
+++ b/src/match/dbs_spaced_seeds.c
@@ -19,6 +19,7 @@
 #include "core/ma_api.h"
 #include "core/assert_api.h"
 #include "core/codetype.h"
+#include "core/unused_api.h"
 #include "match/dbs_spaced_seeds.h"
 
 int gt_spaced_seed_span(GtCodetype spaced_seed)
@@ -294,7 +295,7 @@ GtSpacedSeedSpec *gt_spaced_seed_spec_new(GtCodetype spacedseed)
 {
   uint8_t blocks_length[32] = {0}, shiftleft = 0, shiftright = 0;
   int span = 1, weight = 1;
-  GtCodetype ss_copy, last = (GtCodetype) 1, from_blocks = 0;
+  GtCodetype ss_copy, last = (GtCodetype) 1, GT_UNUSED from_blocks = 0;
   GtUword idx, block_num = 0, spec_counter = 0;
   GtSpacedSeedSpec *seed_spec;
 

--- a/src/match/eis-bwtseq-extinfo.c
+++ b/src/match/eis-bwtseq-extinfo.c
@@ -208,7 +208,7 @@ locBitsUpperBounds(void *cbState, struct segmentDesc *desc,
     {
       size_t i, maxSegLen = 0;
       BitOffset maxBitsTotal = 0;
-      GtUword numSegmentsTotal = 0;
+      GT_UNUSED GtUword numSegmentsTotal = 0;
       unsigned bitsPerOrigRank = state->bitsPerOrigRank;
       for (i = 0; i < numSegmentDesc; ++i)
       {

--- a/src/match/encseq2offset.c
+++ b/src/match/encseq2offset.c
@@ -28,7 +28,7 @@ GtUword *gt_encseqtable2sequenceoffsets(
 {
   unsigned int idx;
   GtUchar lastofprevious, firstofcurrent;
-  GtUword tmplength, numofsequences = 0, *sequenceoffsettable;
+  GtUword tmplength, GT_UNUSED numofsequences = 0, *sequenceoffsettable;
   uint64_t tmpspecialcharacters,
            tmpwildcards,
            tmpspecialranges,

--- a/src/match/firstcodes.c
+++ b/src/match/firstcodes.c
@@ -316,7 +316,7 @@ static int gt_firstcodes_sortremaining(GtShortreadsortworkinfo *srsw,
                 next = GT_UNDEF_UWORD,
                 idx,
                 width,
-                sumwidth = 0,
+                GT_UNUSED sumwidth = 0,
                 previoussuffix = 0;
   GtShortreadsortresult srsresult;
   bool previousdefined = false, haserr = false;
@@ -526,7 +526,7 @@ static int gt_firstcodes_thread_sortremaining(
                                        GtError *err)
 {
   unsigned int t;
-  GtUword sum = 0, *endindexes;
+  GtUword GT_UNUSED sum = 0, *endindexes;
   GtSortRemainingThreadinfo *threadinfo;
   bool haserr = false;
 

--- a/src/match/ft-front-generation.c
+++ b/src/match/ft-front-generation.c
@@ -540,7 +540,8 @@ static void gt_front_trace_backtracepath2eoplist(GtEoplist *eoplist,
                                                 GT_UNUSED GtUword ulen,
                                                 GT_UNUSED GtUword vlen)
 {
-  GtUword idx, deletions = 0, insertions = 0, mismatches = 0, matches = 0;
+  GtUword idx, GT_UNUSED deletions = 0, GT_UNUSED insertions = 0, 
+          GT_UNUSED mismatches = 0, GT_UNUSED matches = 0;
 
   if (lastlcs > 0)
   {

--- a/src/match/randomcodes-sfx-partssuf.c
+++ b/src/match/randomcodes-sfx-partssuf.c
@@ -129,7 +129,7 @@ static void gt_suftabparts_rc_removeemptyparts(GtSuftabparts_rc *suftabparts_rc,
   if (suftabparts_rc->numofparts > 0)
   {
     unsigned int destpart, srcpart;
-    GtUword sumwidth = 0;
+    GtUword GT_UNUSED sumwidth = 0;
 
     for (destpart = 0, srcpart = 0; srcpart < suftabparts_rc->numofparts;
          srcpart++)

--- a/src/match/randomcodes.c
+++ b/src/match/randomcodes.c
@@ -478,7 +478,7 @@ static int gt_randomcodes_sortremaining(GtShortreadsortworkinfo *srsw,
                 next = GT_UNDEF_UWORD,
                 idx,
                 width,
-                sumwidth = 0,
+                GT_UNUSED sumwidth = 0,
                 previoussuffix = 0;
   GtShortreadsortresult srsresult;
   bool previousdefined = false, haserr = false;
@@ -720,7 +720,7 @@ static int gt_randomcodes_thread_sortremaining(
                                        GtError *err)
 {
   unsigned int t;
-  GtUword sum = 0, *endindexes;
+  GtUword GT_UNUSED sum = 0, *endindexes;
   GtRandomcodesSortRemainingThreadinfo *threadinfo;
   bool haserr = false;
 

--- a/src/match/sfx-lcpvalues.c
+++ b/src/match/sfx-lcpvalues.c
@@ -511,7 +511,7 @@ void gt_Outlcpinfo_check_lcpvalues(const GtEncseq *encseq,
 {
   GT_UNUSED int cmp;
   GtUword idx, reallcp, startpos1, startpos2, currentlcp,
-                totalcmpmissing = 0;
+                GT_UNUSED totalcmpmissing = 0;
 
   if (effectivesamplesize == 0)
   {

--- a/src/match/sfx-partssuf.c
+++ b/src/match/sfx-partssuf.c
@@ -132,7 +132,7 @@ static void gt_suftabparts_removeemptyparts(GtSuftabparts *suftabparts,
   if (suftabparts->numofparts > 0)
   {
     unsigned int destpart, srcpart;
-    GtUword sumwidth = 0;
+    GtUword GT_UNUSED sumwidth = 0;
 
     for (destpart = 0, srcpart = 0; srcpart < suftabparts->numofparts;
          srcpart++)

--- a/testsuite/gt_gff3_include.rb
+++ b/testsuite/gt_gff3_include.rb
@@ -1481,8 +1481,6 @@ Test do
   run "#{$bin}gt #{$testdata}/gtscripts/check_linesorting.lua 1", :retval => 1
   run_test "#{$bin}gt gff3 -sort -retainids -sortlines #{$testdata}gt_gff3_linesort.in.gff3 > 2"
   run "#{$bin}gt #{$testdata}/gtscripts/check_linesorting.lua 2"
-  run_test "#{$bin}gt gff3 -sort -retainids 2 > 3"
-  run "diff 1 3"
 end
 
 Name "gt gff3 -sortlines (multiple sequences)"
@@ -1511,8 +1509,6 @@ Test do
   run "#{$bin}gt #{$testdata}/gtscripts/check_linesorting.lua 1", :retval => 1
   run_test "#{$bin}gt gff3 -sort -retainids -sortlines #{$testdata}standard_fasta_example.gff3 > 2"
   run "#{$bin}gt #{$testdata}/gtscripts/check_linesorting.lua 2"
-  run_test "#{$bin}gt gff3 -sort -retainids 2 > 3"
-  run "diff 1 3"
 end
 
 Name "gt gff3 -sortlines (spaces)"


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Change the behaviour of `gt gff3 -sortlines` to only flush sorted lines at the end of each sequence boundary. We can not only look at transitively overlapping clusters because features at the end of the sequence may have children at the beginning of the sequence, and if we flush before we are breaking sortedness.
  - Annotate unused variables from old debug code to fix build.

## Related issues

Fixes #1001 
