### PR TITLE
Add Python bindings required for GFF3 web validator

### DIFF
--- a/gtpython/gt/extended/__init__.py
+++ b/gtpython/gt/extended/__init__.py
@@ -39,6 +39,7 @@ from .node_visitor import *
 from .region_node import *
 from .sequence_node import *
 from .sort_stream import *
+from .type_checker import *
 
 from .rdb import *
 from .anno_db import *
@@ -66,6 +67,9 @@ NodeVisitor.register(gtlib)
 RegionNode.register(gtlib)
 SequenceNode.register(gtlib)
 SortStream.register(gtlib)
+TypeChecker.register(gtlib)
+TypeCheckerBuiltin.register(gtlib)
+TypeCheckerOBO.register(gtlib)
 try:
     AnnoDBSchema.register(gtlib)
     RDB.register(gtlib)

--- a/gtpython/gt/extended/gff3_in_stream.py
+++ b/gtpython/gt/extended/gff3_in_stream.py
@@ -23,10 +23,10 @@ from gt.dlload import gtlib
 from gt.core.error import gterror
 from gt.core.str_array import StrArray
 from gt.extended.genome_stream import GenomeStream
+from gt.extended.type_checker import TypeChecker
 
 
 class GFF3InStream(GenomeStream):
-
     def __init__(self, filename):
         try:
             p = open(filename)
@@ -49,11 +49,18 @@ class GFF3InStream(GenomeStream):
         used_types = StrArray(str_array_ptr)
         return used_types.to_list()
 
+    def set_type_checker(self, tc):
+        if not isinstance(tc, TypeChecker):
+            raise TypeError("argument must be a TypeChecker")
+        gtlib.gt_gff3_in_stream_set_type_checker(self.gs, tc._as_parameter_)
+
     def register(cls, gtlib):
         from ctypes import c_char_p, c_void_p
         gtlib.gt_gff3_in_stream_get_used_types.argtypes = [c_void_p]
         gtlib.gt_gff3_in_stream_new_sorted.argtypes = [c_char_p]
         gtlib.gt_gff3_in_stream_get_used_types.restype = c_void_p
         gtlib.gt_gff3_in_stream_new_sorted.restype = c_void_p
+        gtlib.gt_gff3_in_stream_set_type_checker.argtypes = [
+            c_void_p, c_void_p]
 
     register = classmethod(register)

--- a/gtpython/gt/extended/gff3_in_stream.py
+++ b/gtpython/gt/extended/gff3_in_stream.py
@@ -49,6 +49,15 @@ class GFF3InStream(GenomeStream):
         used_types = StrArray(str_array_ptr)
         return used_types.to_list()
 
+    def check_id_attributes(self):
+        gtlib.gt_gff3_in_stream_check_id_attributes(self.gs)
+
+    def enable_tidy_mode(self):
+        gtlib.gt_gff3_in_stream_enable_tidy_mode(self.gs)
+
+    def enable_strict_mode(self):
+        gtlib.gt_gff3_in_stream_enable_strict_mode(self.gs)
+
     def set_type_checker(self, tc):
         if not isinstance(tc, TypeChecker):
             raise TypeError("argument must be a TypeChecker")
@@ -56,10 +65,14 @@ class GFF3InStream(GenomeStream):
 
     def register(cls, gtlib):
         from ctypes import c_char_p, c_void_p
+
         gtlib.gt_gff3_in_stream_get_used_types.argtypes = [c_void_p]
         gtlib.gt_gff3_in_stream_new_sorted.argtypes = [c_char_p]
         gtlib.gt_gff3_in_stream_get_used_types.restype = c_void_p
         gtlib.gt_gff3_in_stream_new_sorted.restype = c_void_p
+        gtlib.gt_gff3_in_stream_check_id_attributes.argtypes = [c_void_p]
+        gtlib.gt_gff3_in_stream_enable_tidy_mode.argtypes = [c_void_p]
+        gtlib.gt_gff3_in_stream_enable_strict_mode.argtypes = [c_void_p]
         gtlib.gt_gff3_in_stream_set_type_checker.argtypes = [
             c_void_p, c_void_p]
 

--- a/gtpython/gt/extended/type_checker.py
+++ b/gtpython/gt/extended/type_checker.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Sascha Steinbiss <sascha@steinbiss.name>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+from gt.bytes import gtbytes
+from gt.dlload import gtlib
+from gt.core.error import Error, gterror
+
+
+class TypeChecker(object):
+    def __init__(self, *args):
+        raise NotImplementedError(
+            "Please call the constructor of a " + "TypeChecker implementation."
+        )
+
+    def __del__(self):
+        try:
+            gtlib.gt_type_checker_delete(self.tc)
+        except AttributeError:
+            pass
+
+    def description(self):
+        return str(gtlib.gt_type_checker_description(self.tc))
+
+    def is_valid(self, t):
+        return gtlib.gt_type_checker_is_valid(self.tc, gtbytes(t))
+
+    def register(cls, gtlib):
+        from ctypes import c_void_p, c_bool, c_char_p
+
+        gtlib.gt_type_checker_is_valid.argtypes = [c_void_p, c_char_p]
+        gtlib.gt_type_checker_is_valid.restype = c_bool
+        gtlib.gt_type_checker_description.argtypes = [c_void_p]
+        gtlib.gt_type_checker_description.restype = c_char_p
+        gtlib.gt_type_checker_delete.argtypes = [c_void_p]
+
+    register = classmethod(register)
+
+
+class TypeCheckerOBO(TypeChecker):
+    def __init__(self, filename):
+        try:
+            p = open(filename)
+            tmp = p.readline()
+            p.close()
+        except:
+            gterror("File " + filename + " not readable!")
+        err = Error()
+        self.tc = gtlib.gt_type_checker_obo_new(
+            gtbytes(filename), err._as_parameter_)
+        if self.tc == None:
+            gterror(err)
+        self._as_parameter_ = self.tc
+
+    def from_param(cls, obj):
+        if not isinstance(obj, TypeCheckerOBO):
+            raise TypeError("argument must be a TypeCheckerOBO")
+        return obj._as_parameter_
+
+    from_param = classmethod(from_param)
+
+    def register(cls, gtlib):
+        from ctypes import c_char_p, c_void_p
+
+        gtlib.gt_type_checker_obo_new.argtypes = [c_char_p, c_void_p]
+        gtlib.gt_type_checker_obo_new.restype = c_void_p
+
+    register = classmethod(register)
+
+
+class TypeCheckerBuiltin(TypeChecker):
+    def __init__(self):
+        self.tc = gtlib.gt_type_checker_builtin_new()
+        self._as_parameter_ = self.tc
+
+    def from_param(cls, obj):
+        if not isinstance(obj, TypeCheckerOBO):
+            raise TypeError("argument must be a TypeCheckerBuiltin")
+        return obj._as_parameter_
+
+    from_param = classmethod(from_param)
+
+    def register(cls, gtlib):
+        from ctypes import c_void_p
+
+        gtlib.gt_type_checker_builtin_new.restype = c_void_p
+
+    register = classmethod(register)

--- a/gtpython/tests/__init__.py
+++ b/gtpython/tests/__init__.py
@@ -10,6 +10,7 @@ from test_metanode import *
 from test_sequencenode import *
 from test_iterators import *
 from test_stream import *
+from test_typechecker import *
 from test_range import *
 from test_version import *
 

--- a/gtpython/tests/test_stream.py
+++ b/gtpython/tests/test_stream.py
@@ -23,6 +23,21 @@ class StreamTest(unittest.TestCase):
 
         self.assertTrue('1877523' in fi.get_seqids())
 
+    def test_checker(self):
+        tc = gt.extended.TypeCheckerBuiltin()
+        self.ins.set_type_checker(tc)
+        self.ins.pull()
+
+    def test_checker_fail(self):
+        tc = gt.extended.TypeCheckerBuiltin()
+        gff_file = op.join(datadir, "unknowntype.gff3")
+        ins = gt.GFF3InStream(gff_file)
+        ins.set_type_checker(tc)
+        self.assertRaisesRegex(
+            gt.core.error.GTError,
+            'GenomeTools error: type "something" on line 3',
+            ins.pull)
+
 
 class TestDuplicateStream(unittest.TestCase):
 

--- a/gtpython/tests/test_typechecker.py
+++ b/gtpython/tests/test_typechecker.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import unittest
+import gt
+import os
+
+op = os.path
+datadir = op.abspath(op.join(op.dirname(__file__), "..", "..", "testdata"))
+gtdatadir = op.abspath(op.join(op.dirname(__file__), "..", "..", "gtdata"))
+
+
+class TypeCheckerTest(unittest.TestCase):
+    def test_builtin(self):
+        tc = gt.extended.TypeCheckerBuiltin()
+        self.assertTrue(tc.is_valid("gene"))
+        self.assertFalse(tc.is_valid("nothing"))
+
+    def test_obo_success(self):
+        tc = gt.extended.TypeCheckerOBO(
+            os.path.join(gtdatadir, "obo_files/sofa.obo"))
+        self.assertTrue(tc.is_valid("gene"))
+        self.assertFalse(tc.is_valid("nothing"))
+        self.assertFalse(tc.is_valid(""))
+        self.assertFalse(tc.is_valid(None))
+
+    def test_obo_fail(self):
+        self.assertRaises(
+            gt.core.error.GTError, gt.extended.TypeCheckerOBO, "nonexistant"
+        )
+        self.assertRaises(
+            gt.core.error.GTError,
+            gt.extended.TypeCheckerOBO,
+            os.path.join(datadir, "obo_files/corrupt_instance_stanza.obo"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testdata/unknowntype.gff3
+++ b/testdata/unknowntype.gff3
@@ -1,0 +1,4 @@
+##gff-version 3
+##sequence-region   ctg123 1 1497228
+ctg123	gth	something	106716	106973	0.847	+	.	ID=invalid
+


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Add Python bindings for the `TypeChecker`, `TypeCheckerBuiltin` and `TypeCheckerOBO` classes.
  - Add Python bindings for `gt_gff3_in_stream_enable_tidy_mode()`, `gt_gff3_in_stream_check_id_attributes()` and `gt_gff3_in_stream_enable_strict_mode()`
  - Add tests for new features.

These are required to implement the GFF3 web validator using the more future-proof Python bindings, to replace the old version based on the Ruby bindings which are tied to the obsolete Ruby 1.8.
