### PR TITLE
Add explicit dependencies to `gt_config.h`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -852,6 +852,8 @@ obj/%.o: %.cpp
 	$(V_DO)$(CXX) -c $< -o $(@:.o=.d) $(EXP_CPPFLAGS) $(GT_CPPFLAGS) -MM -MP \
 	  -MT $@
 
+obj/src/core/option.o: obj/gt_config.h
+obj/src/core/version.o: obj/gt_config.h
 obj/src/core/versionfunc.o: obj/gt_config.h
 
 # read dependencies


### PR DESCRIPTION
## Brief summary

This PR introduces the following changes:

  - Add explicit dependencies on `gt_config.h` for:
    - `obj/src/core/option.o`
    - `obj/src/core/version.o`

## Related issues

This fixes compilation in unusual orders, e.g. by using `make --shuffle=reverse`.
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1105339