### PR TITLE
ensure validity checks for orphan nodes

### DIFF
--- a/testdata/forward_wrong_seqid.gff3
+++ b/testdata/forward_wrong_seqid.gff3
@@ -1,0 +1,14 @@
+##gff-version 3
+##sequence-region ctg123 1 1497228
+##sequence-region ctg321 1 1497228
+ctg123	.	gene	1000	9000	.	+	.	ID=gene00001;Name=EDEN
+ctg123	.	TF_binding_site	1000	1012	.	+	.	ID=tfbs00001;Parent=gene00001
+ctg123	.	mRNA	1050	9000	.	+	.	ID=mRNA00001;Parent=gene00001;Name=EDEN.1
+ctg123	.	mRNA	1050	9000	.	+	.	ID=mRNA00002;Parent=gene00001;Name=EDEN.2
+ctg123	.	mRNA	1300	9000	.	+	.	ID=mRNA00003;Parent=gene00006;Name=EDEN.3
+ctg123	.	exon	1300	1500	.	+	.	ID=exon00001;Parent=mRNA00003
+ctg123	.	exon	1050	1500	.	+	.	ID=exon00002;Parent=mRNA00001,mRNA00002
+ctg123	.	exon	3000	3902	.	+	.	ID=exon00003;Parent=mRNA00001,mRNA00003
+ctg123	.	exon	5000	5500	.	+	.	ID=exon00004;Parent=mRNA00001,mRNA00002,mRNA00003
+ctg123	.	exon	7000	9000	.	+	.	ID=exon00005;Parent=mRNA00001,mRNA00002,mRNA00003
+ctg321	.	gene	1000	9000	.	+	.	ID=gene00006;Name=EDEN2

--- a/testsuite/gt_gff3_include.rb
+++ b/testsuite/gt_gff3_include.rb
@@ -1560,6 +1560,13 @@ Test do
   run "#{$bin}gt gff3 #{$testdata}/double_free.gff3", :retval => 1
 end
 
+Name "gt gff3 orphan validity checks"
+Keywords "gt_gff3"
+Test do
+  run "#{$bin}gt gff3 #{$testdata}/forward_wrong_seqid.gff3", :retval => 1
+  grep last_stderr, "has different sequence id than its parent on line 14"
+end
+
 def large_gff3_test(name, file)
   Name "gt gff3 #{name}"
   Keywords "gt_gff3 large_gff3"


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Ensure that checks for required preconditions that might cause assertions to fail are also done for orphan nodes (i.e. nodes with forward references to yet unseen parent nodes). This has been shown to open a different code path in which some of these tests can be skipped, leading to issues later.

## Related issues

Fixes #851.
