### PR TITLE
gtlua: check for leaf property in `remove_leaf()`

### DIFF
--- a/src/gtlua/genome_node_lua.c
+++ b/src/gtlua/genome_node_lua.c
@@ -710,6 +710,8 @@ static int feature_node_lua_remove_leaf(lua_State *L)
   luaL_argcheck(L, pf, 1, "not a feature node");
   lf = gt_feature_node_try_cast(*leaf);
   luaL_argcheck(L, lf, 2, "not a feature node");
+  luaL_argcheck(L, gt_feature_node_number_of_children(lf) == 0, 2,
+                "must be a leaf");
   gt_feature_node_remove_leaf(pf, lf);
   return 0;
 }

--- a/testdata/gtscripts/genome_node.lua
+++ b/testdata/gtscripts/genome_node.lua
@@ -97,6 +97,16 @@ child:add_child(newchild)
 assert(count_children(parent) == 4)
 parent:remove_leaf(newchild)
 assert(count_children(parent) == 3)
+-- testing removal of non-leaves, should trigger error
+parent = gt.feature_node_new("seqid", "gene", range:get_start(), range:get_end(), "+")
+child  = gt.feature_node_new("seqid", "mRNA", range:get_start(), range:get_end(), "+")
+newchild = gt.feature_node_new("seqid", "exon", range:get_start(), range:get_end(), "+")
+parent:add_child(child)
+child:add_child(newchild)
+assert(count_children(parent) == 3)
+rval, err = pcall(GenomeTools_genome_node.remove_leaf, parent, child)
+assert(not rval)
+assert(string.find(err, "must be a leaf"))
 
 -- testing get_children
 parent = gt.feature_node_new("seqid", "gene", range:get_start(), range:get_end(), "+")


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Check in the Lua bindings whether the leaf to remove via `genome_node:remove_leaf()` is actually a leaf. If not, a runtime error is raised instead of triggering an assertion in the underlying C function.

## Related issues

Addresses #1020 by avoiding a hard assertion failure.
