### PR TITLE
Add GitHub-based release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,16 +73,17 @@ jobs:
     strategy:
       matrix:
         mingw-arch:
-          - i686
-          - x86_64
+          - machine: i686
+            buildopts: fpic=no cairo=no sharedlib=no 64bit=no
+          - machine: x86_64
+            buildopts: fpic=no cairo=no sharedlib=no
     env:
       DEBIAN_FRONTEND: noninteractive
-      CC: ${{ matrix.mingw-arch }}-w64-mingw32-gcc
+      CC: ${{ matrix.mingw-arch.machine }}-w64-mingw32-gcc
       SYSTEM: Windows
-      MACHINE: ${{ matrix.mingw-arch }}
-      AR: ${{ matrix.mingw-arch }}-w64-mingw32-ar
+      MACHINE: ${{ matrix.mingw-arch.machine }}
+      AR: ${{ matrix.mingw-arch.machine }}-w64-mingw32-ar
       CFLAGS: -Wno-error=attributes -Wno-error=unused-parameter -DSQLITE_MALLOCSIZE=_msize
-      BUILDOPTS: fpic=no cairo=no sharedlib=no
     runs-on: ubuntu-latest
     container: debian:buster
     steps:
@@ -96,4 +97,4 @@ jobs:
                      binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64
       - name: Build
         run: |
-             make fpic=no cairo=no sharedlib=no
+             make ${{ matrix.mingw-arch.buildopts }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: ci.yaml
+name: Build and test
 
 on:
   - push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,176 @@
+name: Build release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Create Release ${{ github.ref }}
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: release
+        uses: actions/create-release@latest
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          draft: false
+          prerelease: false
+          release_name: ${{ github.ref }}
+          tag_name: ${{ github.ref }}
+      
+  linux:
+    name: Linux Binaries
+    needs: release
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      BUILDOPTS: $${{ matrix.options.buildopts }}
+    strategy:
+      matrix:
+        options:
+          - name: complete
+            buildopts: wrapmemcpy=yes CPPFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -D_GNU_SOURCE' DISTSUFFIX=-complete amalgamation=yes
+          - name: barebone
+            buildopts: wrapmemcpy=yes CPPFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -D_GNU_SOURCE' DISTSUFFIX=-barebone amalgamation=yes cairo=no 
+    runs-on: ubuntu-latest
+    container:
+      image: debian:stable
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install deps
+        run: |
+             apt update
+             apt -yq install build-essential libpango1.0-dev libcairo2-dev \
+                             ruby texlive-latex-base texlive-latex-extra \
+                             texlive-fonts-extra texlive-latex-recommended \
+                             texlive-fonts-recommended asciidoc-base
+      - name: Set up user
+        run: |
+             useradd -m -g users testuser
+             chown -R testuser:users .
+      - name: Build ${{ matrix.options.name }} with ${{ matrix.options.buildopts }}
+        run: |
+             su -c "make ${{ matrix.options.buildopts }} manuals manpages" testuser
+             su -c "make ${{ matrix.options.buildopts }} DISTDIR=./dist dist" testuser
+      - name: Upload Assets
+        id: upload_try1
+        continue-on-error: true
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          asset_path: "./dist/*tar.gz"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          overwrite: true
+      - name: Upload Assets (retry)
+        id: upload_try2
+        if: steps.upload_try1.outcome == 'failure'
+        continue-on-error: true
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          asset_path: "./dist/*tar.gz"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          overwrite: true
+
+  macos:
+    name: macOS Binaries
+    needs: release
+    env:
+      BUILDOPTS: $${{ matrix.options.buildopts }}
+    strategy:
+      matrix:
+        options:
+          - name: complete
+            buildopts: DISTSUFFIX=-complete amalgamation=yes
+          - name: barebone
+            buildopts: DISTSUFFIX=-barebone amalgamation=yes cairo=no
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install deps
+        run: |
+             brew install pango cairo libffi pkg-config texlive asciidoc libxslt
+      - name: Build ${{ matrix.options.name }} with ${{ matrix.options.buildopts }}
+        run: |
+             make ${{ matrix.options.buildopts }} manuals
+             make ${{ matrix.options.buildopts }} DISTDIR=./dist dist
+      - name: Upload Assets
+        id: upload_try1
+        continue-on-error: true
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          asset_path: "./dist/*tar.gz"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          overwrite: true
+      - name: Upload Assets (retry)
+        id: upload_try2
+        if: steps.upload_try1.outcome == 'failure'
+        continue-on-error: true
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          asset_path: "./dist/*tar.gz"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          overwrite: true
+
+  windows:
+    name: Windows Binaries
+    needs: release
+    strategy:
+      matrix:
+        mingw-arch:
+          - machine: i686
+            buildopts: fpic=no cairo=no sharedlib=no 64bit=no
+          - machine: x86_64
+            buildopts: fpic=no cairo=no sharedlib=no
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      CC: ${{ matrix.mingw-arch.machine }}-w64-mingw32-gcc
+      SYSTEM: Windows
+      MACHINE: ${{ matrix.mingw-arch.machine }}
+      AR: ${{ matrix.mingw-arch.machine }}-w64-mingw32-ar
+      CFLAGS: -Wno-error=attributes -Wno-error=unused-parameter -DSQLITE_MALLOCSIZE=_msize
+    runs-on: ubuntu-latest
+    container:
+      image: debian:buster
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install deps
+        run: |
+             apt update
+             apt -yq install build-essential ncbi-blast+ ruby \
+                     binutils-mingw-w64-i686 gcc-mingw-w64-i686 \
+                     binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64 \
+                     texlive-latex-base texlive-latex-extra \
+                     texlive-fonts-extra texlive-latex-recommended \
+                     texlive-fonts-recommended asciidoc-base p7zip-full
+      - name: Build
+        run: |
+             make ${{ matrix.mingw-arch.buildopts }} DISTDIR=./dist dist
+      - name: Upload Assets
+        id: upload_try1
+        continue-on-error: true
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          asset_path: "./dist/*zip"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          overwrite: true
+      - name: Upload Assets (retry)
+        id: upload_try2
+        continue-on-error: true
+        uses: shogo82148/actions-upload-release-asset@v1
+        if: steps.upload_try1.outcome == 'failure'
+        with:
+          asset_path: "./dist/*zip"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          overwrite: true

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ BUILDSTAMP:=$(shell date +'"%Y-%m-%d %H:%M:%S"')
 
 # try to set RANLIB automatically
 SYSTEM?=$(shell uname -s)
-MACHINE:=$(shell uname -m)
+MACHINE?=$(shell uname -m)
 ifeq ($(SYSTEM),Darwin)
   RANLIB:=ranlib
   NO_STATIC_LINKING:=defined
@@ -896,7 +896,7 @@ endif
 	$(V_DO)cp $(CURDIR)/LICENSE $(GTDISTDIR)
 	$(V_DO)cp $(CURDIR)/CONTRIBUTORS $(GTDISTDIR)
 	$(V_DO)cp $(CURDIR)/CHANGELOG $(GTDISTDIR)
-	$(V_DO)cp $(CURDIR)/doc/manuals/*.pdf $(GTDISTDIR)/doc
+	$(V_DO)cp $(CURDIR)/doc/manuals/*.pdf $(GTDISTDIR)/doc || true
 	$(V_DO)cp -r $(CURDIR)/gtdata $(GTDISTDIR)
 	$(V_DO)cp -r $(CURDIR)/gtpython $(GTDISTDIR)
 	$(V_DO)cp -r $(CURDIR)/gtruby $(GTDISTDIR)
@@ -985,7 +985,7 @@ gt: bin/gt
 install: all
 	test -d $(prefix)/bin || mkdir -p $(prefix)/bin
 ifeq ($(SYSTEM),Windows)
-	cp bin/gt $(prefix)/bin/gt.exe
+	cp bin/gt.exe $(prefix)/bin/gt.exe
 	$(STRIP) $(prefix)/bin/gt.exe
 else
 	cp bin/gt $(prefix)/bin


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Adds GitHub-based release workflow that creates a release and builds and uploads binary 
    distributions as attachments to it, whenever a new version tag (`'v*'`)is pushed.
    It builds Linux, macOS (both with or without Cairo support, as amalgamations) as well as
    cross-compiled Windows binaries (without Cairo).
  - Adjust `Makefile` to enable successful completion of some of the distribution builds 
    (mostly Windows).