### PR TITLE
unify Python bytes/string handling

### DIFF
--- a/gtpython/gt/annotationsketch/diagram.py
+++ b/gtpython/gt/annotationsketch/diagram.py
@@ -19,6 +19,7 @@
 #
 
 from ctypes import CFUNCTYPE, c_char_p, c_void_p, c_int
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.annotationsketch.block import Block
 from gt.annotationsketch.canvas import Canvas
@@ -60,7 +61,7 @@ class Diagram:
         if rng.start > rng.end:
             gterror("range.start > range.end")
         diagram = gtlib.gt_diagram_new(feature_index,
-                                       str(seqid).encode('UTF-8'), byref(rng),
+                                       gtbytes(seqid), byref(rng),
                                        style, err)
         if err.is_set():
             gterror(err)

--- a/gtpython/gt/annotationsketch/graphics.py
+++ b/gtpython/gt/annotationsketch/graphics.py
@@ -18,6 +18,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.annotationsketch.color import Color
 from gt.core.array import Array
@@ -58,19 +59,19 @@ class Graphics:
     from_param = classmethod(from_param)
 
     def draw_text(self, x, y, text):
-        gtlib.gt_graphics_draw_text(self.g, x, y, str(text).encode("utf-8"))
+        gtlib.gt_graphics_draw_text(self.g, x, y, gtbytes(text))
 
     def draw_text_centered(self, x, y, text):
         gtlib.gt_graphics_draw_text_centered(
-            self.g, x, y, str(text).encode("utf-8"))
+            self.g, x, y, gtbytes(text))
 
     def draw_text_right(self, x, y, text):
         gtlib.gt_graphics_draw_text_right(
-            self.g, x, y, str(text).encode("utf-8"))
+            self.g, x, y, gtbytes(text))
 
     def draw_colored_text(self, x, y, color, text):
         gtlib.gt_graphics_draw_colored_text(
-            self.g, x, y, color, str(text).encode("utf-8"))
+            self.g, x, y, color, gtbytes(text))
 
     def get_image_height(self):
         return gtlib.gt_graphics_get_image_height(self.g)
@@ -82,7 +83,7 @@ class Graphics:
         return gtlib.gt_graphics_get_text_height(self.g)
 
     def get_text_width(self, text):
-        return gtlib.gt_graphics_get_text_width(self.g, str(text).encode("utf-8"))
+        return gtlib.gt_graphics_get_text_width(self.g, gtbytes(text))
 
     def set_margins(self, xmargs, ymargs):
         gtlib.gt_graphics_set_margins(self.g, xmargs, ymargs)
@@ -229,8 +230,7 @@ class Graphics:
 
     def to_file(self, filename):
         err = Error()
-        if gtlib.gt_graphics_save_to_file(self.g,
-                                          str(filename).encode("utf-8"), err) < 0:
+        if gtlib.gt_graphics_save_to_file(self.g, gtbytes(filename), err) < 0:
             gterror(err)
 
     def to_stream(self):
@@ -243,7 +243,7 @@ class Graphics:
         return gtlib.gt_graphics_get_text_height(self.g)
 
     def get_text_width(self, text):
-        return gtlib.gt_graphics_get_text_width(self.g, str(text).encode("utf-8"))
+        return gtlib.gt_graphics_get_text_width(self.g, gtbytes(text))
 
     def register(cls, gtlib):
         from ctypes import c_char_p, c_void_p, c_int, POINTER, c_double, \

--- a/gtpython/gt/annotationsketch/style.py
+++ b/gtpython/gt/annotationsketch/style.py
@@ -18,6 +18,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib, CollectFunc
 from gt.annotationsketch.color import Color
 from gt.core.error import Error, gterror
@@ -61,13 +62,13 @@ class Style:
     def load_file(self, filename):
         err = Error()
         rval = gtlib.gt_style_load_file(self.style,
-                                        str(filename).encode('UTF-8'), err)
+                                        gtbytes(filename), err)
         if rval != 0:
             gterror(err)
 
     def load_str(self, string):
         err = Error()
-        strg = Str(str(string).encode("utf-8"))
+        strg = Str(gtbytes(string))
         rval = gtlib.gt_style_load_str(self.style, strg, err)
         if rval != 0:
             gterror(err)
@@ -95,7 +96,8 @@ class Style:
         gnp = None
         if gn:
             gnp = gn._as_parameter_
-        rval = gtlib.gt_style_get_color(self.style, section, key, byref(color),
+        rval = gtlib.gt_style_get_color(self.style, gtbytes(section),
+                                        gtbytes(key), byref(color),
                                         gnp, err._as_parameter_)
         if rval == STYLE_OK:
             return color
@@ -106,7 +108,8 @@ class Style:
 
     def set_color(self, section, key, color):
         from ctypes import byref
-        gtlib.gt_style_set_color(self.style, section, key, byref(color))
+        gtlib.gt_style_set_color(self.style, gtbytes(section),
+                                 gtbytes(key), byref(color))
 
     def get_cstr(self, section, key, gn=None):
         string = Str()
@@ -114,7 +117,8 @@ class Style:
         gnp = None
         if gn:
             gnp = gn._as_parameter_
-        rval = gtlib.gt_style_get_str(self.style, section, key,
+        rval = gtlib.gt_style_get_str(self.style, gtbytes(section),
+                                      gtbytes(key),
                                       string._as_parameter_, gnp, err._as_parameter_)
         if rval == STYLE_OK:
             return str(string)
@@ -124,8 +128,9 @@ class Style:
             gterror(err)
 
     def set_cstr(self, section, key, value):
-        string = Str(str(value.encode("utf-8")))
-        gtlib.gt_style_set_str(self.style, section, key, string._as_parameter_)
+        string = Str(gtbytes(value))
+        gtlib.gt_style_set_str(self.style, gtbytes(section), 
+                               gtbytes(key), string._as_parameter_)
 
     def get_num(self, section, key, gn=None):
         from ctypes import c_double, byref
@@ -134,7 +139,8 @@ class Style:
         gnp = None
         if gn:
             gnp = gn._as_parameter_
-        rval = gtlib.gt_style_get_num(self.style, section, key, byref(double),
+        rval = gtlib.gt_style_get_num(self.style, gtbytes(section),
+                                      gtbytes(key), byref(double),
                                       gnp, err._as_parameter_)
         if rval == STYLE_OK:
             return double.value
@@ -146,7 +152,8 @@ class Style:
     def set_num(self, section, key, number):
         from ctypes import c_double
         num = c_double(number)
-        gtlib.gt_style_set_num(self.style, section, key, num)
+        gtlib.gt_style_set_num(self.style, gtbytes(section),
+                               gtbytes(key), num)
 
     def get_bool(self, section, key, gn=None):
         from ctypes import byref, c_int
@@ -155,7 +162,8 @@ class Style:
         gnp = None
         if gn:
             gnp = gn._as_parameter_
-        rval = gtlib.gt_style_get_bool(self.style, section, key, byref(bool),
+        rval = gtlib.gt_style_get_bool(self.style, gtbytes(section),
+                                       gtbytes(key), byref(bool),
                                        gnp, err._as_parameter_)
         if rval == STYLE_OK:
             if bool.value == 1:
@@ -169,12 +177,12 @@ class Style:
 
     def set_bool(self, section, key, val):
         if val == True:
-            gtlib.gt_style_set_bool(self.style, section, key, 1)
+            gtlib.gt_style_set_bool(self.style, gtbytes(section), gtbytes(key), 1)
         else:
-            gtlib.gt_style_set_bool(self.style, section, key, 0)
+            gtlib.gt_style_set_bool(self.style, gtbytes(section), gtbytes(key), 0)
 
     def unset(self, section, key):
-        gtlib.gt_style_unset(self.style, section, key)
+        gtlib.gt_style_unset(self.style, gtbytes(section), gtbytes(key))
 
     def register(cls, gtlib):
         from ctypes import c_char_p, c_double, c_float, c_void_p, \

--- a/gtpython/gt/bytes.py
+++ b/gtpython/gt/bytes.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+def gtbytes(data):
+    data = str(data)
+    try:
+        data = bytes(data, 'utf8')
+    except:
+        data = bytes(data)
+    return data

--- a/gtpython/gt/core/alphabet.py
+++ b/gtpython/gt/core/alphabet.py
@@ -18,6 +18,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.core.error import Error, gterror
 from gt.core.gtstr import Str
@@ -49,7 +50,7 @@ class Alphabet:
             raise IOError("file not found: %s" % (indexname + ".al1"))
         e = Error()
         a_ptr = gtlib.gt_alphabet_new_from_file(
-            str(indexname).encode("UTF-8"), e._as_parameter_)
+            gtbytes(indexname), e._as_parameter_)
         a = Alphabet(a_ptr, True)
         if a == None:
             gterror(e)

--- a/gtpython/gt/core/encseq.py
+++ b/gtpython/gt/core/encseq.py
@@ -17,6 +17,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.core.alphabet import Alphabet
 from gt.core.error import Error, gterror
@@ -59,13 +60,9 @@ class EncseqEncoder:
 
     from_param = classmethod(from_param)
 
-    def set_representation_type(self, sat):
-        gtlib.gt_encseq_encoder_set_access_type(
-            self.ee, str(sat.encode("utf-8")))
-
     def set_symbolmap_file(self, fn):
         gtlib.gt_encseq_encoder_use_symbolmap_file(
-            self.ee, str(fn.encode("utf-8")))
+            self.ee, gtbytes(fn))
 
     def enable_description_support(self):
         gtlib.gt_encseq_encoder_enable_description_support(self.ee)
@@ -115,7 +112,7 @@ class EncseqEncoder:
             sa.add(str(f))
         err = Error()
         esptr = gtlib.gt_encseq_encoder_encode(self.ee, sa.strarr,
-                                               str(indexname).encode("UTF-8"),
+                                               gtbytes(indexname),
                                                err.error)
         if esptr != 0:
             gterror(err)
@@ -224,7 +221,7 @@ class EncseqLoader:
             raise IOError("file not found: %s" % indexname + ".sds")
         err = Error()
         esptr = gtlib.gt_encseq_loader_load(self.el,
-                                            str(indexname).encode("UTF-8"),
+                                            gtbytes(indexname),
                                             err.error)
         if not esptr:
             gterror(err)
@@ -290,8 +287,8 @@ class EncseqBuilder:
 
     def add_string(self, string, desc=''):
         string = str(string)
-        gtlib.gt_encseq_builder_add_cstr(self.eb, string.encode('UTF-8'),
-                                         len(string), desc.encode('UTF-8'))
+        gtlib.gt_encseq_builder_add_cstr(self.eb, gtbytes(string),
+                                         len(string), gtbytes(desc))
 
     def build(self):
         err = Error()

--- a/gtpython/gt/core/error.py
+++ b/gtpython/gt/core/error.py
@@ -18,6 +18,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 
 
@@ -58,8 +59,7 @@ class Error(Exception):
             return "undefined error -- please report this as a bug!"
 
     def set(self, errmsg):
-        return gtlib.gt_error_set_nonvariadic(self.error,
-                                              str(errmsg).encode('UTF-8'))
+        return gtlib.gt_error_set_nonvariadic(self.error, gtbytes(errmsg))
 
     def is_set(self):
         return gtlib.gt_error_is_set(self.error) == 1

--- a/gtpython/gt/core/gtstr.py
+++ b/gtpython/gt/core/gtstr.py
@@ -18,6 +18,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 
 
@@ -28,7 +29,7 @@ class Str:
             self.strg = gtlib.gt_str_new()
             self.own = True
         elif isinstance(s, str):
-            self.strg = gtlib.gt_str_new_cstr(str(s).encode('UTF-8'))
+            self.strg = gtlib.gt_str_new_cstr(gtbytes(s))
             self.own = True
         elif isinstance(s, bytes):
             self.strg = gtlib.gt_str_new_cstr(s)
@@ -62,7 +63,7 @@ class Str:
     from_param = classmethod(from_param)
 
     def append_cstr(self, string):
-        gtlib.gt_str_append_cstr(self.strg, str(string).encode('UTF-8'))
+        gtlib.gt_str_append_cstr(self.strg, gtbytes(string))
 
     def length(self):
         return gtlib.gt_str_length(self.strg)

--- a/gtpython/gt/core/str_array.py
+++ b/gtpython/gt/core/str_array.py
@@ -18,6 +18,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 
 
@@ -57,7 +58,7 @@ class StrArray:
         return gtlib.gt_str_array_get(self.strarr, i).decode("UTF-8")
 
     def add(self, s):
-        gtlib.gt_str_array_add_cstr(self.strarr, str(s).encode('UTF-8'))
+        gtlib.gt_str_array_add_cstr(self.strarr, gtbytes(s))
 
     def register(cls, gtlib):
         from ctypes import c_void_p, c_char_p, c_ulong

--- a/gtpython/gt/extended/comment_node.py
+++ b/gtpython/gt/extended/comment_node.py
@@ -17,6 +17,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.extended.genome_node import GenomeNode
 
@@ -28,7 +29,7 @@ class CommentNode(GenomeNode):
 
     @classmethod
     def create_new(cls, comment):
-        fn = gtlib.gt_comment_node_new(str(comment).encode("UTF-8"))
+        fn = gtlib.gt_comment_node_new(gtbytes(comment))
         n = cls.create_from_ptr(fn, True)
         return n
 

--- a/gtpython/gt/extended/dup_feature_stream.py
+++ b/gtpython/gt/extended/dup_feature_stream.py
@@ -17,6 +17,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.extended.genome_stream import GenomeStream
 
@@ -25,9 +26,8 @@ class DuplicateFeatureStream(GenomeStream):
 
     def __init__(self, genome_stream, dest_type, source_type):
         self.gs = gtlib.gt_dup_feature_stream_new(genome_stream._as_parameter_,
-                                                  str(dest_type).encode(
-                                                      'UTF-8'),
-                                                  str(source_type).encode('UTF-8'))
+                                                  gtbytes(dest_type),
+                                                  gtbytes(source_type))
         self._as_parameter_ = self.gs
 
     def from_param(cls, obj):

--- a/gtpython/gt/extended/feature_index.py
+++ b/gtpython/gt/extended/feature_index.py
@@ -18,6 +18,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.core.array import Array
 from gt.core.error import Error, gterror
@@ -49,7 +50,7 @@ class FeatureIndex:
         err = Error()
         result = []
         rval = gtlib.gt_feature_index_get_features_for_seqid(self.fi,
-                                                             seqid.encode('UTF-8'), err)
+                                                             gtbytes(seqid), err)
         if rval:
             a = Array(rval, True)
             for i in range(a.size()):
@@ -63,7 +64,7 @@ class FeatureIndex:
     def add_gff3file(self, filename):
         err = Error()
         rval = gtlib.gt_feature_index_add_gff3file(self.fi,
-                                                   filename.encode('UTF-8'), err)
+                                                   gtbytes(filename), err)
         if rval != 0:
             gterror(err)
 
@@ -72,7 +73,7 @@ class FeatureIndex:
         val = c_int()
         err = Error()
         ret = gtlib.gt_feature_index_has_seqid(self.fi, byref(val),
-                                               seqid.encode('UTF-8'), err._as_parameter_)
+                                               gtbytes(seqid), err._as_parameter_)
         if ret != 0:
             gterror(err)
         else:
@@ -105,7 +106,7 @@ class FeatureIndex:
             gterror("feature_index does not contain seqid")
         range = Range()
         rval = gtlib.gt_feature_index_get_range_for_seqid(self.fi, byref(range),
-                                                          seqid.encode('UTF-8'), err)
+                                                          gtbytes(seqid), err)
         if rval != 0:
             gterror(err)
         return range
@@ -116,9 +117,10 @@ class FeatureIndex:
         err = Error()
         rng = Range(start, end)
         rval = gtlib.gt_feature_index_get_features_for_range(self.fi,
-                                                             a._as_parameter_, seqid.encode(
-                                                                 'UTF-8'),
-                                                             byref(rng), err._as_parameter_)
+                                                             a._as_parameter_,
+                                                             gtbytes(seqid),
+                                                             byref(rng),
+                                                             err._as_parameter_)
         if rval != 0:
             gterror(err)
         result = []

--- a/gtpython/gt/extended/feature_node.py
+++ b/gtpython/gt/extended/feature_node.py
@@ -18,6 +18,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from ctypes import CFUNCTYPE, c_char_p, c_void_p
 from gt.dlload import gtlib, CollectFunc
 from gt.core.error import Error, gterror
@@ -41,9 +42,9 @@ class FeatureNode(GenomeNode):
         if not strand in strandchars:
             gterror("Invalid strand '%s' -- must be one of %s" % (strand,
                                                                   strandchars))
-        s = Str(seqid.encode("utf-8"))
+        s = Str(str(seqid))
         fn = gtlib.gt_feature_node_new(s._as_parameter_,
-                                       type.encode('UTF-8'), start, end,
+                                       gtbytes(type), start, end,
                                        strandchars.index(str(strand)))
         n = cls.create_from_ptr(fn, True)
         n.depth_first = True
@@ -79,7 +80,7 @@ class FeatureNode(GenomeNode):
         return gtlib.gt_feature_node_get_source(self.gn)
 
     def set_source(self, source):
-        s = Str(str(source.encode("utf-8")))
+        s = Str(str(source))
         gtlib.gt_feature_node_set_source(self.gn, s._as_parameter_)
 
     source = cachedproperty(get_source, set_source)
@@ -88,13 +89,12 @@ class FeatureNode(GenomeNode):
         return gtlib.gt_feature_node_get_type(self.gn).decode('UTF-8')
 
     def set_type(self, type):
-        gtlib.gt_feature_node_set_type(self.gn, type.encode('UTF-8'))
+        gtlib.gt_feature_node_set_type(self.gn, gtbytes(type))
 
     type = cachedproperty(get_type, set_type)
 
     def has_type(self, type):
-        return gtlib.gt_feature_node_has_type(self.gn,
-                                              type.encode('UTF-8')) == 1
+        return gtlib.gt_feature_node_has_type(self.gn, gtbytes(type)) == 1
 
     def set_strand(self, strand):
         from gt.extended.strand import strandchars
@@ -144,8 +144,7 @@ class FeatureNode(GenomeNode):
     score = cachedproperty(get_score, set_score, unset_score)
 
     def get_attribute(self, attrib):
-        val = gtlib.gt_feature_node_get_attribute(self.gn,
-                                                  str(attrib).encode("UTF-8"))
+        val = gtlib.gt_feature_node_get_attribute(self.gn, gtbytes(attrib))
         if val == None:
             return None
         else:
@@ -155,15 +154,16 @@ class FeatureNode(GenomeNode):
         if attrib == "" or value == "":
             gterror("attribute keys or values must not be empty!")
         gtlib.gt_feature_node_add_attribute(self.gn,
-                                            str(attrib).encode("UTF-8"),
-                                            str(value).encode("UTF-8"))
+                                            gtbytes(attrib),
+                                            gtbytes(value))
 
     def set_attribute(self, attrib, value):
         if attrib == "" or value == "":
             gterror("attribute keys or values must not be empty!")
         gtlib.gt_feature_node_set_attribute(self.gn,
-                                            str(attrib).encode("UTF-8"),
-                                            str(value).encode("UTF-8"))
+                                            gtbytes(attrib),
+                                            gtbytes(value))
+
 
     def each_attribute(self):
         attribs = self.update_attrs()

--- a/gtpython/gt/extended/gff3_in_stream.py
+++ b/gtpython/gt/extended/gff3_in_stream.py
@@ -18,6 +18,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.core.error import gterror
 from gt.core.str_array import StrArray
@@ -33,8 +34,7 @@ class GFF3InStream(GenomeStream):
             p.close()
         except:
             gterror("File " + filename + " not readable!")
-        filename = filename.encode('UTF-8')
-        self.gs = gtlib.gt_gff3_in_stream_new_sorted(filename)
+        self.gs = gtlib.gt_gff3_in_stream_new_sorted(gtbytes(filename))
         self._as_parameter_ = self.gs
 
     def from_param(cls, obj):

--- a/gtpython/gt/extended/inter_feature_stream.py
+++ b/gtpython/gt/extended/inter_feature_stream.py
@@ -17,6 +17,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.extended.genome_stream import GenomeStream
 
@@ -25,9 +26,8 @@ class InterFeatureStream(GenomeStream):
 
     def __init__(self, genome_stream, surround_type, new_type):
         self.gs = gtlib.gt_inter_feature_stream_new(genome_stream._as_parameter_,
-                                                    str(surround_type).encode(
-                                                        'UTF-8'),
-                                                    str(new_type).encode('UTF-8'))
+                                                    gtbytes(surround_type),
+                                                    gtbytes(new_type))
         self._as_parameter_ = self.gs
 
     def from_param(cls, obj):

--- a/gtpython/gt/extended/meta_node.py
+++ b/gtpython/gt/extended/meta_node.py
@@ -17,6 +17,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.extended.genome_node import GenomeNode
 from gt.core.gtstr import Str
@@ -29,8 +30,7 @@ class MetaNode(GenomeNode):
 
     @classmethod
     def create_new(cls, directive, data):
-        fn = gtlib.gt_meta_node_new(str(directive).encode("UTF-8"),
-                                    str(data).encode("UTF-8"))
+        fn = gtlib.gt_meta_node_new(gtbytes(directive), gtbytes(data))
         n = cls.create_from_ptr(fn, True)
         return n
 

--- a/gtpython/gt/extended/sequence_node.py
+++ b/gtpython/gt/extended/sequence_node.py
@@ -18,7 +18,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-
+from gt.bytes import gtbytes
 from gt.dlload import gtlib
 from gt.core.gtstr import Str
 from gt.extended.genome_node import GenomeNode
@@ -31,8 +31,8 @@ class SequenceNode(GenomeNode):
 
     @classmethod
     def create_new(cls, description, sequence):
-        seq_str = Str(sequence.encode('UTF-8'))
-        description = description.encode('UTF-8')
+        seq_str = Str(gtbytes(sequence))
+        description = gtbytes(description)
         fn = gtlib.gt_sequence_node_new(description, seq_str._as_parameter_)
         n = cls.create_from_ptr(fn, True)
         return n

--- a/testdata/gtpython/style.py
+++ b/testdata/gtpython/style.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     style.set_cstr("exon", "style", "line")
     string = style.get_cstr("exon", "style")
     if string != "line":
-        raise TestFailedException
+        raise TestFailedException(string)
 
   # unset string
 

--- a/testdata/gtpython/unicode_strings.py
+++ b/testdata/gtpython/unicode_strings.py
@@ -29,6 +29,11 @@ if __name__ == "__main__":
                          " style_file PNG_file\n")
         sys.exit(1)
 
+    # Strings in Python3 are always unicode and unicode() does not exist
+    # so there's no need to test this
+    if sys.version_info >= (3, 0):
+        sys.exit(0)
+
     nodes = []
 
     # construct a gene on the forward strand with two exons

--- a/testsuite/gt_python_include.rb
+++ b/testsuite/gt_python_include.rb
@@ -130,7 +130,6 @@ if not $arguments["nocairo"] then
   end
 end
 
-
 Name "gtpython: unittests"
 Keywords "gt_python unittests"
 Test do


### PR DESCRIPTION
This commit unifies string and bytes passing to ctypes across Python 2 and Python 3 situations.

## Brief summary

This PR introduces the following changes:

  - New Python library function `gt.bytes.gtbytes()` that converts any value to its string representation as a bytes buffer to be passed to ctypes `c_char_p` type parameters. This allows the code to be run on Python 2 and 3 without changes.
  - Switch previous `encode('utf-8')` calls and any raw string passes to the new unified function.
