### PR TITLE
Update website with new site structure

### DIFF
--- a/www/genometools.org/htdocs/annotationsketch.html
+++ b/www/genometools.org/htdocs/annotationsketch.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
@@ -242,7 +243,7 @@ TBD
 -->
 
 <div id="footer">
-Copyright &copy; 2007-2011 The <i>GenomeTools</i> authors. Last update: 2011-02-11
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors. Last update: 2011-02-11
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/cgi-bin/annotationsketch_demo.cgi
+++ b/www/genometools.org/htdocs/cgi-bin/annotationsketch_demo.cgi
@@ -77,7 +77,8 @@ HTML_HEADER = <<END
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -107,7 +108,7 @@ END
 
 HTML_FOOTER = <<END
 <div id="footer">
-Copyright &copy; 2007-2011 Sascha Steinbiss. Last update: 2011-02-11
+Copyright &copy; 2007-2023 Sascha Steinbiss. Last update: 2011-02-11
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/cgi-bin/gff3validator.cgi
+++ b/www/genometools.org/htdocs/cgi-bin/gff3validator.cgi
@@ -61,7 +61,8 @@ table.padded-table td {
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -78,7 +79,7 @@ END
 
 HTML_FOOTER = <<END
 <div id="footer">
-Copyright &copy; 2012 Sascha Steinbiss. Last update: 2015-01-25
+Copyright &copy; 2012-2023 Sascha Steinbiss. Last update: 2015-01-25
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/contract.html
+++ b/www/genometools.org/htdocs/contract.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
@@ -243,7 +244,7 @@ This is revision <b>0</b> of the GtDC (2013-07-04).</p>
 </div>
 
 <div id="footer">
-Copyright &copy; 2007-2011 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 Last update: 2011-02-11
 </div>
 </div>

--- a/www/genometools.org/htdocs/contribute.html
+++ b/www/genometools.org/htdocs/contribute.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>

--- a/www/genometools.org/htdocs/contribute.html
+++ b/www/genometools.org/htdocs/contribute.html
@@ -42,7 +42,7 @@ href="contract.html"><em>GenomeTools</em> development contract</a>. If you contr
 
 <h3 id="toc1"><span>Getting Started</span></h3>
 
-<p><a href="http://www.git-scm.com/download">Download</a> and install git. On Ubuntu or Debian, you can use the following command:<pre class="code">apt-get install git</pre> If you are new to git, read the <a href="http://www.git-scm.com/documentation">git docs</a>, and <a href="http://progit.org/book/">Pro git</a> by Scott Chacon.</p>
+<p><a href="http://www.git-scm.com/download">Download</a> and install git. On Ubuntu or Debian, you can use the following command:<pre class="code">apt-get install git</pre> If you are new to git, read the <a href="http://www.git-scm.com/documentation">git docs</a>, and <a href="https://git-scm.com/book/en/v2">Pro git</a> by Scott Chacon.</p>
 <p>Ensure that your copy of git is configured with your real name and the e-mail address you wish to be associated with your contributions. This is required to correctly track authorship:</p>
 <div class="code">
 <pre class="code">

--- a/www/genometools.org/htdocs/customtracks.html
+++ b/www/genometools.org/htdocs/customtracks.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
@@ -123,7 +124,7 @@ Running layout and drawing functions on this diagram then produces the desired i
 </div>
 </p>
 <div id="footer">
-Copyright &copy; 2007-2011 The <i>GenomeTools</i> authors. Last update: 2011-02-11
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors. Last update: 2011-02-11
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/design.html
+++ b/www/genometools.org/htdocs/design.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a id="current" href="design.html">Design</a></li>
@@ -409,7 +410,7 @@ described in this document.
 </p>
 
 <div id="footer">
-Copyright &copy; 2007-2011 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 Last update: 2011-02-11
 </div>
 </div>

--- a/www/genometools.org/htdocs/docs.html
+++ b/www/genometools.org/htdocs/docs.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
@@ -1386,7 +1387,7 @@ Returns translated <code>dna</code>.
 <div id="footer">
 Copyright &copy; 2008-2016
 The <i>GenomeTools</i> authors.
-Last update: 2020-12-07
+Last update: 2023-09-19
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/documentation.html
+++ b/www/genometools.org/htdocs/documentation.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a id="current" href="documentation.html">Documentation</a></li>
@@ -45,7 +46,7 @@
 </ul>
 
 <div id="footer">
-Copyright &copy; 2007-2011 The <i>GenomeTools</i> authors. Last update: 2011-02-11
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors. Last update: 2011-02-11
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/examples_tmpl.html
+++ b/www/genometools.org/htdocs/examples_tmpl.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
@@ -100,7 +101,7 @@ The following C code example illustrates how to produce an image from annotation
 </pre>
 
 <div id="footer">
-Copyright &copy; 2007-2011 The <i>GenomeTools</i> authors. Last update: 2011-02-11
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors. Last update: 2011-02-11
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/index.html
+++ b/www/genometools.org/htdocs/index.html
@@ -12,7 +12,8 @@ annotation drawing, AnnotationSketch, LTR prediction, bioinformatics, computatio
   <div id="menu">
     <ul>
       <li><a id="current" href="index.html">Overview</a></li>
-      <li><a href="pub/">Download</a></li>
+      <li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+      <li><a href="pub/">Archive</a></li>
       <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
       <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
       <li><a href="documentation.html">Documentation</a></li>
@@ -206,7 +207,7 @@ annotation drawing, AnnotationSketch, LTR prediction, bioinformatics, computatio
      <a href="http://www.zbh.uni-hamburg.de">Center for Bioinformatics, University of Hamburg</a>
     </p>
 <div id="footer">
-Copyright &copy; 2006-2014
+Copyright &copy; 2006-2023
 The <i>GenomeTools</i> authors. Last update: 2014-11-05
 </div>
 </div>

--- a/www/genometools.org/htdocs/libgenometools.html
+++ b/www/genometools.org/htdocs/libgenometools.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>
@@ -453,6 +454,15 @@ Helper function for (rare) tools which do not use the full <code>GtOutputFileInf
 Retrieves all features contained in <code>gfi</code> into <code>results</code>. Returns 0 on
    success, a negative value otherwise. The message in <code>err</code> is set
    accordingly.
+</p>
+<hr>
+<a name="gt_dup_feature_stream_new"></a>
+
+<code>GtNodeStream*  gt_dup_feature_stream_new(GtNodeStream*, const char *dest_type,
+                                        const char *source_type)</code>
+<p>
+Duplicate internal feature nodes of type <code>source_type</code> as features with type
+   <code>dest_type</code>. The duplicated features does not inherit the children.
 </p>
 <hr>
 <a name="GtTrackSelectorFunc"></a>
@@ -11563,15 +11573,6 @@ Perform global chaining with overlaps of <code>num_of_fragments</code> many <cod
    ownership of the GtChain.
 </p>
 <hr>
-<a name="gt_dup_feature_stream_new"></a>
-
-<code>GtNodeStream*  gt_dup_feature_stream_new(GtNodeStream*, const char *dest_type,
-                                        const char *source_type)</code>
-<p>
-Duplicate internal feature nodes of type <code>source_type</code> as features with type
-   <code>dest_type</code>. The duplicated features does not inherit the children.
-</p>
-<hr>
 <a name="Grep"></a>
 <h2>Module Grep</h2>
 <a name="gt_grep"></a>
@@ -15475,7 +15476,7 @@ Return random number up to RAND_MAX.
 <div id="footer">
 Copyright &copy; 2008-2016
 The <i>GenomeTools</i> authors.
-Last update: 2020-12-07
+Last update: 2023-09-19
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/license.html
+++ b/www/genometools.org/htdocs/license.html
@@ -9,7 +9,8 @@
   <div id="menu">
     <ul>
       <li><a href="index.html">Overview</a></li>
-      <li><a href="pub/">Download</a></li>
+      <li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+      <li><a href="pub/">Archive</a></li>
       <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
       <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
       <li><a href="documentation.html">Documentation</a></li>

--- a/www/genometools.org/htdocs/license.html
+++ b/www/genometools.org/htdocs/license.html
@@ -23,8 +23,8 @@
 <h1><i>GenomeTools</i> License</h1>
 <pre>
 /*
-  Copyright (c) 2003-2016 G. Gremme, S. Steinbiss, S. Kurtz, and <a href="https://github.com/genometools/genometools/blob/master/CONTRIBUTORS"><code>CONTRIBUTORS</code></a>
-  Copyright (c) 2003-2016 Center for Bioinformatics, University of Hamburg
+  Copyright (c) 2003-2023 G. Gremme, S. Steinbiss, S. Kurtz, and <a href="https://github.com/genometools/genometools/blob/master/CONTRIBUTORS"><code>CONTRIBUTORS</code></a>
+  Copyright (c) 2003-2022 Center for Bioinformatics, University of Hamburg
 
   Permission to use, copy, modify, and distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/www/genometools.org/htdocs/manuals.html
+++ b/www/genometools.org/htdocs/manuals.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>

--- a/www/genometools.org/htdocs/style_options.html
+++ b/www/genometools.org/htdocs/style_options.html
@@ -21,7 +21,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>

--- a/www/genometools.org/htdocs/tool.conf
+++ b/www/genometools.org/htdocs/tool.conf
@@ -537,7 +537,8 @@ cellspacing="0" cellpadding="4">
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -678,7 +679,7 @@ endif::doctype-manpage[]
 
 [footer]
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tool_list.conf
+++ b/www/genometools.org/htdocs/tool_list.conf
@@ -537,7 +537,8 @@ cellspacing="0" cellpadding="4">
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>

--- a/www/genometools.org/htdocs/tools.html
+++ b/www/genometools.org/htdocs/tools.html
@@ -11,7 +11,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>

--- a/www/genometools.org/htdocs/tools/gt.html
+++ b/www/genometools.org/htdocs/tools/gt.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -501,7 +502,7 @@ shows all possible "environment options".</p></div>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_bed_to_gff3.html
+++ b/www/genometools.org/htdocs/tools/gt_bed_to_gff3.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -126,7 +127,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_cds.html
+++ b/www/genometools.org/htdocs/tools/gt_cds.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -215,7 +216,7 @@ sequence file name when it is called with the <tt>sequence_region</tt> as argume
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_chain2dim.html
+++ b/www/genometools.org/htdocs/tools/gt_chain2dim.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -185,7 +186,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_chseqids.html
+++ b/www/genometools.org/htdocs/tools/gt_chseqids.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -132,7 +133,7 @@ and all sequence ids &#8220;chr2&#8221; to &#8220;seq2&#8221;.</p></div>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_clean.html
+++ b/www/genometools.org/htdocs/tools/gt_clean.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -70,7 +71,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_compreads.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -93,7 +94,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_compreads_compress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_compress.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -127,7 +128,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_compreads_decompress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_decompress.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -126,7 +127,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_compreads_refcompress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_refcompress.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -142,7 +143,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_compreads_refdecompress.html
+++ b/www/genometools.org/htdocs/tools/gt_compreads_refdecompress.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -110,7 +111,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_condenseq.html
+++ b/www/genometools.org/htdocs/tools/gt_condenseq.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -93,7 +94,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_congruence.html
+++ b/www/genometools.org/htdocs/tools/gt_congruence.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -84,7 +85,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_congruence_spacedseed.html
+++ b/www/genometools.org/htdocs/tools/gt_congruence_spacedseed.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -102,7 +103,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_convertseq.html
+++ b/www/genometools.org/htdocs/tools/gt_convertseq.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -158,7 +159,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_csa.html
+++ b/www/genometools.org/htdocs/tools/gt_csa.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -179,7 +180,7 @@ shorter than the corresponding exon from the second alternative splice form.</p>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_dot.html
+++ b/www/genometools.org/htdocs/tools/gt_dot.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -70,7 +71,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_dupfeat.html
+++ b/www/genometools.org/htdocs/tools/gt_dupfeat.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -118,7 +119,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_encseq.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -113,7 +114,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_encseq2spm.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq2spm.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -126,7 +127,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_encseq_bench.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_bench.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -94,7 +95,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_encseq_bitextract.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_bitextract.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -110,7 +111,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_encseq_check.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_check.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -118,7 +119,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_encseq_decode.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_decode.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -150,7 +151,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_encseq_encode.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_encode.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -223,7 +224,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_encseq_info.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_info.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -142,7 +143,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_encseq_md5.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_md5.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -110,7 +111,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_encseq_sample.html
+++ b/www/genometools.org/htdocs/tools/gt_encseq_sample.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -142,7 +143,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_eval.html
+++ b/www/genometools.org/htdocs/tools/gt_eval.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -142,7 +143,7 @@ that type from the &#8220;reference&#8221;.</p></div>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_extractfeat.html
+++ b/www/genometools.org/htdocs/tools/gt_extractfeat.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -284,7 +285,7 @@ sequence file name when it is called with the <tt>sequence_region</tt> as argume
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_extractseq.html
+++ b/www/genometools.org/htdocs/tools/gt_extractseq.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -269,7 +270,7 @@ they have to appear in lexicographic order
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_fastq_sample.html
+++ b/www/genometools.org/htdocs/tools/gt_fastq_sample.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -79,7 +80,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_featureindex.html
+++ b/www/genometools.org/htdocs/tools/gt_featureindex.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -119,7 +120,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_fingerprint.html
+++ b/www/genometools.org/htdocs/tools/gt_fingerprint.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -189,7 +190,7 @@ CAACGTAATGGGAGCTTAAAAATA</tt></pre>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_genomediff.html
+++ b/www/genometools.org/htdocs/tools/gt_genomediff.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -211,7 +212,7 @@ You can use</p></div>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_gff3.html
+++ b/www/genometools.org/htdocs/tools/gt_gff3.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -264,7 +265,7 @@ given GFF3 files must be defined.</p></div>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_gff3_to_gtf.html
+++ b/www/genometools.org/htdocs/tools/gt_gff3_to_gtf.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -102,7 +103,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_gff3validator.html
+++ b/www/genometools.org/htdocs/tools/gt_gff3validator.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -92,7 +93,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_gtf_to_gff3.html
+++ b/www/genometools.org/htdocs/tools/gt_gtf_to_gff3.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -110,7 +111,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_hop.html
+++ b/www/genometools.org/htdocs/tools/gt_hop.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -302,7 +303,7 @@ as cognate sequence and outputs an ideal list of corrections.)</p></div>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_id_to_md5.html
+++ b/www/genometools.org/htdocs/tools/gt_id_to_md5.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -199,7 +200,7 @@ sequence file name when it is called with the <tt>sequence_region</tt> as argume
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_inlineseq_add.html
+++ b/www/genometools.org/htdocs/tools/gt_inlineseq_add.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -160,7 +161,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_inlineseq_split.html
+++ b/www/genometools.org/htdocs/tools/gt_inlineseq_split.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -86,7 +87,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_interfeat.html
+++ b/www/genometools.org/htdocs/tools/gt_interfeat.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -118,7 +119,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_loccheck.html
+++ b/www/genometools.org/htdocs/tools/gt_loccheck.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -70,7 +71,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_ltrclustering.html
+++ b/www/genometools.org/htdocs/tools/gt_ltrclustering.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -118,7 +119,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_ltrdigest.html
+++ b/www/genometools.org/htdocs/tools/gt_ltrdigest.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -437,7 +438,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_ltrharvest.html
+++ b/www/genometools.org/htdocs/tools/gt_ltrharvest.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -316,7 +317,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_matchtool.html
+++ b/www/genometools.org/htdocs/tools/gt_matchtool.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -126,7 +127,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_matstat.html
+++ b/www/genometools.org/htdocs/tools/gt_matstat.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -132,7 +133,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_md5_to_id.html
+++ b/www/genometools.org/htdocs/tools/gt_md5_to_id.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -110,7 +111,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_merge.html
+++ b/www/genometools.org/htdocs/tools/gt_merge.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -119,7 +120,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_mergefeat.html
+++ b/www/genometools.org/htdocs/tools/gt_mergefeat.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -102,7 +103,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_mkfeatureindex.html
+++ b/www/genometools.org/htdocs/tools/gt_mkfeatureindex.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -112,7 +113,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_mmapandread.html
+++ b/www/genometools.org/htdocs/tools/gt_mmapandread.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -70,7 +71,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_orffinder.html
+++ b/www/genometools.org/htdocs/tools/gt_orffinder.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -201,7 +202,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_packedindex.html
+++ b/www/genometools.org/htdocs/tools/gt_packedindex.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -104,7 +105,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_prebwt.html
+++ b/www/genometools.org/htdocs/tools/gt_prebwt.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -86,7 +87,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_readjoiner.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -89,7 +90,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_readjoiner_assembly.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner_assembly.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -167,7 +168,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_readjoiner_overlap.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner_overlap.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -118,7 +119,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_readjoiner_prefilter.html
+++ b/www/genometools.org/htdocs/tools/gt_readjoiner_prefilter.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -163,7 +164,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_repfind.html
+++ b/www/genometools.org/htdocs/tools/gt_repfind.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -257,7 +258,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_scriptfilter.html
+++ b/www/genometools.org/htdocs/tools/gt_scriptfilter.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -102,7 +103,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_seed_extend.html
+++ b/www/genometools.org/htdocs/tools/gt_seed_extend.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -335,7 +336,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_select.html
+++ b/www/genometools.org/htdocs/tools/gt_select.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -271,7 +272,7 @@ indicating that the node survived the filtering process.</p></div>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_seq.html
+++ b/www/genometools.org/htdocs/tools/gt_seq.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -183,7 +184,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_seqfilter.html
+++ b/www/genometools.org/htdocs/tools/gt_seqfilter.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -159,7 +160,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_seqids.html
+++ b/www/genometools.org/htdocs/tools/gt_seqids.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -70,7 +71,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_seqmutate.html
+++ b/www/genometools.org/htdocs/tools/gt_seqmutate.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -128,7 +129,7 @@ mRNA and EST sequences. Bioinformatics, 21(9):1859-1875, 2005.</em></p></div>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_seqorder.html
+++ b/www/genometools.org/htdocs/tools/gt_seqorder.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -126,7 +127,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_seqstat.html
+++ b/www/genometools.org/htdocs/tools/gt_seqstat.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -144,7 +145,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_seqtransform.html
+++ b/www/genometools.org/htdocs/tools/gt_seqtransform.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -119,7 +120,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_seqtranslate.html
+++ b/www/genometools.org/htdocs/tools/gt_seqtranslate.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -118,7 +119,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_sequniq.html
+++ b/www/genometools.org/htdocs/tools/gt_sequniq.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -129,7 +130,7 @@ contained within other sequences.</p></div>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_shredder.html
+++ b/www/genometools.org/htdocs/tools/gt_shredder.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -187,7 +188,7 @@ To get rid of such fragments use <tt>gt seqfilter</tt> (see example below).</p><
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_shulengthdist.html
+++ b/www/genometools.org/htdocs/tools/gt_shulengthdist.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -94,7 +95,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_simreads.html
+++ b/www/genometools.org/htdocs/tools/gt_simreads.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -199,7 +200,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_sketch.html
+++ b/www/genometools.org/htdocs/tools/gt_sketch.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -179,7 +180,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_sketch_page.html
+++ b/www/genometools.org/htdocs/tools/gt_sketch_page.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -163,7 +164,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_snpper.html
+++ b/www/genometools.org/htdocs/tools/gt_snpper.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -288,7 +289,7 @@ sequence file name when it is called with the <tt>sequence_region</tt> as argume
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_speck.html
+++ b/www/genometools.org/htdocs/tools/gt_speck.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -228,7 +229,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_splicesiteinfo.html
+++ b/www/genometools.org/htdocs/tools/gt_splicesiteinfo.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -192,7 +193,7 @@ sequence file name when it is called with the <tt>sequence_region</tt> as argume
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_splitfasta.html
+++ b/www/genometools.org/htdocs/tools/gt_splitfasta.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -111,7 +112,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_stat.html
+++ b/www/genometools.org/htdocs/tools/gt_stat.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -174,7 +175,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_tagerator.html
+++ b/www/genometools.org/htdocs/tools/gt_tagerator.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -177,7 +178,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_tallymer.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -94,7 +95,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_tallymer_mkindex.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer_mkindex.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -145,7 +146,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_tallymer_occratio.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer_occratio.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -135,7 +136,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_tallymer_search.html
+++ b/www/genometools.org/htdocs/tools/gt_tallymer_search.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -110,7 +111,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_tirvish.html
+++ b/www/genometools.org/htdocs/tools/gt_tirvish.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -265,7 +266,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_uniq.html
+++ b/www/genometools.org/htdocs/tools/gt_uniq.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -122,7 +123,7 @@ score, this one is kept.</p></div>
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_uniquesub.html
+++ b/www/genometools.org/htdocs/tools/gt_uniquesub.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -132,7 +133,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/tools/gt_wtree.html
+++ b/www/genometools.org/htdocs/tools/gt_wtree.html
@@ -10,7 +10,8 @@
 <div id="menu">
 <ul>
 <li><a href="../index.html">Overview</a></li>
-<li><a href="../pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="https://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="../documentation.html">Documentation</a></li>
@@ -78,7 +79,7 @@ display version information and exit
 </div>
 </div>
 <div id="footer">
-Copyright &copy; 2007-2016 The <i>GenomeTools</i> authors.
+Copyright &copy; 2007-2023 The <i>GenomeTools</i> authors.
 </div>
 </div>
 </body>

--- a/www/genometools.org/htdocs/trackselectors.html
+++ b/www/genometools.org/htdocs/trackselectors.html
@@ -9,7 +9,8 @@
 <div id="menu">
 <ul>
 <li><a href="index.html">Overview</a></li>
-<li><a href="pub/">Download</a></li>
+<li><a href="https://github.com/genometools/genometools/releases">Releases</a></li>
+<li><a href="pub/">Archive</a></li>
 <li><a href="http://github.com/genometools/genometools">Browse source</a></li>
 <li><a href="http://github.com/genometools/genometools/issues/">Issue tracker</a></li>
 <li><a href="documentation.html">Documentation</a></li>


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Restructure toplevel link buttons on website to
    - rename "Download" to "Archive" at it will no longer be updated
    - introduce a new "Releases" button linking to the GitHub release page.
  - Update copyright dates on website.
  - Regenerate automatic documentation (tools, API) to update coyright date and links.
  - Update the broken link to Scott Chacon's Pro Git book.

