### PR TITLE
fix quicksort segfault

### DIFF
--- a/src/core/qsort_r.c
+++ b/src/core/qsort_r.c
@@ -96,7 +96,8 @@ void
 gt_qsort_r(void *a, size_t n, size_t es, void *data, GtCompareWithData cmp)
 {
   char *pa, *pb, *pc, *pd, *pl, *pm, *pn;
-  int d, r, swaptype, swap_cnt;
+  int swaptype, swap_cnt;
+  long d, r;
 
   while (1)
   {

--- a/src/extended/region_mapping.c
+++ b/src/extended/region_mapping.c
@@ -357,7 +357,7 @@ int gt_region_mapping_get_sequence_length(GtRegionMapping *rm,
   GtUword filenum, seqnum;
   int had_err;
   gt_error_check(err);
-  GT_UNUSED GtRange range;
+  GT_UNUSED GtRange range = {0,0};
   gt_assert(rm && seqid);
   if (rm->userawseq) {
     return rm->rawlength;

--- a/src/ltr/ltrdigest_pbs_visitor.c
+++ b/src/ltr/ltrdigest_pbs_visitor.c
@@ -377,8 +377,9 @@ static void pbs_attach_results_to_gff3(GtLTRdigestPBSVisitor *lv,
     /* find best-scoring PBS on the given canonical strand */
     while (hit->strand != *canonical_strand
              && i < gt_pbs_results_get_number_of_hits(results)) {
+      const char *msg = gt_feature_node_get_attribute(mainnode, "ID");
       gt_log_log("dropping PBS because of nonconsistent strand: %s\n",
-                 gt_feature_node_get_attribute(mainnode, "ID"));
+                 msg == NULL ? "undefined" : msg);
       hit = gt_pbs_results_get_ranked_hit(results, i++);
     }
     /* if there is none, do not report a PBS */

--- a/src/ltr/ltrdigest_ppt_visitor.c
+++ b/src/ltr/ltrdigest_ppt_visitor.c
@@ -479,8 +479,9 @@ static void ppt_attach_results_to_gff3(GtLTRdigestPPTVisitor *lv,
     /* find best-scoring PPT on the given canonical strand */
     while (hit->strand != *canonical_strand
              && i < gt_ppt_results_get_number_of_hits(results)) {
+      const char *msg = gt_feature_node_get_attribute(mainnode, "ID");
       gt_log_log("dropping PPT because of nonconsistent strand: %s\n",
-                 gt_feature_node_get_attribute(mainnode, "ID"));
+                 msg == NULL ? "undefined" : msg);
       hit = gt_ppt_results_get_ranked_hit(results, i++);
     }
     /* if there is none, do not report a PPT */


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Switch two variables in `core/qsort_r.c` to `long` from `int` to counter overflows when processing large data, as reported by LTRharvest users.
  - Initalize some variables to fix building on macOS with gcc.
  
## Related issues

Adresses #940 by including a patch proven to solve the issue for at least one user. I can not see significantly bad side effects at first glance.
