### PR TITLE
Fixed lines resulting in compiler errors for gcc-13-2

### DIFF
--- a/scripts/ctags.sh
+++ b/scripts/ctags.sh
@@ -32,7 +32,6 @@ ctags -w ${exuberantopts}          \
       src/examples/*.[ch]          \
       src/extended/*.[ch]          \
       src/gtlua/*.[ch]             \
-      src/gth/*.[ch]               \
       src/ltr/*.[ch]               \
       src/match/*.[ch]             \
       src/mgth/*.[ch]              \

--- a/src/core/encseq.c
+++ b/src/core/encseq.c
@@ -5376,7 +5376,6 @@ static int countnumberofexceptionranges(const GtAlphabet *alpha,
 {
   int had_err = 0;
   GtSequenceBuffer *fb;
-  GtUword currentpos;
   if (plainformat)
     fb = gt_sequence_buffer_plain_new(filenametab);
   else
@@ -5392,7 +5391,7 @@ static int countnumberofexceptionranges(const GtAlphabet *alpha,
     GtUchar charcode;
 
     gt_sequence_buffer_set_symbolmap(fb, gt_alphabet_symbolmap(alpha));
-    for (currentpos = 0; /* Nothing */; currentpos++) {
+    for (/*Nothing*/; /* Nothing */; /*Nothing*/) {
       retval = gt_sequence_buffer_next_with_original_raw(fb, &charcode, &cc,
                                                           err);
       if (retval > 0) {
@@ -6271,7 +6270,6 @@ unsigned int gt_encseq_extract2bitencvector(
   GtEndofTwobitencoding etbecurrent;
   GtUword twobitencodingstoppos;
   unsigned int offset;
-  int idx;
   bool fwd;
 
   if (pos == encseq->totallength || pos == encseq->logicaltotallength ||
@@ -6305,7 +6303,7 @@ unsigned int gt_encseq_extract2bitencvector(
   if (GT_ISDIRREVERSE(readmode)) {
     pos = GT_REVERSEPOS(encseq->logicaltotallength, pos);
   }
-  for (idx = 0, offset = 0; /* Nothing */; idx++,
+  for (offset = 0; /* Nothing */;
        offset += (unsigned int) GT_UNITSIN2BITENC) {
     if (fwd) {
       if (pos == twobitencodingstoppos) {
@@ -6352,7 +6350,7 @@ unsigned int gt_encseq_relpos_extract2bitencvector(
 {
   GtEndofTwobitencoding etbecurrent;
   GtUword pos, twobitencodingstoppos;
-  unsigned int offset, idx;
+  unsigned int offset;
 
   if (seqnum < gt_encseq_num_of_sequences(encseq) - 1) {
     twobitencodingstoppos = gt_encseq_seqstartpos(encseq, seqnum + 1) - 1;
@@ -6366,7 +6364,7 @@ unsigned int gt_encseq_relpos_extract2bitencvector(
     if (twobitencodingstoppos > maxpos)
       twobitencodingstoppos = maxpos;
   }
-  for (idx = 0, offset = 0; /* Nothing */; idx++,
+  for (offset = 0; /* Nothing */;
        offset += (unsigned int) GT_UNITSIN2BITENC) {
     if (pos == twobitencodingstoppos) {
       return offset;
@@ -7877,11 +7875,9 @@ static int testfullscan(const GtStrArray *filenametab,
   int retval;
   bool haserr = false;
   GtEncseqReader *esr = NULL;
-  GtUint64 fullscanpbar = 0;
 
   gt_error_check(err);
   totallength = encseq->totallength;
-  /* gt_progressbar_start(&fullscanpbar, (GtUint64) totallength); */
   if (filenametab != NULL) {
     fb = gt_sequence_buffer_new_guess_type(filenametab, err);
     if (!fb)
@@ -7931,7 +7927,6 @@ static int testfullscan(const GtStrArray *filenametab,
         haserr = true;
         break;
       }
-      fullscanpbar++;
     }
     /* gt_progressbar_stop(); */
   }

--- a/src/core/encseq.c
+++ b/src/core/encseq.c
@@ -1761,8 +1761,7 @@ static void initSWtable(GtSWtable *swtable,
       swtable->st_uint32.numofpositionstostore = items;
       break;
     default:
-      fprintf(stderr, "initSWtable(sat = %s is undefined)\n",
-                     gt_encseq_access_type_str(sat));
+      fprintf(stderr, "initSWtable(sat = %d is undefined)\n",sat);
       exit(GT_EXIT_PROGRAMMING_ERROR);
   }
 }

--- a/src/core/md5_tab.c
+++ b/src/core/md5_tab.c
@@ -39,7 +39,7 @@ static bool read_fingerprints(GtMD5Tab *md5_tab,
                               bool use_file_locking)
 {
   bool reading_succeeded = true;
-  size_t len;
+  size_t len = 0;
   gt_assert(md5_tab && fingerprints_filename);
   /* open file */
   gt_assert(gt_file_exists(fingerprints_filename));

--- a/src/extended/editscript.c
+++ b/src/extended/editscript.c
@@ -528,8 +528,7 @@ GtUword gt_editscript_get_sub_sequence_u(const GtEditscript *editscript,
 {
   GtEditscriptPos pos;
   GtBitsequence elem = 0;
-  GtUword vidx = 0,
-          uidx,
+  GtUword uidx,
           bufidx = 0;
   uint32_t j,
            elems_served = 0,
@@ -571,7 +570,6 @@ GtUword gt_editscript_get_sub_sequence_u(const GtEditscript *editscript,
             *buffer = gt_realloc(*buffer, sizeof (**buffer) * *bufsize);
           }
         }
-        vidx++;
         uidx++;
       }
       mismatch_or_deletion = elem == GT_EDITSCRIPT_MISDEL_SYM(editscript);
@@ -593,7 +591,6 @@ GtUword gt_editscript_get_sub_sequence_u(const GtEditscript *editscript,
               *buffer = gt_realloc(*buffer, sizeof (**buffer) * *bufsize);
             }
           }
-          vidx++;
         }
         if (mismatch_or_deletion) uidx++;
       }
@@ -604,7 +601,6 @@ GtUword gt_editscript_get_sub_sequence_u(const GtEditscript *editscript,
          j < (uint32_t) editscript->trailing_matches;
        ++j) {
     (*buffer)[bufidx++] = gt_encseq_get_encoded_char(encseq, uidx, dir);
-    vidx++;
     uidx++;
   }
   gt_assert(uidx == start + utopos + 1);

--- a/src/ltr/ltrdigest_pdom_visitor.c
+++ b/src/ltr/ltrdigest_pdom_visitor.c
@@ -398,7 +398,7 @@ static int gt_ltrdigest_pdom_visitor_parse_domainhits(
                                                      GtError *err)
 {
   int had_err = 0;
-  GtUword i, nof_targets = 0, nof_hits = 0;
+  GtUword i, nof_hits = 0;
   gt_assert(lv && instream && status);
   gt_error_check(err);
 
@@ -418,7 +418,6 @@ static int gt_ltrdigest_pdom_visitor_parse_domainhits(
         for (i = 0UL; i < 2UL && !had_err; i++)
           had_err = pdom_parser_get_next_line(buf, instream, err);
       }
-      nof_targets++;
       nof_hits = 0UL;
       gt_hmmer_parse_status_mark_frame_finished(status);
     }

--- a/src/ltr/ltrharvest_stream.c
+++ b/src/ltr/ltrharvest_stream.c
@@ -296,7 +296,6 @@ static void searchforbestTSDandormotifatborders(const SubRepeatInfo
                 difffromoldboundary1 = 0,
                 difffromoldboundary2 = 0;
   LTRMotifmismatches tmp_mm;
-  unsigned int hitcounter = 0;
   Repeat *rep;
 
   if (subrepeatinfo->repeats.nextfreeRepeat > 0)
@@ -380,7 +379,6 @@ static void searchforbestTSDandormotifatborders(const SubRepeatInfo
               min = GT_MIN(oldrightLTR_3, boundaries->rightLTR_3);
               difffromoldboundary2 = max - min;
 
-              hitcounter++;
             } else
             {
               GtUword max, min, difffromnewboundary1,
@@ -409,7 +407,6 @@ static void searchforbestTSDandormotifatborders(const SubRepeatInfo
 
                 difffromoldboundary1 = difffromnewboundary1;
                 difffromoldboundary2 = difffromnewboundary2;
-                hitcounter++;
               }
             }
           }

--- a/src/match/cgr_spacedseed.c
+++ b/src/match/cgr_spacedseed.c
@@ -230,7 +230,6 @@ int gt_matchspacedseed(bool withesa,
     const GtUchar *query;
     GtUword querylen;
     char *desc = NULL;
-    uint64_t unitnum;
     int retval;
     Limdfsresources *limdfsresources = NULL;
     const AbstractDfstransformer *dfst;
@@ -256,7 +255,7 @@ int gt_matchspacedseed(bool withesa,
     {
       GtAlphabet *a = gt_encseq_alphabet(encseq);
       gt_seq_iterator_set_symbolmap(seqit, gt_alphabet_symbolmap(a));
-      for (unitnum = 0; /* Nothing */; unitnum++)
+      for (/*Nothing*/; /* Nothing */; /*Nothing*/)
       {
         retval = gt_seq_iterator_next(seqit,
                                      &query,

--- a/src/match/chain2dim.c
+++ b/src/match/chain2dim.c
@@ -1241,16 +1241,16 @@ static void mergestartandendpoints(const GtChain2Dimmode *chainmode,
                                    bool gapsL1,
                                    unsigned int presortdim)
 {
-  GtUword xidx, startcount, endcount;
+  GtUword startcount, endcount;
   const unsigned int postsortdim = 1U - presortdim;
   bool addterminal = (chainmode->chainkind == GLOBALCHAINING) ? false : true;
 
   matchstore->dictroot = gt_rbtree_new(gt_chain2dim_cmpendMatchpoint2,
                                        gt_free_func, NULL);
-  for (xidx = 0, startcount = 0, endcount = 0;
+  for (startcount = 0, endcount = 0;
        startcount < matchtable->nextfree &&
        endcount < matchtable->nextfree;
-       xidx++)
+       /*Nothing*/)
   {
     if (comparestartandend(matchtable->matches + startcount,
                            matchtable->matches +
@@ -1283,7 +1283,6 @@ static void mergestartandendpoints(const GtChain2Dimmode *chainmode,
                    startcount,
                    presortdim);
     startcount++;
-    xidx++;
   }
   while (endcount < matchtable->nextfree)
   {
@@ -1293,7 +1292,6 @@ static void mergestartandendpoints(const GtChain2Dimmode *chainmode,
                                           endpointperm[endcount],
                                           postsortdim));
     endcount++;
-    xidx++;
   }
 }
 
@@ -1395,7 +1393,7 @@ static void makesortedendpointpermutation(GtUword *perm,
                                           GtChain2Dimmatchtable *matchtable,
                                           unsigned int presortdim)
 {
-  GtUword temp, *iptr, *jptr, i, moves = 0;
+  GtUword temp, *iptr, *jptr, i;
 
   for (i = 0; i < matchtable->nextfree; i++)
   {
@@ -1413,7 +1411,6 @@ static void makesortedendpointpermutation(GtUword *perm,
       temp = *(jptr-1);
       *(jptr-1) = *jptr;
       *jptr = temp;
-      moves++;
     }
   }
 }

--- a/src/match/dbs_spaced_seeds.c
+++ b/src/match/dbs_spaced_seeds.c
@@ -294,7 +294,6 @@ struct GtSpacedSeedSpec
 GtSpacedSeedSpec *gt_spaced_seed_spec_new(GtCodetype spacedseed)
 {
   uint8_t blocks_length[32] = {0}, shiftleft = 0, shiftright = 0;
-  int span = 1, weight = 1;
   GtCodetype ss_copy, last = (GtCodetype) 1, GT_UNUSED from_blocks = 0;
   GtUword idx, block_num = 0, spec_counter = 0;
   GtSpacedSeedSpec *seed_spec;
@@ -305,10 +304,6 @@ GtSpacedSeedSpec *gt_spaced_seed_spec_new(GtCodetype spacedseed)
   {
     GtCodetype current = ss_copy & (GtCodetype) 1;
 
-    if (current == (GtCodetype) 1)
-    {
-      weight++;
-    }
     if (current != last)
     {
       block_num++;
@@ -316,7 +311,6 @@ GtSpacedSeedSpec *gt_spaced_seed_spec_new(GtCodetype spacedseed)
     }
     gt_assert(block_num < sizeof blocks_length/sizeof blocks_length[0]);
     blocks_length[block_num]++;
-    span++;
   }
   block_num++;
   gt_assert(block_num % 2 == 1);

--- a/src/match/ft-front-generation.c
+++ b/src/match/ft-front-generation.c
@@ -274,7 +274,7 @@ static void front_trace2eoplist_directed(GtEoplist *eoplist,
                                          const GtFtPolished_point *pp)
 {
   GtUword distance, localoffset, globaloffset, remainingvalidfronts,
-          totalrunlength = 0, trimleft;
+          trimleft;
   GtWord diagonal;
   unsigned int row, lcs;
   uint8_t trace, preferred_eop = FT_EOP_MISMATCH;
@@ -310,7 +310,6 @@ static void front_trace2eoplist_directed(GtEoplist *eoplist,
     }
     if (trace & preferred_eop)
     {
-      totalrunlength++;
       if (preferred_eop == FT_EOP_MISMATCH)
       {
         nextrowadd = 1;

--- a/src/match/rdj-spmfind.c
+++ b/src/match/rdj-spmfind.c
@@ -850,7 +850,9 @@ int gt_spmfind_eqlen_process(void *data,
     GtUword spaceforbucketprocessing, GtError *err)
 {
   GtBUstate_spmeq *state = data;
+#ifdef GT_READJOINER_DEBUG
   unsigned int nof_w_parts = 0;
+#endif
   gt_assert(state != NULL);
   gt_assert(snrp != NULL);
   gt_assert(lcptab_bucket != NULL);
@@ -868,12 +870,14 @@ int gt_spmfind_eqlen_process(void *data,
     {
       return -1;
     }
+#ifdef GT_READJOINER_DEBUG
     if (state->w_overflow)
       nof_w_parts++;
+#endif
     state->w_offset += state->w_maxsize;
   } while (state->w_overflow);
 #ifdef GT_READJOINER_DEBUG
-  gt_log_log("bucket divided in %u parts", nof_w_parts);
+  gt_log_log("%s: bucket divided in %u parts", __func__, nof_w_parts);
 #endif
   return 0;
 }
@@ -898,7 +902,9 @@ int gt_spmfind_varlen_process(void *data,
     GtUword spaceforbucketprocessing, GtError *err)
 {
   GtBUstate_spmvar *state = data;
+#ifdef GT_READJOINER_DEBUG
   unsigned int nof_w_parts = 0;
+#endif
   gt_assert(state != NULL);
   gt_assert(snrp != NULL);
   gt_assert(lcptab_bucket != NULL);
@@ -916,9 +922,14 @@ int gt_spmfind_varlen_process(void *data,
     {
       return -1;
     }
+#ifdef GT_READJOINER_DEBUG
     if (state->w_overflow)
       nof_w_parts++;
+#endif
     state->w_offset += state->w_maxsize;
   } while (state->w_overflow);
+#ifdef GT_READJOINER_DEBUG
+  gt_log_log("%s: bucket divided in %u parts", __func__, nof_w_parts);
+#endif
   return 0;
 }

--- a/src/match/sfx-mapped4.gen
+++ b/src/match/sfx-mapped4.gen
@@ -23,7 +23,8 @@ static GtCodetype PROCESSKMERPREFIX(getencseqkmers_nospecialtwobitencoding)(
                                     GtUword startpos,
                                     GtUword endpos)
 {
-  GtUword position, unitindex, relpos = 0;
+  GtUword position, unitindex;
+  GT_UNUSED GtUword relpos = 0;
   GtCodetype code, transcode;
   GtTwobitencoding currentencoding;
   unsigned int shiftright;


### PR DESCRIPTION
1) src/core/md5_tab.c
   init len = 0, as len may not be defined when first used
2) src/core/encseq.c
   if sat is undefined out sat and not gt_encseq_access_type_str(sat)

Remove src/gth/*.[ch] list of paths expressions in ctags.sh

## Brief summary

This PR introduces the following changes:

  - ...
  - ...
  - ...

## Related issues

Fixes #...
Adresses #... by ...
